### PR TITLE
Added support for ignoring paths in the replacer.

### DIFF
--- a/src/Replacer/Replacer.php
+++ b/src/Replacer/Replacer.php
@@ -147,8 +147,8 @@ class Replacer implements ReplacerInterface {
   /**
    * {@inheritdoc}
    */
-  public function replaceInDir(string $directory): static {
-    $files = File::scandir($directory);
+  public function replaceInDir(string $directory, array $ignore_paths = []): static {
+    $files = File::scandir($directory, $ignore_paths);
 
     foreach ($files as $file) {
       // @codeCoverageIgnoreStart

--- a/src/Replacer/ReplacerInterface.php
+++ b/src/Replacer/ReplacerInterface.php
@@ -114,11 +114,13 @@ interface ReplacerInterface {
    *
    * @param string $directory
    *   The directory to process.
+   * @param array<string> $ignore_paths
+   *   Paths to ignore during scanning.
    *
    * @return static
    *   The replacer instance for chaining.
    */
-  public function replaceInDir(string $directory): static;
+  public function replaceInDir(string $directory, array $ignore_paths = []): static;
 
   /**
    * Add exclusions to replacement rules.

--- a/tests/phpunit/Unit/ReplacerTest.php
+++ b/tests/phpunit/Unit/ReplacerTest.php
@@ -388,6 +388,29 @@ final class ReplacerTest extends UnitTestCase {
     $this->assertDirectoriesIdentical($after_dir, $temp_dir);
   }
 
+  public function testReplaceInDirWithIgnorePaths(): void {
+    $temp_dir = self::$tmp . '/replacer_ignore_test';
+    $ignored_dir = $temp_dir . '/ignored';
+
+    // Create directory structure.
+    File::mkdir($temp_dir);
+    File::mkdir($ignored_dir);
+
+    // Create files with version strings.
+    file_put_contents($temp_dir . '/root.txt', 'version 1.2.3');
+    file_put_contents($ignored_dir . '/ignored.txt', 'version 4.5.6');
+
+    $replacer = Replacer::versions()->setMaxReplacements(0);
+
+    $result = $replacer->replaceInDir($temp_dir, [$ignored_dir]);
+
+    $this->assertSame($replacer, $result);
+    // Root file should be replaced.
+    $this->assertSame('version __VERSION__', file_get_contents($temp_dir . '/root.txt'));
+    // Ignored directory file should NOT be replaced.
+    $this->assertSame('version 4.5.6', file_get_contents($ignored_dir . '/ignored.txt'));
+  }
+
   public function testAddExclusionsAppliesToAllRules(): void {
     $replacer = Replacer::create()
       ->addReplacement(Replacement::create('r1', '/\d+\.\d+\.\d+/', '__V1__'))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The directory replacement operation now accepts an optional ignore paths parameter, allowing you to exclude specific directories or paths from processing while applying changes to the rest of the target directory.

* **Tests**
  * Added test coverage to verify the ignore paths feature functions correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->