### PR TITLE
Added support for multiple dataset arguments in 'update-snapshots' script.

### DIFF
--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -118,23 +118,27 @@ function setup_signal_handlers(): void {
  */
 function run_specified_datasets(array $config): void {
   $datasets = $config['datasets'];
+  $total = count($datasets);
   $failed = [];
 
-  foreach ($datasets as $dataset) {
-    verbose("Scanning for dataset: %s\n", $dataset);
+  verbose("Running %d specified dataset(s)\n", $total);
 
-    $cmd = sprintf(
-      'XDEBUG_MODE=off UPDATE_SNAPSHOTS=1 %s/vendor/bin/phpunit --no-coverage --filter=%s',
-      $config['root'],
-      escapeshellarg($config['test_name'] . '@' . $dataset)
+  $current = 0;
+  foreach ($datasets as $dataset) {
+    $current++;
+
+    $result = run_with_timeout(
+      $config['test_name'] . '@' . $dataset,
+      $current,
+      $total,
+      $dataset,
+      $config['timeout'],
+      $config['retries'],
+      $config['debug'],
+      $config['root']
     );
 
-    passthru($cmd, $exit_code);
-
-    if ($exit_code === 0) {
-      verbose("Completed successfully\n");
-    }
-    else {
+    if ($result !== 0) {
       $failed[] = $dataset;
     }
   }
@@ -531,7 +535,7 @@ Options:
   --root=<path>         Path to project root directory (default: current dir)
   --test-dir=<path>     Directory containing tests (default: tests)
   --timeout=<seconds>   Timeout for each test run (default: 30)
-  --retries=<count>     Max retries for timed out tests (default: 3)
+  --retries=<count>     Max retries for timed out tests (default: 12)
   --debug               Show PHPUnit output for failed tests.
   --help                This help.
 

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -10,9 +10,10 @@
  *
  * Usage:
  * @code
- * vendor/bin/snapshot-update [options] <test-name> <snapshots-path> [dataset]
+ * vendor/bin/snapshot-update [options] <test-name> <snapshots-path> [dataset ...]
  * vendor/bin/snapshot-update testMySnapshot path/to/snapshots
  * vendor/bin/snapshot-update testMySnapshot path/to/snapshots baseline
+ * vendor/bin/snapshot-update testMySnapshot path/to/snapshots baseline scenario1
  * vendor/bin/snapshot-update --root=../.. testMySnapshot path/to/snapshots
  * @endcode
  */
@@ -57,9 +58,9 @@ function main(array $argv, int $argc): void {
   // Change to root directory.
   chdir($config['root']);
 
-  // If dataset provided, run single PHPUnit command with filter.
-  if ($config['dataset'] !== '') {
-    run_single_dataset($config);
+  // If datasets provided, run only specified datasets.
+  if (!empty($config['datasets'])) {
+    run_specified_datasets($config);
 
     return;
   }
@@ -110,29 +111,37 @@ function setup_signal_handlers(): void {
 }
 
 /**
- * Run a single dataset.
+ * Run specified datasets.
  *
  * @param array<string, mixed> $config
  *   Configuration array.
  */
-function run_single_dataset(array $config): void {
-  verbose("Scanning for dataset: %s\n", $config['dataset']);
+function run_specified_datasets(array $config): void {
+  $datasets = $config['datasets'];
+  $failed = [];
 
-  $cmd = sprintf(
-    'XDEBUG_MODE=off UPDATE_SNAPSHOTS=1 %s/vendor/bin/phpunit --no-coverage --filter=%s',
-    $config['root'],
-    escapeshellarg($config['test_name'] . '@' . $config['dataset'])
-  );
+  foreach ($datasets as $dataset) {
+    verbose("Scanning for dataset: %s\n", $dataset);
 
-  passthru($cmd, $exit_code);
+    $cmd = sprintf(
+      'XDEBUG_MODE=off UPDATE_SNAPSHOTS=1 %s/vendor/bin/phpunit --no-coverage --filter=%s',
+      $config['root'],
+      escapeshellarg($config['test_name'] . '@' . $dataset)
+    );
 
-  if ($exit_code === 0) {
-    verbose("Completed successfully\n");
+    passthru($cmd, $exit_code);
 
-    return;
+    if ($exit_code === 0) {
+      verbose("Completed successfully\n");
+    }
+    else {
+      $failed[] = $dataset;
+    }
   }
 
-  throw new \Exception('Failed');
+  if (!empty($failed)) {
+    throw new \Exception(sprintf('Failed datasets: %s', implode(', ', $failed)));
+  }
 }
 
 /**
@@ -407,7 +416,7 @@ function parse_arguments(array $argv): array {
     'debug' => FALSE,
     'test_name' => '',
     'snapshots_path' => '',
-    'dataset' => '',
+    'datasets' => [],
     'root' => (string) getcwd(),
     'test_dir' => 'tests',
     'timeout' => 30,
@@ -443,8 +452,8 @@ function parse_arguments(array $argv): array {
   if (isset($positional[1])) {
     $config['snapshots_path'] = $positional[1];
   }
-  if (isset($positional[2])) {
-    $config['dataset'] = $positional[2];
+  if (count($positional) > 2) {
+    $config['datasets'] = array_slice($positional, 2);
   }
 
   return $config;
@@ -508,13 +517,14 @@ This script runs PHPUnit with UPDATE_SNAPSHOTS=1 for each dataset to avoid
 memory issues and handle hanging tests with timeouts and retries.
 
 Usage:
-  vendor/bin/{$script_name} [options] <test-name> <snapshots-path> [dataset]
+  vendor/bin/{$script_name} [options] <test-name> <snapshots-path> [dataset ...]
 
 Arguments:
   test-name             Test method name pattern (e.g., 'testMySnapshot').
   snapshots-path        Path to snapshots directory (relative to --root).
                         Baseline path is derived as '_baseline' subdirectory.
-  dataset               Optional dataset name to update (e.g., 'baseline').
+  dataset               Optional dataset name(s) to update (e.g., 'baseline').
+                        Multiple datasets can be specified separated by spaces.
                         If not provided, all datasets will be updated.
 
 Options:
@@ -528,6 +538,7 @@ Options:
 Examples:
   vendor/bin/{$script_name} testMySnapshot tests/snapshots
   vendor/bin/{$script_name} testMySnapshot tests/snapshots baseline
+  vendor/bin/{$script_name} testMySnapshot tests/snapshots baseline scenario1
   vendor/bin/{$script_name} --root=/path/to/project testMySnapshot tests/snapshots
   vendor/bin/{$script_name} --test-dir=tests/Functional testMySnapshot tests/snapshots
 

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -59,6 +59,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessOutputContains('--timeout=');
     $this->assertProcessOutputContains('--retries=');
     $this->assertProcessOutputContains('--debug');
+    $this->assertProcessOutputContains('dataset ...');
     $this->assertProcessOutputContains('Examples:');
   }
 
@@ -229,18 +230,19 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   }
 
   /**
-   * Test scenario_change: single dataset mode updates files (no commit).
+   * Test scenario_change: specified dataset mode updates files (no commit).
    *
    * Scenario: scenario_change
    * - Actual has extra scenario_file.txt
-   * - Run ONLY scenario1 dataset (single dataset mode)
-   * - Expected: Files updated, no commit (single dataset mode doesn't commit)
+   * - Run ONLY scenario1 dataset (specified dataset mode)
+   * - Expected: Files updated, no commit (specified dataset mode doesn't
+   *   commit)
    */
   public function testScenarioChangeUpdatesFiles(): void {
     $this->setupTestProject('scenario_change');
 
     // Run update-snapshots for ONLY scenario1 dataset.
-    // Single dataset mode doesn't create commits.
+    // Specified dataset mode doesn't create commits.
     $this->processRun('php', [
       $this->scriptPath,
       '--root=' . $this->projectDir,
@@ -251,7 +253,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'scenario1',
     ]);
 
-    // Assert: single dataset mode ran.
+    // Assert: specified dataset mode ran.
     $this->assertProcessOutputContains('Scanning for dataset: scenario1');
 
     // Assert: scenario diff file was created.
@@ -262,9 +264,46 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $expected_file = $this->fixturesDir . '/scenario_change/expected/scenario1/scenario_file.txt';
     $this->assertFileEquals($expected_file, $scenario_file);
 
-    // Assert: only 1 commit (initial - single dataset mode doesn't commit).
+    // Assert: only 1 commit (initial - specified dataset mode doesn't commit).
     $commit_count = $this->getCommitCount();
-    $this->assertSame(1, $commit_count, 'Single dataset mode should not create commits');
+    $this->assertSame(1, $commit_count, 'Specified dataset mode should not create commits');
+  }
+
+  /**
+   * Test multiple datasets: specified datasets are all processed.
+   *
+   * Scenario: scenario_change
+   * - Run baseline AND scenario1 datasets
+   * - Expected: Both datasets processed, files updated, no commit.
+   */
+  public function testMultipleDatasetsUpdatesFiles(): void {
+    $this->setupTestProject('both_change');
+
+    // Run update-snapshots for baseline AND scenario1 datasets.
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=60',
+      'testSnapshot',
+      'tests/snapshots',
+      'baseline',
+      'scenario1',
+    ]);
+
+    // Assert: both datasets were scanned.
+    $this->assertProcessOutputContains('Scanning for dataset: baseline');
+    $this->assertProcessOutputContains('Scanning for dataset: scenario1');
+
+    // Assert: baseline files match expected (includes scenario_file.txt).
+    $this->assertDirectoriesIdentical(
+      $this->fixturesDir . '/both_change/expected/_baseline',
+      $this->projectDir . '/tests/snapshots/_baseline'
+    );
+
+    // Assert: only 1 commit (initial - specified dataset mode doesn't commit).
+    $commit_count = $this->getCommitCount();
+    $this->assertSame(1, $commit_count, 'Specified dataset mode should not create commits');
   }
 
   /**

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -254,7 +254,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     ]);
 
     // Assert: specified dataset mode ran.
-    $this->assertProcessOutputContains('Scanning for dataset: scenario1');
+    $this->assertProcessOutputContains('Running 1 specified dataset(s)');
+    $this->assertProcessOutputContains('scenario1');
 
     // Assert: scenario diff file was created.
     $scenario_file = $this->projectDir . '/tests/snapshots/scenario1/scenario_file.txt';
@@ -292,8 +293,9 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     ]);
 
     // Assert: both datasets were scanned.
-    $this->assertProcessOutputContains('Scanning for dataset: baseline');
-    $this->assertProcessOutputContains('Scanning for dataset: scenario1');
+    $this->assertProcessOutputContains('Running 2 specified dataset(s)');
+    $this->assertProcessOutputContains('baseline');
+    $this->assertProcessOutputContains('scenario1');
 
     // Assert: baseline files match expected (includes scenario_file.txt).
     $this->assertDirectoriesIdentical(


### PR DESCRIPTION
## Summary

Updated the `update-snapshots` script to accept multiple dataset names as positional arguments instead of only one. Previously, running `snapshot-update testName path dataset1` was the only way to target a specific dataset. Now, multiple datasets can be specified like `snapshot-update testName path dataset1 dataset2`, and each will be processed sequentially.

## Changes

### CLI script (`bin/update-snapshots`)
- Changed `$config['dataset']` (string) to `$config['datasets']` (array) to collect all positional args from index 2+
- Replaced `run_single_dataset()` with `run_specified_datasets()` that loops over all specified datasets and reports failures at the end
- Updated usage line, argument descriptions, and examples in help text to show `[dataset ...]`

### Tests (`tests/phpunit/Functional/SnapshotUpdateScriptTest.php`)
- Added `testMultipleDatasetsUpdatesFiles` test that passes two dataset names (`baseline`, `scenario1`) and verifies both are processed
- Added help text assertion for `dataset ...`
- Updated comments to reflect "specified dataset mode" terminology

## Before / After

```
Before:
┌──────────────────────────────────────────────────┐
│  snapshot-update testName path [dataset]          │
│                                                   │
│  Positional[2] ─► single string                   │
│       │                                           │
│       ▼                                           │
│  run_single_dataset() ─► 1 passthru call          │
└──────────────────────────────────────────────────┘

After:
┌──────────────────────────────────────────────────┐
│  snapshot-update testName path [dataset ...]      │
│                                                   │
│  Positional[2..N] ─► array of strings             │
│       │                                           │
│       ▼                                           │
│  run_specified_datasets()                         │
│       │                                           │
│       ├─► dataset1 passthru                       │
│       ├─► dataset2 passthru                       │
│       └─► datasetN passthru                       │
│                                                   │
│  Failures collected and reported at end           │
└──────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Extends the `update-snapshots` CLI script to accept and process multiple dataset names as positional arguments, allowing users to specify which datasets to update in a single command rather than running the tool once per dataset.

## Key Changes

### Script Functionality (`bin/update-snapshots`)
- Replaced single-dataset execution with multi-dataset support: removed run_single_dataset() and added run_specified_datasets() which iterates through multiple datasets sequentially.
- Updated argument parsing to accept multiple dataset names as positional arguments (index 2+) instead of a single optional dataset string.
- Changed public configuration from `'dataset'` (string) to `'datasets'` (array) to store all specified datasets.
- Updated help/usage text to reflect multiple dataset support with `[dataset ...]` syntax and updated examples.
- Uses run_with_timeout() inside run_specified_datasets() and adjusted default retry behavior (commit note: fixed '--retries' help text and switched to run_with_timeout()).
- When no datasets provided, the script still discovers and runs all datasets (run_all_datasets()).

### Error Handling
- Per-dataset verbose output is shown for each specified dataset.
- Failures are collected across datasets and, if any fail, a consolidated exception is thrown listing all failed datasets.

### Test Coverage
- Added testMultipleDatasetsUpdatesFiles() to verify multiple datasets (baseline and scenario1) are processed together.
- Updated testHelpFlag() to assert `dataset ...` appears in help output.
- Updated testScenarioChangeUpdatesFiles() comments and assertions to use "specified dataset mode" terminology and to assert "Running 1 specified dataset(s)".

## Usage
- Update multiple specific datasets:
  vendor/bin/update-snapshots testMySnapshot tests/snapshots baseline scenario1
- Update a single dataset:
  vendor/bin/update-snapshots testMySnapshot tests/snapshots baseline

## Impact
- Breaking change for callers expecting $config['dataset']: use $config['datasets'] (array) instead.
- Users can update multiple datasets in one command; behavior for baseline and dataset ordering is preserved.

Possibly related:
- See repository issue tracker for related discussions: https://github.com/AlexSkrypnyk/snapshot/issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->