### PR TITLE
Added parallel execution support to snapshot update script.

### DIFF
--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -166,32 +166,38 @@ function run_all_datasets(array $config): void {
 
   $stats = ['current' => 0, 'succeeded' => 0, 'failed' => 0, 'timedout' => 0];
 
-  foreach ($datasets as $dataset) {
+  // Run baseline sequentially first.
+  $scenario_datasets = $datasets;
+  if ($datasets[0] === BASELINE_DATASET_NAME) {
     $stats['current']++;
 
     $result = run_with_timeout(
-      $config['test_name'] . '@' . $dataset,
+      $config['test_name'] . '@' . BASELINE_DATASET_NAME,
       $stats['current'],
       $total_datasets,
-      $dataset,
+      BASELINE_DATASET_NAME,
       $config['timeout'],
       $config['retries'],
       $config['debug'],
       $config['root']
     );
 
-    // Handle baseline dataset specially.
-    if ($dataset === BASELINE_DATASET_NAME) {
-      $baseline_committed = handle_baseline_result($result, $config['root'], $baseline_path);
-    }
-
-    // Update statistics.
+    $baseline_committed = handle_baseline_result($result, $config['root'], $baseline_path);
     $stats = update_stats($stats, $result, $total_datasets);
 
-    // Exit on timeout.
     if ($result === 2) {
       throw new \Exception('Test timed out');
     }
+
+    $scenario_datasets = array_slice($datasets, 1);
+  }
+
+  // Run remaining scenarios in parallel.
+  if (!empty($scenario_datasets)) {
+    $parallel_stats = run_datasets_parallel($scenario_datasets, $stats['current'], $total_datasets, $config);
+    $stats['succeeded'] += $parallel_stats['succeeded'];
+    $stats['failed'] += $parallel_stats['failed'];
+    $stats['timedout'] += $parallel_stats['timedout'];
   }
 
   // Print summary.
@@ -425,6 +431,7 @@ function parse_arguments(array $argv): array {
     'test_dir' => 'tests',
     'timeout' => 30,
     'retries' => 12,
+    'jobs' => 4,
   ];
 
   // Remove script name.
@@ -500,6 +507,10 @@ function parse_option(string $arg, array $config): array {
       $config['retries'] = (int) $value;
       break;
 
+    case 'jobs':
+      $config['jobs'] = max(1, (int) $value);
+      break;
+
     case 'debug':
       $config['debug'] = TRUE;
       break;
@@ -536,6 +547,7 @@ Options:
   --test-dir=<path>     Directory containing tests (default: tests)
   --timeout=<seconds>   Timeout for each test run (default: 30)
   --retries=<count>     Max retries for timed out tests (default: 12)
+  --jobs=<count>        Number of parallel jobs for scenarios (default: 4)
   --debug               Show PHPUnit output for failed tests.
   --help                This help.
 
@@ -622,6 +634,333 @@ function run_with_timeout(string $filter, int $current, int $total, string $data
   verbose(" ✗\n");
 
   return 1;
+}
+
+/**
+ * Run datasets in parallel with live progress display.
+ *
+ * @param array<string> $datasets
+ *   Dataset names to run.
+ * @param int $start_number
+ *   Starting dataset number (for display).
+ * @param int $total_datasets
+ *   Total number of datasets (for display).
+ * @param array<string, mixed> $config
+ *   Configuration array.
+ *
+ * @return array<string, int>
+ *   Statistics: succeeded, failed, timedout counts.
+ */
+function run_datasets_parallel(array $datasets, int $start_number, int $total_datasets, array $config): array {
+  $jobs = (int) $config['jobs'];
+  $is_tty = function_exists('posix_isatty') && posix_isatty(STDOUT);
+
+  // Build task list.
+  $tasks = [];
+  $number = $start_number;
+  foreach ($datasets as $dataset) {
+    $number++;
+    $tasks[] = [
+      'dataset' => $dataset,
+      'number' => $number,
+      'status' => 'queued',
+      'process' => NULL,
+      'pipes' => [],
+      'output' => [],
+      'start_time' => NULL,
+      'elapsed' => NULL,
+      'dots' => 0,
+      'attempt' => 1,
+      'last_dot_time' => 0.0,
+    ];
+  }
+
+  $rendered_lines = 0;
+
+  verbose("Running %d scenarios (parallel: %d)\n\n", count($datasets), $jobs);
+
+  // Event loop.
+  while (TRUE) {
+    dispatch_signals();
+
+    // Start phase: fill empty slots.
+    $running_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
+    foreach ($tasks as &$task) {
+      if ($running_count >= $jobs) {
+        break;
+      }
+      if ($task['status'] !== 'queued') {
+        continue;
+      }
+      $task = start_task($task, $config);
+      $running_count++;
+    }
+    unset($task);
+
+    // Poll phase: check running processes.
+    foreach ($tasks as &$task) {
+      if ($task['status'] !== 'running') {
+        continue;
+      }
+      $task = poll_task($task, $config);
+    }
+    unset($task);
+
+    // Render phase.
+    $rendered_lines = render_progress($tasks, $total_datasets, $is_tty, $rendered_lines);
+
+    // Exit check: all done?
+    $pending = array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued' || $t['status'] === 'running');
+    if (empty($pending)) {
+      break;
+    }
+
+    usleep(100000);
+  }
+
+  // Print debug output for failures.
+  if ($config['debug']) {
+    foreach ($tasks as $task) {
+      if ($task['status'] === 'failed' || $task['status'] === 'timeout') {
+        verbose("\n--- DEBUG: %s ---\n", $task['dataset']);
+        verbose("%s\n", implode("\n", $task['output']));
+        verbose("--- END DEBUG ---\n");
+      }
+    }
+  }
+
+  verbose("\n");
+
+  // Aggregate stats.
+  $stats = ['succeeded' => 0, 'failed' => 0, 'timedout' => 0];
+  foreach ($tasks as $task) {
+    if ($task['status'] === 'success') {
+      $stats['succeeded']++;
+    }
+    elseif ($task['status'] === 'timeout') {
+      $stats['timedout']++;
+    }
+    else {
+      $stats['failed']++;
+    }
+  }
+
+  return $stats;
+}
+
+/**
+ * Start a queued task by spawning a PHPUnit process.
+ *
+ * @param array<string, mixed> $task
+ *   Task array.
+ * @param array<string, mixed> $config
+ *   Configuration array.
+ *
+ * @return array<string, mixed>
+ *   Updated task array with running process.
+ */
+function start_task(array $task, array $config): array {
+  $filter = $config['test_name'] . '@' . $task['dataset'];
+  $cmd = sprintf(
+    'XDEBUG_MODE=off UPDATE_SNAPSHOTS=1 timeout --foreground %ds %s/vendor/bin/phpunit --no-coverage --filter=%s 2>&1',
+    $config['timeout'],
+    $config['root'],
+    escapeshellarg($filter)
+  );
+
+  $descriptors = [
+    0 => ['pipe', 'r'],
+    1 => ['pipe', 'w'],
+    2 => ['pipe', 'w'],
+  ];
+
+  $process = proc_open($cmd, $descriptors, $pipes);
+
+  if (!is_resource($process)) {
+    $task['status'] = 'failed';
+    return $task;
+  }
+
+  fclose($pipes[0]);
+  stream_set_blocking($pipes[1], FALSE);
+  stream_set_blocking($pipes[2], FALSE);
+
+  $task['status'] = 'running';
+  $task['process'] = $process;
+  $task['pipes'] = $pipes;
+  $task['start_time'] = microtime(TRUE);
+  $task['last_dot_time'] = microtime(TRUE);
+
+  return $task;
+}
+
+/**
+ * Poll a running task for completion and progress.
+ *
+ * @param array<string, mixed> $task
+ *   Task array with running process.
+ * @param array<string, mixed> $config
+ *   Configuration array.
+ *
+ * @return array<string, mixed>
+ *   Updated task array.
+ */
+function poll_task(array $task, array $config): array {
+  $status = proc_get_status($task['process']);
+  $task['output'] = collect_output($task['pipes'], $task['output']);
+
+  // Update dots every 250ms.
+  if (microtime(TRUE) - $task['last_dot_time'] >= 0.25) {
+    $task['dots']++;
+    $task['last_dot_time'] = microtime(TRUE);
+  }
+
+  if ($status['running']) {
+    return $task;
+  }
+
+  // Process finished.
+  $task['output'] = collect_output($task['pipes'], $task['output']);
+  fclose($task['pipes'][1]);
+  fclose($task['pipes'][2]);
+  $exit_code = proc_close($task['process']);
+  $task['elapsed'] = round(microtime(TRUE) - $task['start_time'], 1);
+  $task['process'] = NULL;
+  $task['pipes'] = [];
+
+  if ($exit_code === 0) {
+    $task['status'] = 'success';
+    return $task;
+  }
+
+  // Timeout - retry if attempts remain.
+  if ($exit_code === 124) {
+    if ($task['attempt'] < $config['retries']) {
+      $task['attempt']++;
+      $task['status'] = 'queued';
+      $task['dots'] = 0;
+      $task['start_time'] = NULL;
+      $task['elapsed'] = NULL;
+      return $task;
+    }
+    $task['status'] = 'timeout';
+    return $task;
+  }
+
+  // Interrupt.
+  if ($exit_code === 130) {
+    exit(130);
+  }
+
+  $task['status'] = 'failed';
+
+  return $task;
+}
+
+/**
+ * Render progress display for all tasks.
+ *
+ * @param array<int, array<string, mixed>> $tasks
+ *   All tasks.
+ * @param int $total_datasets
+ *   Total dataset count for numbering.
+ * @param bool $is_tty
+ *   Whether output is a TTY.
+ * @param int $previous_lines
+ *   Number of lines rendered in the previous frame.
+ *
+ * @return int
+ *   Number of lines rendered.
+ */
+function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $previous_lines): int {
+  $lines = [];
+
+  foreach ($tasks as $task) {
+    $prefix = sprintf('  [%d/%d] %s ', $task['number'], $total_datasets, $task['dataset']);
+
+    switch ($task['status']) {
+      case 'queued':
+        $lines[] = $prefix;
+        break;
+
+      case 'running':
+        $lines[] = $prefix . str_repeat('.', $task['dots']);
+        break;
+
+      case 'success':
+        $lines[] = $prefix . '✓ ' . $task['elapsed'] . 's';
+        break;
+
+      case 'failed':
+        $lines[] = $prefix . '✗ ' . $task['elapsed'] . 's';
+        break;
+
+      case 'timeout':
+        $lines[] = $prefix . '⏱ ' . $task['elapsed'] . 's';
+        break;
+    }
+  }
+
+  // Footer.
+  $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
+  $failed = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
+  $running = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
+  $queued = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued'));
+  $timedout = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
+
+  $lines[] = '';
+  $lines[] = sprintf('  Done: %d  Failed: %d  Running: %d  Queued: %d  Timeout: %d', $succeeded, $failed, $running, $queued, $timedout);
+
+  $total_lines = count($lines);
+
+  if (!$is_tty) {
+    // Non-TTY: only print when all done.
+    if ($running === 0 && $queued === 0) {
+      foreach ($lines as $line) {
+        verbose("%s\n", $line);
+      }
+    }
+    return $total_lines;
+  }
+
+  // TTY: move cursor up to overwrite previous frame.
+  if ($previous_lines > 0) {
+    verbose("\033[%dA", $previous_lines);
+  }
+
+  foreach ($lines as $line) {
+    verbose("\033[K%s\n", $line);
+  }
+
+  return $total_lines;
+}
+
+/**
+ * Kill all running processes in task list.
+ *
+ * @param array<int, array<string, mixed>> $tasks
+ *   All tasks.
+ */
+function kill_all_tasks(array &$tasks): void {
+  foreach ($tasks as &$task) {
+    if ($task['status'] === 'running' && is_resource($task['process'])) {
+      $status = proc_get_status($task['process']);
+      if ($status['running'] && $status['pid'] > 0) {
+        posix_kill($status['pid'], SIGTERM);
+      }
+      if (is_resource($task['pipes'][1])) {
+        fclose($task['pipes'][1]);
+      }
+      if (is_resource($task['pipes'][2])) {
+        fclose($task['pipes'][2]);
+      }
+      proc_close($task['process']);
+      $task['status'] = 'failed';
+      $task['process'] = NULL;
+      $task['pipes'] = [];
+    }
+  }
+  unset($task);
 }
 
 /**

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -99,14 +99,14 @@ function validate_config(array $config): void {
  */
 function setup_signal_handlers(): void {
   if (function_exists('pcntl_signal')) {
-    pcntl_signal(SIGINT, function (): void {
+    $handler = function (): void {
+      // Restore terminal if in TUI mode.
+      exit_tui();
       verbose("\nInterrupted by user\n");
       exit(130);
-    });
-    pcntl_signal(SIGTERM, function (): void {
-      verbose("\nInterrupted by user\n");
-      exit(130);
-    });
+    };
+    pcntl_signal(SIGINT, $handler);
+    pcntl_signal(SIGTERM, $handler);
   }
 }
 
@@ -675,13 +675,23 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total_da
     ];
   }
 
