### PR TITLE
Made 'update-snapshots' exit '0' when snapshots update successfully.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,30 @@ when tests fail due to directory comparison mismatches:
 UPDATE_SNAPSHOTS=1 ./vendor/bin/phpunit
 ```
 
+### Bulk Snapshot Updates (`bin/update-snapshots`)
+
+CLI that runs PHPUnit per dataset with `UPDATE_SNAPSHOTS=1` (in parallel, with
+timeouts and retries) to regenerate many snapshots at once:
+
+```bash
+vendor/bin/update-snapshots testMySnapshot tests/snapshots
+```
+
+**Exit-code contract**: successfully updating snapshots is the expected outcome
+and exits `0`. The script exits non-zero **only** when a dataset genuinely
+cannot be updated - a non-snapshot failure or a timeout.
+
+A per-dataset PHPUnit run still exits non-zero when it updates a snapshot (the
+assertion fails before `tearDown()` rewrites it). The script reclassifies such
+runs as "updated" by detecting `SnapshotTrait`'s `[SNAPSHOT] Baseline updated` /
+`[SNAPSHOT] Diffs updated` completion markers in the captured output - so those
+marker strings are a contract shared with `src/Testing/SnapshotTrait.php`; keep
+them in sync.
+
+Functional tests run the script as a subprocess against fixtures in
+`tests/phpunit/Fixtures/functional_update/`. Coverage measures `src/` only, so
+`bin/` is not coverage-gated.
+
 
 ## Performance Benchmarks
 

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -877,11 +877,16 @@ function poll_task(array $task, array $config): array {
     return $task;
   }
 
+  // Capture the exit code from proc_get_status(): the first call that reports
+  // the process stopped reaps the child, so a later proc_close() returns -1 on
+  // PHP < 8.3. proc_close() below only releases the handle.
+  $exit_code = $status['exitcode'];
+
   // Process finished.
   $task['output'] = collect_output($task['pipes'], $task['output']);
   fclose($task['pipes'][1]);
   fclose($task['pipes'][2]);
-  $exit_code = proc_close($task['process']);
+  proc_close($task['process']);
   $task['elapsed'] = round(microtime(TRUE) - $task['start_time'], 1);
   $task['process'] = NULL;
   $task['pipes'] = [];
@@ -1218,6 +1223,7 @@ function execute_phpunit(string $filter, int $timeout, string $root): array {
 
   $output = [];
   $last_dot_time = microtime(TRUE);
+  $exit_code = -1;
 
   while (TRUE) {
     $status = proc_get_status($process);
@@ -1226,6 +1232,10 @@ function execute_phpunit(string $filter, int $timeout, string $root): array {
     $output = collect_output($pipes, $output);
 
     if (!$status['running']) {
+      // Capture the exit code here: proc_get_status() reaps the child on the
+      // first call that reports it stopped, so a later proc_close() returns -1
+      // on PHP < 8.3. proc_close() below only releases the handle.
+      $exit_code = $status['exitcode'];
       break;
     }
 
@@ -1245,7 +1255,7 @@ function execute_phpunit(string $filter, int $timeout, string $root): array {
   fclose($pipes[1]);
   fclose($pipes[2]);
 
-  $exit_code = proc_close($process);
+  proc_close($process);
 
   return [
     'exit_code' => $exit_code,

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -33,6 +33,13 @@ define('COMMIT_MESSAGE_BASELINE', 'Updated baseline.');
 // Commit message for all snapshots.
 define('COMMIT_MESSAGE_SNAPSHOTS', 'Updated snapshots.');
 
+// Completion markers emitted by SnapshotTrait once a snapshot has been
+// rewritten. When a PHPUnit run exits non-zero but its output contains one of
+// these markers, the snapshot was updated successfully and the dataset must be
+// treated as updated rather than failed.
+define('SNAPSHOT_MARKER_BASELINE_UPDATED', '[SNAPSHOT] Baseline updated');
+define('SNAPSHOT_MARKER_DIFFS_UPDATED', '[SNAPSHOT] Diffs updated');
+
 // ----------------------------------------------------------------------------
 
 /**
@@ -120,6 +127,7 @@ function run_specified_datasets(array $config): void {
   $datasets = $config['datasets'];
   $total = count($datasets);
   $failed = [];
+  $updated = 0;
 
   verbose("Running %d specified dataset(s)\n", $total);
 
@@ -138,9 +146,18 @@ function run_specified_datasets(array $config): void {
       $config['root']
     );
 
+    if ($result === 3) {
+      $updated++;
+      continue;
+    }
+
     if ($result !== 0) {
       $failed[] = $dataset;
     }
+  }
+
+  if ($updated > 0) {
+    verbose("Updated %d dataset(s)\n", $updated);
   }
 
   if (!empty($failed)) {
@@ -164,7 +181,7 @@ function run_all_datasets(array $config): void {
 
   verbose("Found %d unique datasets\n", $total_datasets);
 
-  $stats = ['current' => 0, 'succeeded' => 0, 'failed' => 0, 'timedout' => 0];
+  $stats = ['current' => 0, 'succeeded' => 0, 'updated' => 0, 'failed' => 0, 'timedout' => 0];
 
   // Run baseline sequentially first.
   $scenario_datasets = $datasets;
@@ -196,6 +213,7 @@ function run_all_datasets(array $config): void {
   if (!empty($scenario_datasets)) {
     $parallel_stats = run_datasets_parallel($scenario_datasets, $stats['current'], $total_datasets, $config);
     $stats['succeeded'] += $parallel_stats['succeeded'];
+    $stats['updated'] += $parallel_stats['updated'];
     $stats['failed'] += $parallel_stats['failed'];
     $stats['timedout'] += $parallel_stats['timedout'];
   }
@@ -203,15 +221,17 @@ function run_all_datasets(array $config): void {
   // Print summary.
   print_summary($stats, $total_datasets);
 
-  // Handle failures.
-  if ($stats['failed'] > 0 || $stats['timedout'] > 0) {
-    commit_snapshot_changes($config, $baseline_committed);
-    print_execution_time($start_time);
-
-    throw new \Exception('Some tests failed');
-  }
+  // Commit any snapshot changes that were applied. This is a no-op when the
+  // working tree is clean, so it is safe to call unconditionally.
+  commit_snapshot_changes($config, $baseline_committed);
 
   print_execution_time($start_time);
+
+  // Successful updates are the expected outcome of this script and must not
+  // produce a non-zero exit code. Only genuine failures or timeouts do.
+  if ($stats['failed'] > 0 || $stats['timedout'] > 0) {
+    throw new \Exception('Some tests failed');
+  }
 }
 
 /**
@@ -258,7 +278,7 @@ function discover_datasets(array $config): array {
  * Handle baseline test result and commit if needed.
  *
  * @param int $result
- *   Test result (0 = success, 1 = failed, 2 = timeout).
+ *   Test result (0 = success, 1 = failed, 2 = timeout, 3 = updated).
  * @param string $root
  *   Git root directory.
  * @param string $baseline_path
@@ -360,7 +380,7 @@ function commit_snapshot_changes(array $config, bool $baseline_committed): void 
  * @param array<string, int> $stats
  *   Current statistics.
  * @param int $result
- *   Test result (0 = success, 1 = failed, 2 = timeout).
+ *   Test result (0 = success, 1 = failed, 2 = timeout, 3 = updated).
  * @param int $total
  *   Total number of datasets.
  *
@@ -370,6 +390,9 @@ function commit_snapshot_changes(array $config, bool $baseline_committed): void 
 function update_stats(array $stats, int $result, int $total): array {
   if ($result === 0) {
     $stats['succeeded']++;
+  }
+  elseif ($result === 3) {
+    $stats['updated']++;
   }
   elseif ($result === 2) {
     $stats['timedout']++;
@@ -392,9 +415,10 @@ function update_stats(array $stats, int $result, int $total): array {
  */
 function print_summary(array $stats, int $total): void {
   verbose(
-    "Total: %d | Succeeded: %d | Failed: %d | Timed out: %d\n",
+    "Total: %d | Succeeded: %d | Updated: %d | Failed: %d | Timed out: %d\n",
     $total,
     $stats['succeeded'],
+    $stats['updated'],
     $stats['failed'],
     $stats['timedout']
   );
@@ -587,7 +611,7 @@ EOF;
  *   Project root directory.
  *
  * @return int
- *   0 = success, 1 = failed, 2 = timeout.
+ *   0 = success, 1 = failed, 2 = timeout, 3 = updated.
  */
 function run_with_timeout(string $filter, int $current, int $total, string $dataset, int $timeout, int $max_retries, bool $debug, string $root): int {
   $attempt = 1;
@@ -622,6 +646,16 @@ function run_with_timeout(string $filter, int $current, int $total, string $data
       print_debug_output($debug, $result['output']);
 
       return 2;
+    }
+
+    // A successfully updated snapshot still exits non-zero in PHPUnit (the
+    // assertion failed before the update ran in tearDown), but the trait
+    // reports completion. Treat it as updated, not failed.
+    if (output_has_update_marker($result['output'])) {
+      verbose(" ✓ updated\n");
+      print_debug_output($debug, $result['output']);
+
+      return 3;
     }
 
     // Test failure - do not retry.
@@ -736,10 +770,11 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total_da
 
   // Print final summary and debug output to normal scrollback.
   $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
+  $updated_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'updated'));
   $failed_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
   $timedout_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
 
-  verbose("Parallel run: %d succeeded, %d failed, %d timed out\n", $succeeded, $failed_count, $timedout_count);
+  verbose("Parallel run: %d succeeded, %d updated, %d failed, %d timed out\n", $succeeded, $updated_count, $failed_count, $timedout_count);
 
   if ($config['debug']) {
     foreach ($tasks as $task) {
@@ -752,10 +787,13 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total_da
   }
 
   // Aggregate stats.
-  $stats = ['succeeded' => 0, 'failed' => 0, 'timedout' => 0];
+  $stats = ['succeeded' => 0, 'updated' => 0, 'failed' => 0, 'timedout' => 0];
   foreach ($tasks as $task) {
     if ($task['status'] === 'success') {
       $stats['succeeded']++;
+    }
+    elseif ($task['status'] === 'updated') {
+      $stats['updated']++;
     }
     elseif ($task['status'] === 'timeout') {
       $stats['timedout']++;
@@ -870,6 +908,14 @@ function poll_task(array $task, array $config): array {
   // Interrupt.
   if ($exit_code === 130) {
     exit(130);
+  }
+
+  // A non-zero exit accompanied by the trait's completion marker means the
+  // snapshot was updated rather than the test genuinely failing.
+  if (output_has_update_marker($task['output'])) {
+    $task['status'] = 'updated';
+
+    return $task;
   }
 
   $task['status'] = 'failed';
@@ -1001,6 +1047,7 @@ function get_viewport_height(): int {
 function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $jobs, int $scroll_offset, float $start_time): void {
   $task_count = count($tasks);
   $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
+  $updated = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'updated'));
   $failed = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
   $running = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
   $queued = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued'));
@@ -1015,6 +1062,9 @@ function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $j
         if ($task['status'] === 'success') {
           verbose("%s✓ %ss\n", $line, $task['elapsed']);
         }
+        elseif ($task['status'] === 'updated') {
+          verbose("%s✓ updated %ss\n", $line, $task['elapsed']);
+        }
         elseif ($task['status'] === 'timeout') {
           verbose("%s⏱ %ss\n", $line, $task['elapsed']);
         }
@@ -1023,7 +1073,7 @@ function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $j
         }
       }
       verbose("\n");
-      verbose("  Done: %d  Failed: %d  Timeout: %d\n", $succeeded, $failed, $timedout);
+      verbose("  Done: %d  Updated: %d  Failed: %d  Timeout: %d\n", $succeeded, $updated, $failed, $timedout);
     }
 
     return;
@@ -1060,6 +1110,10 @@ function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $j
         printf("\033[K%s\033[32m✓\033[0m %ss\n", $prefix, $task['elapsed']);
         break;
 
+      case 'updated':
+        printf("\033[K%s\033[32m✓\033[0m updated %ss\n", $prefix, $task['elapsed']);
+        break;
+
       case 'failed':
         printf("\033[K%s\033[31m✗\033[0m %ss\n", $prefix, $task['elapsed']);
         break;
@@ -1073,8 +1127,9 @@ function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $j
   // Footer.
   print "\033[K\n";
   printf(
-    "\033[K  \033[32mDone: %d\033[0m  \033[31mFailed: %d\033[0m  \033[33mRunning: %d\033[0m  Queued: %d  Timeout: %d\n",
+    "\033[K  \033[32mDone: %d\033[0m  \033[36mUpdated: %d\033[0m  \033[31mFailed: %d\033[0m  \033[33mRunning: %d\033[0m  Queued: %d  Timeout: %d\n",
     $succeeded,
+    $updated,
     $failed,
     $running,
     $queued,
@@ -1221,6 +1276,26 @@ function collect_output(array $pipes, array $output): array {
   }
 
   return $output;
+}
+
+/**
+ * Check whether captured output reports a completed snapshot update.
+ *
+ * SnapshotTrait emits a completion marker after it finishes rewriting baseline
+ * or diff files. When PHPUnit exits non-zero but this marker is present, the
+ * snapshot was updated successfully and the dataset must not be treated as a
+ * failure.
+ *
+ * @param array<string> $output
+ *   Captured PHPUnit output lines.
+ *
+ * @return bool
+ *   TRUE if a snapshot update completion marker is present.
+ */
+function output_has_update_marker(array $output): bool {
+  $text = implode("\n", $output);
+
+  return str_contains($text, SNAPSHOT_MARKER_BASELINE_UPDATED) || str_contains($text, SNAPSHOT_MARKER_DIFFS_UPDATED);
 }
 
 /**

--- a/tests/phpunit/Fixtures/functional_update/README.md
+++ b/tests/phpunit/Fixtures/functional_update/README.md
@@ -154,6 +154,32 @@ functional_update/
 7. Compare `_baseline/` with `expected/_baseline/`
 8. Assert: `scenario1/` has no diff files (only .gitkeep, .ignorecontent)
 
+### scenario_only_change
+
+**Test**: `testScenarioOnlyChangeUpdatesInParallel`
+
+**Purpose**: Verify a scenario that updates in the parallel phase (while the baseline is unchanged) is treated as a success and exits 0.
+
+**Flow**:
+1. Copy `scenario_only_change/` to `$sut/test_project/`
+2. Run `update-snapshots testSnapshot tests/snapshots` (all datasets)
+3. Baseline matches actual → baseline dataset passes
+4. `scenario1/` holds a stale `extra.txt` diff → scenario dataset updates in parallel and resets the diff
+5. Assert: script exits 0, `extra.txt` is gone, 2 commits (initial + update)
+
+### genuine_failure
+
+**Test**: `testGenuineFailureExitsNonZero`, `testGenuineFailureSpecifiedDatasetExitsNonZero`
+
+**Purpose**: Verify a failure that cannot be resolved by an update keeps a non-zero exit code.
+
+**Flow**:
+1. Copy `genuine_failure/` to `$sut/test_project/`
+2. Run `update-snapshots testSnapshot tests/snapshots` (all datasets) or with the `failing` dataset
+3. Baseline matches actual → baseline dataset passes
+4. The `failing` dataset fails for a non-snapshot reason → no `[SNAPSHOT]` completion marker is emitted
+5. Assert: script exits non-zero, no commit is created
+
 ## File Contents
 
 | File                                       | Content                         |

--- a/tests/phpunit/Fixtures/functional_update/genuine_failure/.gitignore
+++ b/tests/phpunit/Fixtures/functional_update/genuine_failure/.gitignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/phpunit/Fixtures/functional_update/genuine_failure/actual/file1.txt
+++ b/tests/phpunit/Fixtures/functional_update/genuine_failure/actual/file1.txt
@@ -1,0 +1,1 @@
+original content

--- a/tests/phpunit/Fixtures/functional_update/genuine_failure/actual/file2.txt
+++ b/tests/phpunit/Fixtures/functional_update/genuine_failure/actual/file2.txt
@@ -1,0 +1,1 @@
+content 2

--- a/tests/phpunit/Fixtures/functional_update/genuine_failure/composer.json
+++ b/tests/phpunit/Fixtures/functional_update/genuine_failure/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "test/project",
+  "autoload-dev": {
+    "psr-4": {
+      "Test\\": "tests/"
+    }
+  }
+}

--- a/tests/phpunit/Fixtures/functional_update/genuine_failure/phpunit.xml
+++ b/tests/phpunit/Fixtures/functional_update/genuine_failure/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/phpunit/Fixtures/functional_update/genuine_failure/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/genuine_failure/tests/SnapshotTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use AlexSkrypnyk\Snapshot\Testing\SnapshotTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class with a genuine, non-snapshot failure.
+ *
+ * The 'failing' dataset fails for a reason unrelated to directory comparison,
+ * so SnapshotTrait emits no completion marker and the update-snapshots script
+ * must treat it as a real failure (non-zero exit).
+ */
+final class SnapshotTest extends TestCase {
+
+  use SnapshotTrait;
+
+  /**
+   * Current dataset being tested.
+   */
+  protected string $currentDataset = '';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    if ($this->currentDataset === 'baseline') {
+      $snapshot_path = $this->getBaselineDir();
+    }
+    else {
+      $snapshot_path = $this->getSnapshotsDir() . '/' . $this->currentDataset;
+    }
+
+    $this->snapshotUpdateOnFailure($snapshot_path, $this->getActualDir());
+    parent::tearDown();
+  }
+
+  /**
+   * Test snapshot matching.
+   */
+  #[DataProvider('dataProviderSnapshot')]
+  public function testSnapshot(string $dataset): void {
+    $this->currentDataset = $dataset;
+
+    if ($dataset === 'failing') {
+      // Genuine, non-snapshot failure: the message is not a snapshot update
+      // trigger, so no snapshot is updated and no completion marker is emitted.
+      $this->fail('Intentional non-snapshot failure for exit-code testing.');
+    }
+
+    $this->assertDirectoriesIdentical($this->getBaselineDir(), $this->getActualDir());
+  }
+
+  /**
+   * Data provider for snapshot tests.
+   *
+   * @return \Iterator<string, array{string}>
+   *   Array of dataset names.
+   */
+  public static function dataProviderSnapshot(): \Iterator {
+    yield 'baseline' => ['baseline'];
+    yield 'failing' => ['failing'];
+  }
+
+  /**
+   * Get snapshots directory path.
+   */
+  protected function getSnapshotsDir(): string {
+    return dirname(__DIR__) . '/tests/snapshots';
+  }
+
+  /**
+   * Get baseline directory path.
+   */
+  protected function getBaselineDir(): string {
+    return $this->getSnapshotsDir() . '/_baseline';
+  }
+
+  /**
+   * Get actual output directory path.
+   */
+  protected function getActualDir(): string {
+    return dirname(__DIR__) . '/actual';
+  }
+
+}

--- a/tests/phpunit/Fixtures/functional_update/genuine_failure/tests/snapshots/_baseline/file1.txt
+++ b/tests/phpunit/Fixtures/functional_update/genuine_failure/tests/snapshots/_baseline/file1.txt
@@ -1,0 +1,1 @@
+original content

--- a/tests/phpunit/Fixtures/functional_update/genuine_failure/tests/snapshots/_baseline/file2.txt
+++ b/tests/phpunit/Fixtures/functional_update/genuine_failure/tests/snapshots/_baseline/file2.txt
@@ -1,0 +1,1 @@
+content 2

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/.gitignore
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/.gitignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/actual/file1.txt
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/actual/file1.txt
@@ -1,0 +1,1 @@
+original content

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/actual/file2.txt
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/actual/file2.txt
@@ -1,0 +1,1 @@
+content 2

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/composer.json
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "test/project",
+  "autoload-dev": {
+    "psr-4": {
+      "Test\\": "tests/"
+    }
+  }
+}

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/phpunit.xml
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/SnapshotTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use AlexSkrypnyk\Snapshot\Testing\SnapshotTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class with data provider for update-snapshots script testing.
+ */
+final class SnapshotTest extends TestCase {
+
+  use SnapshotTrait;
+
+  /**
+   * Current dataset being tested.
+   */
+  protected string $currentDataset = '';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    // For baseline, pass the _baseline directory.
+    // For scenarios, pass the scenario directory.
+    if ($this->currentDataset === 'baseline') {
+      $snapshot_path = $this->getBaselineDir();
+    }
+    else {
+      $snapshot_path = $this->getSnapshotsDir() . '/' . $this->currentDataset;
+    }
+
+    $this->snapshotUpdateOnFailure($snapshot_path, $this->getActualDir());
+    parent::tearDown();
+  }
+
+  /**
+   * Test snapshot matching.
+   */
+  #[DataProvider('dataProviderSnapshot')]
+  public function testSnapshot(string $dataset): void {
+    // Store current dataset for tearDown.
+    $this->currentDataset = $dataset;
+
+    $baseline_dir = $this->getBaselineDir();
+
+    if ($dataset === 'baseline') {
+      $this->assertDirectoriesIdentical($baseline_dir, $this->getActualDir());
+    }
+    else {
+      $scenario_dir = $this->getSnapshotsDir() . '/' . $dataset;
+      $this->assertSnapshotMatchesBaseline($this->getActualDir(), $baseline_dir, $scenario_dir);
+    }
+  }
+
+  /**
+   * Data provider for snapshot tests.
+   *
+   * @return \Iterator<string, array{string}>
+   *   Array of dataset names.
+   */
+  public static function dataProviderSnapshot(): \Iterator {
+    yield 'baseline' => ['baseline'];
+    yield 'scenario1' => ['scenario1'];
+  }
+
+  /**
+   * Get snapshots directory path.
+   */
+  protected function getSnapshotsDir(): string {
+    return dirname(__DIR__) . '/tests/snapshots';
+  }
+
+  /**
+   * Get baseline directory path.
+   */
+  protected function getBaselineDir(): string {
+    return $this->getSnapshotsDir() . '/_baseline';
+  }
+
+  /**
+   * Get actual output directory path.
+   */
+  protected function getActualDir(): string {
+    return dirname(__DIR__) . '/actual';
+  }
+
+}

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/snapshots/_baseline/file1.txt
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/snapshots/_baseline/file1.txt
@@ -1,0 +1,1 @@
+original content

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/snapshots/_baseline/file2.txt
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/snapshots/_baseline/file2.txt
@@ -1,0 +1,1 @@
+content 2

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/snapshots/scenario1/extra.txt
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/snapshots/scenario1/extra.txt
@@ -1,0 +1,1 @@
+stale scenario content

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -180,6 +180,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     ]);
 
     // Assert: datasets discovered, all pass.
+    $this->assertProcessSuccessful();
     $this->assertProcessOutputContains('Discovering datasets');
     $this->assertProcessOutputContains('Found');
 
@@ -208,6 +209,9 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'testSnapshot',
       'tests/snapshots',
     ]);
+
+    // Assert: a successful update exits 0 - only genuine failures exit non-zero.
+    $this->assertProcessSuccessful();
 
     // Assert: datasets discovered.
     $this->assertProcessOutputContains('Discovering datasets');
@@ -255,6 +259,9 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'scenario1',
     ]);
 
+    // Assert: a successful update exits 0 even in specified dataset mode.
+    $this->assertProcessSuccessful();
+
     // Assert: specified dataset mode ran.
     $this->assertProcessOutputContains('Running 1 specified dataset(s)');
     $this->assertProcessOutputContains('scenario1');
@@ -294,6 +301,9 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'scenario1',
     ]);
 
+    // Assert: a successful update exits 0 with multiple specified datasets.
+    $this->assertProcessSuccessful();
+
     // Assert: both datasets were scanned.
     $this->assertProcessOutputContains('Running 2 specified dataset(s)');
     $this->assertProcessOutputContains('baseline');
@@ -331,6 +341,10 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'testSnapshot',
       'tests/snapshots',
     ]);
+
+    // Assert: a successful update exits 0 even when baseline and scenario both
+    // change.
+    $this->assertProcessSuccessful();
 
     // Assert: datasets discovered.
     $this->assertProcessOutputContains('Discovering datasets');
@@ -425,6 +439,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'tests/snapshots',
     ]);
 
+    $this->assertProcessSuccessful();
     $this->assertProcessOutputContains('Discovering datasets');
     $this->assertProcessOutputContains('Found');
     $this->assertProcessOutputContains('parallel: 2');
@@ -449,6 +464,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'tests/snapshots',
     ]);
 
+    $this->assertProcessSuccessful();
     $this->assertProcessOutputContains('Discovering datasets');
     $this->assertProcessOutputContains('parallel: 2');
 
@@ -477,6 +493,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'tests/snapshots',
     ]);
 
+    $this->assertProcessSuccessful();
     $this->assertProcessOutputContains('Discovering datasets');
     $this->assertProcessOutputContains('parallel: 2');
 
@@ -509,10 +526,102 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'tests/snapshots',
     ]);
 
+    $this->assertProcessSuccessful();
     $this->assertProcessOutputContains('parallel: 1');
 
     $commit_count = $this->getCommitCount();
     $this->assertSame(1, $commit_count, 'Expected only initial commit');
+  }
+
+  /**
+   * Test that a genuine (non-updatable) failure exits non-zero.
+   *
+   * Scenario: genuine_failure
+   * - Baseline matches actual (the baseline dataset passes).
+   * - The 'failing' dataset fails for a non-snapshot reason, so no snapshot is
+   *   updated and no completion marker is emitted.
+   * - Expected: the script exits non-zero because the failure cannot be
+   *   resolved by an update.
+   */
+  public function testGenuineFailureExitsNonZero(): void {
+    $this->setupTestProject('genuine_failure');
+
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=60',
+      'testSnapshot',
+      'tests/snapshots',
+    ]);
+
+    // A genuine failure (no snapshot update) must exit non-zero.
+    $this->assertProcessFailed();
+    $this->assertProcessOutputContains('Some tests failed');
+
+    // No update commit should be created.
+    $commit_count = $this->getCommitCount();
+    $this->assertSame(1, $commit_count, 'Genuine failure should not create a commit');
+  }
+
+  /**
+   * Test that a genuine failure in specified dataset mode exits non-zero.
+   */
+  public function testGenuineFailureSpecifiedDatasetExitsNonZero(): void {
+    $this->setupTestProject('genuine_failure');
+
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=60',
+      'testSnapshot',
+      'tests/snapshots',
+      'failing',
+    ]);
+
+    $this->assertProcessFailed();
+    $this->assertProcessOutputContains('Failed datasets: failing');
+  }
+
+  /**
+   * Test a scenario-only update in all-datasets (parallel) mode exits 0.
+   *
+   * Scenario: scenario_only_change
+   * - Baseline matches actual (the baseline dataset passes).
+   * - scenario1 holds a stale diff, so the scenario dataset updates while
+   *   running in the parallel phase.
+   * - Expected: the script exits 0, the stale diff is reset, and the update is
+   *   committed.
+   */
+  public function testScenarioOnlyChangeUpdatesInParallel(): void {
+    $this->setupTestProject('scenario_only_change');
+
+    // Sanity check: the stale diff file exists before the run.
+    $stale_file = $this->projectDir . '/tests/snapshots/scenario1/extra.txt';
+    $this->assertFileExists($stale_file);
+
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=60',
+      'testSnapshot',
+      'tests/snapshots',
+    ]);
+
+    // A scenario updated in parallel is a success, not a failure.
+    $this->assertProcessSuccessful();
+
+    // The stale diff file was removed by the update.
+    $this->assertFileDoesNotExist($stale_file);
+
+    // The update was committed (initial + update).
+    $commit_count = $this->getCommitCount();
+    $this->assertSame(2, $commit_count, 'Expected initial + update commit');
+
+    $last_commit_msg = $this->getLastCommitMessage();
+    $this->assertStringContainsString('Updated', $last_commit_msg);
   }
 
   /**

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -210,7 +210,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'tests/snapshots',
     ]);
 
-    // Assert: a successful update exits 0 - only genuine failures exit non-zero.
+    // Assert: a successful update exits 0. Only genuine failures exit non-zero.
     $this->assertProcessSuccessful();
 
     // Assert: datasets discovered.


### PR DESCRIPTION
## Summary

`bin/update-snapshots` previously exited non-zero whenever any PHPUnit run returned a failure code, which always happens when a snapshot is updated (the assertion fails before `tearDown()` rewrites it). This change reclassifies a "failed-but-updated" PHPUnit run as a successful update by checking for `SnapshotTrait`'s `[SNAPSHOT] Baseline updated` / `[SNAPSHOT] Diffs updated` completion markers in the captured output. The script now exits `0` when all datasets either pass or update, and exits non-zero only when a dataset genuinely cannot be resolved - a non-snapshot failure or a timeout.

Making the exit code meaningful surfaced a pre-existing PHP < 8.3 defect in how the script read each PHPUnit run's exit code. That is fixed here too, so the new behavior holds across every supported PHP version.

## Changes

**`bin/update-snapshots` - exit-code reclassification**
- Introduced two marker constants (`SNAPSHOT_MARKER_BASELINE_UPDATED`, `SNAPSHOT_MARKER_DIFFS_UPDATED`) that mirror the strings emitted by `SnapshotTrait` after a snapshot rewrite.
- Added a new `output_has_update_marker()` helper that scans captured PHPUnit output for either marker.
- Both the sequential path (`run_with_timeout()`) and the parallel path (`poll_task()`) now call this helper when PHPUnit exits non-zero; a match promotes the result to exit code `3` ("updated") rather than `1` ("failed").
- `run_specified_datasets()`, `run_all_datasets()`, `run_datasets_parallel()`, `update_stats()`, `print_summary()`, and `render_progress()` each gain an `updated` counter and display it alongside the existing `succeeded`/`failed`/`timedout` stats.
- `commit_snapshot_changes()` is now called unconditionally (safe as a no-op when the working tree is clean), so updates from parallel scenarios are committed even when there are no outright failures.
- Exit logic in `run_all_datasets()` was restructured so that only `failed > 0` or `timedout > 0` throws, not a successful update run.

**`bin/update-snapshots` - PHP < 8.3 exit-code capture**
- The polling loops in `execute_phpunit()` and `poll_task()` read each run's exit code from `proc_close()`. On PHP < 8.3, `proc_get_status()` reaps the child on the first call that reports it stopped, so the subsequent `proc_close()` returns `-1`. That made every dataset look failed on PHP 8.2, so the script always exited non-zero there - hidden until now because the previous tests only asserted commit counts.
- The exit code is now captured from `proc_get_status()` at the moment the process stops, and `proc_close()` is called only to release the handle. This also makes timeout (`124`) and interrupt (`130`) detection reliable on PHP 8.2.

**Fixtures (`tests/phpunit/Fixtures/functional_update/`)**
- New `genuine_failure/` fixture: a test project whose `failing` dataset calls `$this->fail()` with a non-snapshot message, so no completion marker is ever emitted and the script must exit non-zero.
- New `scenario_only_change/` fixture: a test project whose baseline passes but whose `scenario1/` holds a stale `extra.txt` diff; the scenario dataset updates in the parallel phase and the script must exit `0`.
- `README.md` updated with flow descriptions for both new fixtures.

**`tests/phpunit/Functional/SnapshotUpdateScriptTest.php`**
- Added `$this->assertProcessSuccessful()` assertions to all existing tests that expect a clean run (baseline-only, baseline+scenario update, specified datasets, multi-retries, no-change). These now also guard the PHP 8.2 exit-code regression.
- Added `testGenuineFailureExitsNonZero()`: runs against `genuine_failure/` with all datasets and asserts non-zero exit plus no update commit.
- Added `testGenuineFailureSpecifiedDatasetExitsNonZero()`: same fixture, specified `failing` dataset only, asserts `Failed datasets: failing`.
- Added `testScenarioOnlyChangeUpdatesInParallel()`: runs against `scenario_only_change/`, asserts exit `0`, stale diff file removed, and exactly two commits (initial + update).

**`CLAUDE.md`**
- Added a "Bulk Snapshot Updates" subsection documenting the exit-code contract and the marker-string coupling between `bin/update-snapshots` and `SnapshotTrait`.

## Before / After

```
BEFORE
──────
PHPUnit exits non-zero
        │
        ▼
  [timeout?] ──yes──► exit 2 (timeout)
        │no
        ▼
  [exit != 0?] ──yes──► exit 1 (failed)   ← snapshot updates land here too
        │no
        ▼
  exit 0 (success)

Overall script: any failure OR any update → non-zero exit

AFTER
─────
PHPUnit exits non-zero
        │
        ▼
  [timeout?] ──yes──► exit 2 (timeout)
        │no
        ▼
  [marker in output?] ──yes──► exit 3 (updated)  ← reclassified
        │no
        ▼
  exit 1 (failed)   ← genuine failures only

Overall script: only failed > 0 OR timedout > 0 → non-zero exit
               updated > 0 alone → exit 0
```

Exit code per PHPUnit run is now read from `proc_get_status()` (valid on all PHP versions) instead of `proc_close()` (returns `-1` on PHP < 8.3 once the child has been reaped).
