### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,20 @@
 {
     "extends": ["config:recommended"],
     "automerge": true,
-    "dependencyDashboard": true
+    "rangeStrategy": "bump",
+    "dependencyDashboard": true,
+    "pinDigests": true,
+    "branchPrefix": "deps/",
+    "packageRules": [
+        {
+            "matchManagers": ["composer"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "matchPackageNames": ["*"],
+            "groupName": "all dependencies",
+            "groupSlug": "all"
+        }
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,17 @@
     "branchPrefix": "deps/",
     "packageRules": [
         {
+            "matchDepNames": ["php"],
             "matchManagers": ["composer"],
+            "enabled": false
+        },
+        {
+            "matchDepNames": ["node", "yarn"],
+            "matchManagers": ["npm"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm", "composer"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -47,63 +47,63 @@ final class SnapshotTest extends UnitTestCase {
   public static function dataProviderCompare(): \Iterator {
     yield 'files_equal' => [];
     yield 'files_not_equal' => [
-        [
-          'absent_dir1' => [
-            'f4.txt',
-          ],
-          'absent_dir2' => [
-            'f3.txt',
-          ],
-          'content' => [
-            'f2.txt' => [
-              'dir1' => "f2l1\n",
-              'dir2' => "f2l1-changed\n",
-            ],
+      [
+        'absent_dir1' => [
+          'f4.txt',
+        ],
+        'absent_dir2' => [
+          'f3.txt',
+        ],
+        'content' => [
+          'f2.txt' => [
+            'dir1' => "f2l1\n",
+            'dir2' => "f2l1-changed\n",
           ],
         ],
+      ],
     ];
     yield 'files_equal_ignorecontent' => [];
     yield 'files_not_equal_ignorecontent' => [
-        [
-          'absent_dir1' => [
-            'f4.txt',
-          ],
-          'absent_dir2' => [
-            'f3.txt',
-          ],
-          'content' => [
-            'f2.txt' => [
-              'dir1' => "f2l1\n",
-              'dir2' => "f2l1-changed\n",
-            ],
+      [
+        'absent_dir1' => [
+          'f4.txt',
+        ],
+        'absent_dir2' => [
+          'f3.txt',
+        ],
+        'content' => [
+          'f2.txt' => [
+            'dir1' => "f2l1\n",
+            'dir2' => "f2l1-changed\n",
           ],
         ],
+      ],
     ];
     yield 'files_equal_advanced' => [];
     yield 'files_not_equal_advanced' => [
-        [
-          'absent_dir1' => [
-            'dir2_flat-present-dst/d2f1.txt',
-            'dir2_flat-present-dst/d2f2.txt',
-            'dir3_subdirs/dir31/f4-new-file-notignore-everywhere.txt',
-            'dir5_content_ignore/dir51/d51f2-new-file.txt',
-            'f4-new-file-notignore-everywhere.txt',
-          ],
-          'absent_dir2' => [
-            'd32f2_symlink_deep.txt',
-            'dir1_flat/d1f1_symlink.txt',
-            'dir1_flat/d1f3-only-src.txt',
-            'dir3_subdirs/dir32-unignored/d32f1_symlink.txt',
-            'dir3_subdirs_symlink',
-            'f2_symlink.txt',
-          ],
-          'content' => [
-            'dir3_subdirs/dir32-unignored/d32f2.txt' => [
-              'dir1' => "d32f2l1\n",
-              'dir2' => "d32f2l1-changed\n",
-            ],
+      [
+        'absent_dir1' => [
+          'dir2_flat-present-dst/d2f1.txt',
+          'dir2_flat-present-dst/d2f2.txt',
+          'dir3_subdirs/dir31/f4-new-file-notignore-everywhere.txt',
+          'dir5_content_ignore/dir51/d51f2-new-file.txt',
+          'f4-new-file-notignore-everywhere.txt',
+        ],
+        'absent_dir2' => [
+          'd32f2_symlink_deep.txt',
+          'dir1_flat/d1f1_symlink.txt',
+          'dir1_flat/d1f3-only-src.txt',
+          'dir3_subdirs/dir32-unignored/d32f1_symlink.txt',
+          'dir3_subdirs_symlink',
+          'f2_symlink.txt',
+        ],
+        'content' => [
+          'dir3_subdirs/dir32-unignored/d32f2.txt' => [
+            'dir1' => "d32f2l1\n",
+            'dir2' => "d32f2l1-changed\n",
           ],
         ],
+      ],
     ];
   }
 
@@ -130,11 +130,11 @@ final class SnapshotTest extends UnitTestCase {
 
   public static function dataProviderCompareRender(): \Iterator {
     yield 'files_equal' => [
-        [],
+      [],
     ];
     yield 'files_not_equal' => [
-        [
-          'Differences between directories',
+      [
+        'Differences between directories',
           <<<ABSENT
 Files absent in [left]:
   f4.txt
@@ -143,22 +143,22 @@ ABSENT,
 Files absent in [right]:
   f3.txt
 ABSENT,
-          'Files that differ in content:',
-          'f2.txt' => <<<DIFF_WRAP
+        'Files that differ in content:',
+        'f2.txt' => <<<DIFF_WRAP
           --- DIFF START ---
           @@ -1 +1 @@
           -f2l1
           +f2l1-changed
           --- DIFF END ---
           DIFF_WRAP,
-        ],
+      ],
     ];
     yield 'files_equal_ignorecontent' => [
-        [],
+      [],
     ];
     yield 'files_not_equal_ignorecontent' => [
-        [
-          'Differences between directories',
+      [
+        'Differences between directories',
           <<<ABSENT
 Files absent in [left]:
   f4.txt
@@ -167,23 +167,23 @@ ABSENT,
 Files absent in [right]:
   f3.txt
 ABSENT,
-          'Files that differ in content:',
-          'f2.txt' => <<<DIFF_WRAP
+        'Files that differ in content:',
+        'f2.txt' => <<<DIFF_WRAP
           --- DIFF START ---
           @@ -1 +1 @@
           -f2l1
           +f2l1-changed
           --- DIFF END ---
           DIFF_WRAP,
-        ],
+      ],
     ];
     yield 'files_equal_advanced' => [
-        [],
+      [],
     ];
     yield 'files_not_equal_advanced' => [
-        [
-          'Differences between directories',
-          "Files absent in [left]:\n",
+      [
+        'Differences between directories',
+        "Files absent in [left]:\n",
           <<<ABSENT
   dir2_flat-present-dst/d2f1.txt
   dir2_flat-present-dst/d2f2.txt
@@ -191,7 +191,7 @@ ABSENT,
   dir5_content_ignore/dir51/d51f2-new-file.txt
   f4-new-file-notignore-everywhere.txt
 ABSENT,
-          "Files absent in [right]:\n",
+        "Files absent in [right]:\n",
           <<<ABSENT
   d32f2_symlink_deep.txt
   dir1_flat/d1f1_symlink.txt
@@ -200,15 +200,15 @@ ABSENT,
   dir3_subdirs_symlink
   f2_symlink.txt
 ABSENT,
-          'Files that differ in content:',
-          'dir3_subdirs/dir32-unignored/d32f2.txt' => <<<DIFF_WRAP
+        'Files that differ in content:',
+        'dir3_subdirs/dir32-unignored/d32f2.txt' => <<<DIFF_WRAP
           --- DIFF START ---
           @@ -1 +1 @@
           -d32f2l1
           +d32f2l1-changed
           --- DIFF END ---
           DIFF_WRAP,
-        ],
+      ],
     ];
   }
 


### PR DESCRIPTION
Updated renovate.json with standardised config via repoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the Renovate configuration with a standardized schema via repoRanger, establishing consistent dependency management practices for the project.

## Changes

**renovate.json**

- Extends Renovate's recommended config preset.
- Sets `rangeStrategy` to "bump".
- Enables `pinDigests` to pin container image digests.
- Keeps `automerge: true`.
- Keeps `dependencyDashboard: true`.
- Sets `branchPrefix` to "deps/".
- Adds packageRules:
  - Disables updates for PHP (composer).
  - Disables updates for Node/Yarn (npm).
  - Disables major updates for npm and composer.
  - Groups all dependencies into a single group named "all dependencies" (slug: "all").

**tests/phpunit/Unit/SnapshotTest.php**

- Adjusts several test data providers to add an extra outer array level around previously nested diff structures (changes the shape of static test data only).

## Impact

Standardizes dependency update behavior, groups updates into consolidated PRs, and reduces risk of breaking Composer/npm major upgrades by disabling major updates for those managers. Tests updated to reflect changed fixture/data-provider shape.

Possibly related:
- No matching or relevant issue references were found in the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->