-  $rendered_lines = 0;
+  $scroll_offset = 0;
+  $start_time = microtime(TRUE);
 
-  verbose("Running %d scenarios (parallel: %d)\n\n", count($datasets), $jobs);
+  verbose("Running %d scenarios (parallel: %d)\n", count($datasets), $jobs);
+
+  if ($is_tty) {
+    enter_tui();
+  }
 
   // Event loop.
   while (TRUE) {
     dispatch_signals();
+
+    // Read keyboard input for scrolling (TTY only).
+    if ($is_tty) {
+      $scroll_offset = read_keyboard_input($scroll_offset, count($tasks));
+    }
 
     // Start phase: fill empty slots.
     $running_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
@@ -707,7 +717,7 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total_da
     unset($task);
 
     // Render phase.
-    $rendered_lines = render_progress($tasks, $total_datasets, $is_tty, $rendered_lines);
+    render_progress($tasks, $total_datasets, $is_tty, $jobs, $scroll_offset, $start_time);
 
     // Exit check: all done?
     $pending = array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued' || $t['status'] === 'running');
@@ -715,10 +725,22 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total_da
       break;
     }
 
-    usleep(100000);
+    usleep(50000);
   }
 
-  // Print debug output for failures.
+  if ($is_tty) {
+    // Hold final frame briefly so user can see results.
+    sleep(2);
+    exit_tui();
+  }
+
+  // Print final summary and debug output to normal scrollback.
+  $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
+  $failed_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
+  $timedout_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
+
+  verbose("Parallel run: %d succeeded, %d failed, %d timed out\n", $succeeded, $failed_count, $timedout_count);
+
   if ($config['debug']) {
     foreach ($tasks as $task) {
       if ($task['status'] === 'failed' || $task['status'] === 'timeout') {
@@ -728,8 +750,6 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total_da
       }
     }
   }
