### PR TITLE
Added support for sebastian/diff v7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=8.2",
         "alexskrypnyk/file": "^0.19.0",
-        "sebastian/diff": "^6.0"
+        "sebastian/diff": "^6.0 || ^7.0"
     },
     "require-dev": {
         "alexskrypnyk/phpunit-helpers": "^0.15.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request expands the dependency constraint for `sebastian/diff` in `composer.json` from `^6.0` to `^6.0 || ^7.0`, enabling compatibility with both 6.x and 7.x releases of the PHP diff library. The change maintains backward compatibility with version 6.x while adding support for the newer major version.

The library uses `sebastian/diff` in `src/Compare/Diff.php` to generate unified diffs via the `Differ` class and `UnifiedDiffOutputBuilder`, which remain compatible across both v6 and v7 releases.

**Changes:**
- Updated `composer.json` dependency specification

**Impact:** Minimal - dependency constraint broadening with no code modifications required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->