### PR TITLE
Fixed Syncer not respecting content_ignored flag during sync

### DIFF
--- a/src/Sync/Syncer.php
+++ b/src/Sync/Syncer.php
@@ -32,7 +32,12 @@ class Syncer implements SyncerInterface {
     foreach ($this->srcIndex->getFiles() as $file) {
       $absolute_src_path = $file->getPathname();
       $absolute_dst_path = $dst . DIRECTORY_SEPARATOR . $file->getPathnameFromBasepath();
-      File::copy($absolute_src_path, $absolute_dst_path, $permissions, $copy_empty_dirs);
+      if ($file->isIgnoreContent()) {
+        File::dump($absolute_dst_path, $file->getContent());
+      }
+      else {
+        File::copy($absolute_src_path, $absolute_dst_path, $permissions, $copy_empty_dirs);
+      }
     }
 
     return $this;

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -409,6 +409,23 @@ ABSENT,
     $this->assertArrayHasKey('f2.txt', $absent_right);
   }
 
+  public function testSyncRespectsContentIgnored(): void {
+    $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
+    $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
+    mkdir($src);
+
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'regular.txt', 'regular content');
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'ignored.txt', 'actual secret content');
+    file_put_contents($src . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT, "^ignored.txt\n");
+
+    Snapshot::sync($src, $dst);
+
+    $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'regular.txt');
+    $this->assertSame('regular content', file_get_contents($dst . DIRECTORY_SEPARATOR . 'regular.txt'));
+    $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'ignored.txt');
+    $this->assertSame(IndexedFile::CONTENT_IGNORED_MARKER, file_get_contents($dst . DIRECTORY_SEPARATOR . 'ignored.txt'));
+  }
+
   public function testSyncUsesFileCopy(): void {
     $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
     $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';


### PR DESCRIPTION
## Summary

- Fixed `Syncer::sync()` not respecting the `content_ignored` flag, causing files marked with `^` in `.ignorecontent` to receive actual file content instead of the marker during snapshot updates.
- The performance optimization in `0872738` changed regular file copying from `File::dump($path, $file->getContent())` to `File::copy()`, which bypassed the `isIgnoreContent()` check entirely.
- Added a test to verify content_ignored files retain the marker content after sync.

## Test plan

- [x] New `testSyncRespectsContentIgnored` test verifies the fix
- [x] All 231 existing tests pass
- [x] All linters pass (PHPCS, PHPStan, Rector)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a regression in the `Syncer::sync()` method where files marked as content-ignored (via the `.ignorecontent` file with the `^` prefix) were not retaining their marker content during synchronization operations.

## Problem

A previous performance optimization (commit 0872738) replaced `File::dump($path, $file->getContent())` calls with `File::copy()` in the sync operation. While this improved performance for normal files, it inadvertently bypassed the `isIgnoreContent()` check, causing content-ignored files to be synced with their actual file contents instead of the `CONTENT_IGNORED_MARKER` placeholder.

## Solution

The `Syncer::sync()` method now conditionally handles file content during synchronization:
- If a file is marked as ignore-content (`isIgnoreContent()` returns true), it uses `File::dump()` to write the marker content to the destination
- Otherwise, it uses the optimized `File::copy()` operation for normal files

## Changes

**src/Sync/Syncer.php** (+6/-1)
- Added conditional logic to check `$file->isIgnoreContent()` before deciding whether to dump marker content or copy actual file content

**tests/phpunit/Unit/SnapshotTest.php** (+17/-0)
- Added `testSyncRespectsContentIgnored()` test that verifies:
  - Regular files are synced with their content preserved
  - Files marked with `^` in `.ignorecontent` are synced with the `CONTENT_IGNORED_MARKER` instead of actual content

## Testing

- All 231 existing tests pass
- New test `testSyncRespectsContentIgnored()` validates the fix
- All linters pass (PHPCS, PHPStan, Rector)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->