-
-  verbose("\n");
 
   // Aggregate stats.
   $stats = ['succeeded' => 0, 'failed' => 0, 'timedout' => 0];
@@ -858,7 +878,112 @@ function poll_task(array $task, array $config): array {
 }
 
 /**
+ * Track whether TUI mode is active.
+ *
+ * @param bool|null $set
+ *   Set to TRUE/FALSE to change state, or NULL to query.
+ *
+ * @return bool
+ *   Whether TUI mode is active.
+ */
+function is_tui_active(?bool $set = NULL): bool {
+  static $active = FALSE;
+
+  if ($set !== NULL) {
+    $active = $set;
+  }
+
+  return $active;
+}
+
+/**
+ * Enter TUI mode: alternate screen, hidden cursor, raw input.
+ */
+function enter_tui(): void {
+  // @codeCoverageIgnoreStart
+  print "\033[?1049h";
+  print "\033[2J\033[H";
+  print "\033[?25l";
+  system('stty -icanon -echo');
+  stream_set_blocking(STDIN, FALSE);
+  is_tui_active(TRUE);
+  // @codeCoverageIgnoreEnd
+}
+
+/**
+ * Exit TUI mode: show cursor, restore screen, reset terminal.
+ */
+function exit_tui(): void {
+  // @codeCoverageIgnoreStart
+  if (!is_tui_active()) {
+    return;
+  }
+  print "\033[?25h";
+  print "\033[?1049l";
+  system('stty sane');
+  is_tui_active(FALSE);
+  // @codeCoverageIgnoreEnd
+}
+
+/**
+ * Read keyboard input and update scroll offset.
+ *
+ * @param int $scroll_offset
+ *   Current scroll offset.
+ * @param int $task_count
+ *   Total number of tasks.
+ *
+ * @return int
+ *   Updated scroll offset.
+ */
+function read_keyboard_input(int $scroll_offset, int $task_count): int {
+  // @codeCoverageIgnoreStart
+  $viewport_height = get_viewport_height();
+  $max_scroll = max(0, $task_count - $viewport_height);
+
+  $all_input = '';
+  while (($chunk = fread(STDIN, 256)) !== FALSE && $chunk !== '') {
+    $all_input .= $chunk;
+  }
+
+  if ($all_input === '') {
+    return $scroll_offset;
+  }
+
+  $scroll_offset -= substr_count($all_input, "\033[A");
+  $scroll_offset += substr_count($all_input, "\033[B");
+  $scroll_offset -= substr_count($all_input, "\033[5~") * $viewport_height;
+  $scroll_offset += substr_count($all_input, "\033[6~") * $viewport_height;
+
+  return max(0, min($max_scroll, $scroll_offset));
+  // @codeCoverageIgnoreEnd
+}
+
+/**
+ * Get the viewport height for task display.
+ *
+ * @return int
+ *   Number of task lines that fit in the viewport.
+ */
+function get_viewport_height(): int {
+  $term_height = (int) exec('tput lines');
+  if ($term_height < 10) {
+    $term_height = 24;
+  }
+
+  // Header (2) + footer (3) + scroll hint (1) = 6 chrome lines.
+  $chrome_lines = 6;
+  $min_task_lines = 10;
+  $max_task_lines = (int) floor($term_height * 0.8);
+
+  return max($min_task_lines, min($max_task_lines, $term_height - $chrome_lines));
+}
+
+/**
  * Render progress display for all tasks.
+ *
+ * In TTY mode, uses alternate screen with viewport scrolling.
+ * In non-TTY mode, prints final results only.
  *
  * @param array<int, array<string, mixed>> $tasks
  *   All tasks.
@@ -866,73 +991,105 @@ function poll_task(array $task, array $config): array {
  *   Total dataset count for numbering.
  * @param bool $is_tty
  *   Whether output is a TTY.
- * @param int $previous_lines
- *   Number of lines rendered in the previous frame.
- *
- * @return int
- *   Number of lines rendered.
+ * @param int $jobs
+ *   Number of parallel jobs.
+ * @param int $scroll_offset
+ *   Current scroll offset for viewport.
+ * @param float $start_time
+ *   Start time of parallel run.
  */
-function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $previous_lines): int {
-  $lines = [];
-
-  foreach ($tasks as $task) {
-    $prefix = sprintf('  [%d/%d] %s ', $task['number'], $total_datasets, $task['dataset']);
-
-    switch ($task['status']) {
-      case 'queued':
-        $lines[] = $prefix;
-        break;
-
-      case 'running':
-        $lines[] = $prefix . str_repeat('.', $task['dots']);
-        break;
-
-      case 'success':
-        $lines[] = $prefix . '✓ ' . $task['elapsed'] . 's';
-        break;
-
-      case 'failed':
-        $lines[] = $prefix . '✗ ' . $task['elapsed'] . 's';
-        break;
-
-      case 'timeout':
-        $lines[] = $prefix . '⏱ ' . $task['elapsed'] . 's';
-        break;
-    }
-  }
-
-  // Footer.
+function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $jobs, int $scroll_offset, float $start_time): void {
+  $task_count = count($tasks);
   $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
   $failed = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
   $running = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
   $queued = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued'));
   $timedout = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
-
-  $lines[] = '';
-  $lines[] = sprintf('  Done: %d  Failed: %d  Running: %d  Queued: %d  Timeout: %d', $succeeded, $failed, $running, $queued, $timedout);
-
-  $total_lines = count($lines);
+  $pad = strlen((string) $total_datasets);
 
   if (!$is_tty) {
     // Non-TTY: only print when all done.
     if ($running === 0 && $queued === 0) {
-      foreach ($lines as $line) {
-        verbose("%s\n", $line);
+      foreach ($tasks as $task) {
+        $line = sprintf('  [%' . $pad . 'd/%d] %s ', $task['number'], $total_datasets, $task['dataset']);
+        if ($task['status'] === 'success') {
+          verbose("%s✓ %ss\n", $line, $task['elapsed']);
+        }
+        elseif ($task['status'] === 'timeout') {
+          verbose("%s⏱ %ss\n", $line, $task['elapsed']);
+        }
+        else {
+          verbose("%s✗ %ss\n", $line, $task['elapsed']);
+        }
       }
+      verbose("\n");
+      verbose("  Done: %d  Failed: %d  Timeout: %d\n", $succeeded, $failed, $timedout);
     }
-    return $total_lines;
+
+    return;
   }
 
-  // TTY: move cursor up to overwrite previous frame.
-  if ($previous_lines > 0) {
-    verbose("\033[%dA", $previous_lines);
+  // @codeCoverageIgnoreStart
+  $viewport_height = get_viewport_height();
+  $max_scroll = max(0, $task_count - $viewport_height);
+  $scroll_offset = min($scroll_offset, $max_scroll);
+
+  // Cursor to home.
+  print "\033[H";
+
+  // Header.
+  printf("\033[K  Running %d scenarios (parallel: %d)\n", $task_count, $jobs);
+  print "\033[K\n";
+
+  // Visible slice of tasks.
+  $visible_end = min($task_count, $scroll_offset + $viewport_height);
+  for ($i = $scroll_offset; $i < $visible_end; $i++) {
+    $task = $tasks[$i];
+    $prefix = sprintf('  [%' . $pad . 'd/%d] %-20s ', $task['number'], $total_datasets, $task['dataset']);
+
+    switch ($task['status']) {
+      case 'queued':
+        printf("\033[K%s\033[90m·\033[0m\n", $prefix);
+        break;
+
+      case 'running':
+        printf("\033[K%s\033[33m%s\033[0m\n", $prefix, str_repeat('.', $task['dots']));
+        break;
+
+      case 'success':
+        printf("\033[K%s\033[32m✓\033[0m %ss\n", $prefix, $task['elapsed']);
+        break;
+
+      case 'failed':
+        printf("\033[K%s\033[31m✗\033[0m %ss\n", $prefix, $task['elapsed']);
+        break;
+
+      case 'timeout':
+        printf("\033[K%s\033[33m⏱\033[0m %ss\n", $prefix, $task['elapsed']);
+        break;
+    }
   }
 
-  foreach ($lines as $line) {
-    verbose("\033[K%s\n", $line);
-  }
+  // Footer.
+  print "\033[K\n";
+  printf(
+    "\033[K  \033[32mDone: %d\033[0m  \033[31mFailed: %d\033[0m  \033[33mRunning: %d\033[0m  Queued: %d  Timeout: %d\n",
+    $succeeded,
+    $failed,
+    $running,
+    $queued,
+    $timedout
+  );
+  printf("\033[K  Elapsed: %s\n", format_time((int) (microtime(TRUE) - $start_time)));
 
-  return $total_lines;
+  // Scroll indicator.
+  if ($max_scroll > 0) {
+    printf("\033[K\033[90m  ↑↓ Scroll (%d-%d of %d)\033[0m\n", $scroll_offset + 1, $visible_end, $task_count);
+  }
+  else {
+    print "\033[K\n";
+  }
+  // @codeCoverageIgnoreEnd
 }
 
 /**

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -80,8 +80,9 @@ trait SnapshotTrait {
       $this->fail($message ?: sprintf('The baseline directory does not exist: %s', $baseline));
     }
 
-    // We use the .expected dir to easily assess the combined expected snapshot.
-    $expected = $expected ?: File::realpath($baseline . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '.expected');
+    // Use a unique temp directory per invocation to avoid collisions when
+    // multiple PHPUnit processes run snapshot tests in parallel.
+    $expected = $expected ?: sys_get_temp_dir() . DIRECTORY_SEPARATOR . '.snapshot-expected-' . getmypid() . '-' . hrtime(TRUE);
     File::rmdir($expected);
 
     try {

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -59,6 +59,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessOutputContains('--root=');
     $this->assertProcessOutputContains('--timeout=');
     $this->assertProcessOutputContains('--retries=');
+    $this->assertProcessOutputContains('--jobs=');
     $this->assertProcessOutputContains('--debug');
     $this->assertProcessOutputContains('dataset ...');
     $this->assertProcessOutputContains('Examples:');
@@ -406,6 +407,112 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
     $expected_file = $this->fixturesDir . '/scenario_change/expected/scenario1/scenario_file.txt';
     $this->assertFileEquals($expected_file, $scenario_file);
+  }
+
+  /**
+   * Test no_change scenario works with parallel jobs.
+   */
+  public function testNoChangeParallelJobs(): void {
+    $this->setupTestProject('no_change');
+
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=60',
+      '--jobs=2',
+      'testSnapshot',
+      'tests/snapshots',
+    ]);
+
+    $this->assertProcessOutputContains('Discovering datasets');
+    $this->assertProcessOutputContains('Found');
+    $this->assertProcessOutputContains('parallel: 2');
+
+    $commit_count = $this->getCommitCount();
+    $this->assertSame(1, $commit_count, 'Expected only initial commit');
+  }
+
+  /**
+   * Test baseline_change scenario works with parallel jobs.
+   */
+  public function testBaselineChangeParallelJobs(): void {
+    $this->setupTestProject('baseline_change');
+
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=60',
+      '--jobs=2',
+      'testSnapshot',
+      'tests/snapshots',
+    ]);
+
+    $this->assertProcessOutputContains('Discovering datasets');
+    $this->assertProcessOutputContains('parallel: 2');
+
+    $commit_count = $this->getCommitCount();
+    $this->assertSame(2, $commit_count, 'Expected initial + update commit');
+
+    $this->assertDirectoriesIdentical(
+      $this->fixturesDir . '/baseline_change/expected/_baseline',
+      $this->projectDir . '/tests/snapshots/_baseline'
+    );
+  }
+
+  /**
+   * Test both_change scenario works with parallel jobs.
+   */
+  public function testBothChangeParallelJobs(): void {
+    $this->setupTestProject('both_change');
+
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=60',
+      '--jobs=2',
+      'testSnapshot',
+      'tests/snapshots',
+    ]);
+
+    $this->assertProcessOutputContains('Discovering datasets');
+    $this->assertProcessOutputContains('parallel: 2');
+
+    $commit_count = $this->getCommitCount();
+    $this->assertSame(2, $commit_count, 'Expected initial + update commit');
+
+    $this->assertDirectoriesIdentical(
+      $this->fixturesDir . '/both_change/expected/_baseline',
+      $this->projectDir . '/tests/snapshots/_baseline'
+    );
+
+    $scenario_path = $this->projectDir . '/tests/snapshots/scenario1';
+    $scenario_files = array_diff(scandir($scenario_path), ['.', '..', '.gitkeep', '.ignorecontent']);
+    $this->assertCount(0, $scenario_files, 'scenario1 should not contain any diff files');
+  }
+
+  /**
+   * Test that --jobs=1 works as sequential fallback.
+   */
+  public function testJobsOneSequential(): void {
+    $this->setupTestProject('no_change');
+
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=60',
+      '--jobs=1',
+      'testSnapshot',
+      'tests/snapshots',
+    ]);
+
+    $this->assertProcessOutputContains('parallel: 1');
+
+    $commit_count = $this->getCommitCount();
+    $this->assertSame(1, $commit_count, 'Expected only initial commit');
   }
 
   /**


### PR DESCRIPTION
Added parallel execution support to the snapshot update script.

## Summary

The `bin/update-snapshots` script previously ran all dataset scenarios sequentially, one at a time. This change introduces parallel execution for scenario datasets (all datasets except the baseline), allowing multiple PHPUnit processes to run concurrently. The baseline dataset is always run first and sequentially to ensure it is committed before scenarios are processed. A new `--jobs` option controls the degree of parallelism (default: 4).

## Changes

### `bin/update-snapshots`

- Refactored `run_all_datasets()` to separate baseline execution (sequential, always first) from scenario execution (parallel).
- Added `--jobs=<count>` CLI option (default: 4, minimum: 1) parsed via `parse_option()`.
- Added `run_datasets_parallel()`: an event-loop driven parallel runner that spawns up to `--jobs` PHPUnit processes at a time and monitors them.
- Added `start_task()`: spawns a PHPUnit process for a dataset using `proc_open` with non-blocking I/O.
- Added `poll_task()`: polls a running process for completion, handles retries on timeout (exit code 124), and interrupt handling (exit code 130).
- Added `render_progress()`: renders a live TTY progress display (overwriting previous frame) or a final summary for non-TTY output.
- Added `kill_all_tasks()`: terminates all running processes on interrupt/shutdown.

### `tests/phpunit/Functional/SnapshotUpdateScriptTest.php`

- Added assertion that `--jobs=` appears in the help output.
- Added `testNoChangeParallelJobs()`: verifies no extra commits when running with `--jobs=2` and no changes needed.
- Added `testBaselineChangeParallelJobs()`: verifies baseline is updated and committed correctly when running in parallel mode.
- Added `testBothChangeParallelJobs()`: verifies both baseline and scenario updates work correctly with `--jobs=2`.
- Added `testJobsOneSequential()`: verifies `--jobs=1` works as a sequential fallback.

## Before / After

```
Before: run_all_datasets()
┌─────────────────────────────────────────┐
│  foreach $datasets                      │
│  ┌──────────────────────────────────┐   │
│  │  run_with_timeout(dataset)       │   │
│  │  if baseline → commit            │   │
│  │  update_stats()                  │   │
│  └──────────────────────────────────┘   │
│  (sequential: baseline, s1, s2, s3...)  │
└─────────────────────────────────────────┘

After: run_all_datasets()
┌──────────────────────────────────────────────────────┐
│  Step 1 (sequential):                                │
│  ┌────────────────────────────────┐                  │
│  │  run_with_timeout(_baseline)   │                  │
│  │  handle_baseline_result()      │                  │
│  └────────────────────────────────┘                  │
│                                                      │
│  Step 2 (parallel, up to --jobs workers):            │
│  ┌──────────────────────────────────────────────┐    │
│  │  run_datasets_parallel([s1, s2, s3, ...])    │    │
│  │                                              │    │
│  │  Event loop:                                 │    │
│  │  ┌──────────┐ ┌──────────┐ ┌──────────┐     │    │
│  │  │ start_   │ │ poll_    │ │ render_  │     │    │
│  │  │ task()   │ │ task()   │ │ progress │     │    │
│  │  └──────────┘ └──────────┘ └──────────┘     │    │
│  │                                              │    │
│  │  [s1]....✓  [s2]....✓  [s3]....✓           │    │
│  └──────────────────────────────────────────────┘    │
└──────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Parallel Execution Support for Snapshot Update Script

This PR introduces parallel execution capabilities to the `bin/update-snapshots` script, enabling concurrent processing of scenario datasets while maintaining sequential execution of the baseline dataset.

### Key Changes

**Script Enhancements (`bin/update-snapshots`):**
- Refactored dataset execution workflow to separate baseline (always runs first, sequentially) from scenarios (run in parallel).
- Added `run_datasets_parallel()`: event-loop driven orchestrator that spawns up to `--jobs` concurrent PHPUnit processes.
- Added `start_task()` and `poll_task()` helpers for spawning and monitoring individual dataset processes with non-blocking I/O (`proc_open`).
- Added retry logic for timeout handling (exit code 124) and graceful interrupt handling (exit code 130).
- Added `render_progress()` for live TTY-based progress display and fallback logging for non-TTY environments.
- Added `kill_all_tasks()` for safe termination of all running processes on shutdown.
- Added `--jobs=<count>` CLI option (default: 4, minimum: 1) to control maximum concurrent PHPUnit processes and parsing via `parse_option()`.
- Ensures baseline dataset (BASELINE_DATASET_NAME) runs first and is committed before scenario datasets run in parallel.
- Refactored signal handling to centralize terminal-restoration logic for SIGINT/SIGTERM.

**Test Coverage (`tests/phpunit/Functional/SnapshotUpdateScriptTest.php`):**
- Validates `--jobs` appears in help output.
- Added functional tests:
  - `testNoChangeParallelJobs()` — verifies behavior with `--jobs=2` when no changes are needed.
  - `testBaselineChangeParallelJobs()` — validates baseline update and commit behavior in parallel mode.
  - `testBothChangeParallelJobs()` — confirms baseline and scenario updates work correctly with `--jobs=2`.
  - `testJobsOneSequential()` — verifies `--jobs=1` executes sequentially as a fallback.
- Tests for parallel execution were duplicated in two consecutive insertion regions (file contains duplicated blocks).

**Testing Isolation Fix (`src/Testing/SnapshotTrait.php`):**
- Replaces shared fixed ".expected" directory with a unique per-invocation temporary expected directory (using sys_get_temp_dir(), PID, and high-resolution time) to avoid test corruption when running PHPUnit in parallel.

### Behavioral Impact

- Before: All datasets executed sequentially in a single loop.
- After: Baseline dataset runs first (sequential); remaining scenario datasets processed concurrently up to the configured job limit with live progress reporting, retry and timeout handling, and task management. Existing commit and snapshot semantics remain, with added per-task debug output in parallel mode.

### Code Changes
- bin/update-snapshots: large additions (~+349 / -10 lines) adding parallel runner, helpers, progress rendering, and signal handling changes.
- tests/phpunit/Functional/SnapshotUpdateScriptTest.php: +107 / -0 lines (new/updated functional tests; duplicated blocks).
- src/Testing/SnapshotTrait.php: small change to use unique temp expected directory (+3 / -2 lines).

Possibly related:
- Repository search found no existing issues or open threads referencing parallelizing snapshot updates, the `--jobs` option, or baseline-first execution. If there are external or GitHub issue threads discussing parallel snapshot updates, please link them (for example: #123) to aid discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->