### PR TITLE
Converged internal naming consistency across the library.

### DIFF
--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -10,11 +10,11 @@
  *
  * Usage:
  * @code
- * vendor/bin/snapshot-update [options] <test-name> <snapshots-path> [dataset ...]
- * vendor/bin/snapshot-update testMySnapshot path/to/snapshots
- * vendor/bin/snapshot-update testMySnapshot path/to/snapshots baseline
- * vendor/bin/snapshot-update testMySnapshot path/to/snapshots baseline scenario1
- * vendor/bin/snapshot-update --root=../.. testMySnapshot path/to/snapshots
+ * vendor/bin/update-snapshots [options] <test-name> <snapshots-path> [dataset ...]
+ * vendor/bin/update-snapshots testMySnapshot path/to/snapshots
+ * vendor/bin/update-snapshots testMySnapshot path/to/snapshots baseline
+ * vendor/bin/update-snapshots testMySnapshot path/to/snapshots baseline scenario1
+ * vendor/bin/update-snapshots --root=../.. testMySnapshot path/to/snapshots
  * @endcode
  */
 
@@ -547,7 +547,7 @@ function parse_option(string $arg, array $config): array {
  * Print help.
  */
 function print_help(): void {
-  $script_name = 'snapshot-update';
+  $script_name = 'update-snapshots';
   $out = <<<EOF
 Update test snapshots
 ---------------------
@@ -621,7 +621,7 @@ function run_with_timeout(string $filter, int $current, int $total, string $data
   while ($attempt <= $retries) {
     dispatch_signals();
 
-    $result = execute_phpunit($filter, $timeout, $root);
+    $result = run_phpunit($filter, $timeout, $root);
 
     if ($result['exit_code'] === 130) {
       verbose("\n");
@@ -651,7 +651,7 @@ function run_with_timeout(string $filter, int $current, int $total, string $data
     // A successfully updated snapshot still exits non-zero in PHPUnit (the
     // assertion failed before the update ran in tearDown), but the trait
     // reports completion. Treat it as updated, not failed.
-    if (output_has_update_marker($result['output'])) {
+    if (has_update_marker($result['output'])) {
       verbose(" ✓ updated\n");
       print_debug_output($debug, $result['output']);
 
@@ -917,7 +917,7 @@ function poll_task(array $task, array $config): array {
 
   // A non-zero exit accompanied by the trait's completion marker means the
   // snapshot was updated rather than the test genuinely failing.
-  if (output_has_update_marker($task['output'])) {
+  if (has_update_marker($task['output'])) {
     $task['status'] = 'updated';
 
     return $task;
@@ -1193,7 +1193,7 @@ function kill_all_tasks(array &$tasks): void {
  * @return array{exit_code: int, output: array<string>}
  *   Array with exit code and output lines.
  */
-function execute_phpunit(string $filter, int $timeout, string $root): array {
+function run_phpunit(string $filter, int $timeout, string $root): array {
   $cmd = sprintf(
     // Do not use 2>&1 here: proc_open already captures stdout and stderr on
     // separate pipes. Merging them at the shell level forces fwrite(STDERR,...)
@@ -1302,7 +1302,7 @@ function collect_output(array $pipes, array $output): array {
  * @return bool
  *   TRUE if a snapshot update completion marker is present.
  */
-function output_has_update_marker(array $output): bool {
+function has_update_marker(array $output): bool {
   $text = implode("\n", $output);
 
   return str_contains($text, SNAPSHOT_MARKER_BASELINE_UPDATED) || str_contains($text, SNAPSHOT_MARKER_DIFFS_UPDATED);

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -177,9 +177,9 @@ function run_all_datasets(array $config): void {
   $baseline_path = rtrim((string) $config['snapshots_path'], '/') . '/' . BASELINE_SUFFIX;
 
   $datasets = discover_datasets($config);
-  $total_datasets = count($datasets);
+  $total = count($datasets);
 
-  verbose("Found %d unique datasets\n", $total_datasets);
+  verbose("Found %d unique datasets\n", $total);
 
   $stats = ['current' => 0, 'succeeded' => 0, 'updated' => 0, 'failed' => 0, 'timedout' => 0];
 
@@ -191,7 +191,7 @@ function run_all_datasets(array $config): void {
     $result = run_with_timeout(
       $config['test_name'] . '@' . BASELINE_DATASET_NAME,
       $stats['current'],
-      $total_datasets,
+      $total,
       BASELINE_DATASET_NAME,
       $config['timeout'],
       $config['retries'],
@@ -200,7 +200,7 @@ function run_all_datasets(array $config): void {
     );
 
     $baseline_committed = handle_baseline_result($result, $config['root'], $baseline_path);
-    $stats = update_stats($stats, $result, $total_datasets);
+    $stats = update_stats($stats, $result, $total);
 
     if ($result === 2) {
       throw new \Exception('Test timed out');
@@ -211,7 +211,7 @@ function run_all_datasets(array $config): void {
 
   // Run remaining scenarios in parallel.
   if (!empty($scenario_datasets)) {
-    $parallel_stats = run_datasets_parallel($scenario_datasets, $stats['current'], $total_datasets, $config);
+    $parallel_stats = run_datasets_parallel($scenario_datasets, $stats['current'], $total, $config);
     $stats['succeeded'] += $parallel_stats['succeeded'];
     $stats['updated'] += $parallel_stats['updated'];
     $stats['failed'] += $parallel_stats['failed'];
@@ -219,7 +219,7 @@ function run_all_datasets(array $config): void {
   }
 
   // Print summary.
-  print_summary($stats, $total_datasets);
+  print_summary($stats, $total);
 
   // Commit any snapshot changes that were applied. This is a no-op when the
   // working tree is clean, so it is safe to call unconditionally.
@@ -603,7 +603,7 @@ EOF;
  *   Dataset name.
  * @param int $timeout
  *   Timeout in seconds.
- * @param int $max_retries
+ * @param int $retries
  *   Maximum number of retries.
  * @param bool $debug
  *   Whether to print debug output on failure.
@@ -613,12 +613,12 @@ EOF;
  * @return int
  *   0 = success, 1 = failed, 2 = timeout, 3 = updated.
  */
-function run_with_timeout(string $filter, int $current, int $total, string $dataset, int $timeout, int $max_retries, bool $debug, string $root): int {
+function run_with_timeout(string $filter, int $current, int $total, string $dataset, int $timeout, int $retries, bool $debug, string $root): int {
   $attempt = 1;
 
   verbose('[%d/%d] %s ', $current, $total, $dataset);
 
-  while ($attempt <= $max_retries) {
+  while ($attempt <= $retries) {
     dispatch_signals();
 
     $result = execute_phpunit($filter, $timeout, $root);
@@ -636,8 +636,8 @@ function run_with_timeout(string $filter, int $current, int $total, string $data
 
     // Timeout - retry if attempts remain.
     if ($result['exit_code'] === 124) {
-      if ($attempt < $max_retries) {
-        verbose(" TIMEOUT, retry %d/%d ", $attempt + 1, $max_retries);
+      if ($attempt < $retries) {
+        verbose(" TIMEOUT, retry %d/%d ", $attempt + 1, $retries);
         $attempt++;
         continue;
       }
@@ -677,7 +677,7 @@ function run_with_timeout(string $filter, int $current, int $total, string $data
  *   Dataset names to run.
  * @param int $start_number
  *   Starting dataset number (for display).
- * @param int $total_datasets
+ * @param int $total
  *   Total number of datasets (for display).
  * @param array<string, mixed> $config
  *   Configuration array.
@@ -685,7 +685,7 @@ function run_with_timeout(string $filter, int $current, int $total, string $data
  * @return array<string, int>
  *   Statistics: succeeded, failed, timedout counts.
  */
-function run_datasets_parallel(array $datasets, int $start_number, int $total_datasets, array $config): array {
+function run_datasets_parallel(array $datasets, int $start_number, int $total, array $config): array {
   $jobs = (int) $config['jobs'];
   $is_tty = function_exists('posix_isatty') && posix_isatty(STDOUT);
 
@@ -751,7 +751,7 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total_da
     unset($task);
 
     // Render phase.
-    render_progress($tasks, $total_datasets, $is_tty, $jobs, $scroll_offset, $start_time);
+    render_progress($tasks, $total, $is_tty, $jobs, $scroll_offset, $start_time);
 
     // Exit check: all done?
     $pending = array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued' || $t['status'] === 'running');
@@ -770,11 +770,11 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total_da
 
   // Print final summary and debug output to normal scrollback.
   $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
-  $updated_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'updated'));
-  $failed_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
-  $timedout_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
+  $updated = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'updated'));
+  $failed = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
+  $timedout = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
 
-  verbose("Parallel run: %d succeeded, %d updated, %d failed, %d timed out\n", $succeeded, $updated_count, $failed_count, $timedout_count);
+  verbose("Parallel run: %d succeeded, %d updated, %d failed, %d timed out\n", $succeeded, $updated, $failed, $timedout);
 
   if ($config['debug']) {
     foreach ($tasks as $task) {
@@ -1038,7 +1038,7 @@ function get_viewport_height(): int {
  *
  * @param array<int, array<string, mixed>> $tasks
  *   All tasks.
- * @param int $total_datasets
+ * @param int $total
  *   Total dataset count for numbering.
  * @param bool $is_tty
  *   Whether output is a TTY.
@@ -1049,7 +1049,7 @@ function get_viewport_height(): int {
  * @param float $start_time
  *   Start time of parallel run.
  */
-function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $jobs, int $scroll_offset, float $start_time): void {
+function render_progress(array $tasks, int $total, bool $is_tty, int $jobs, int $scroll_offset, float $start_time): void {
   $task_count = count($tasks);
   $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
   $updated = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'updated'));
@@ -1057,13 +1057,13 @@ function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $j
   $running = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
   $queued = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued'));
   $timedout = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
-  $pad = strlen((string) $total_datasets);
+  $pad = strlen((string) $total);
 
   if (!$is_tty) {
     // Non-TTY: only print when all done.
     if ($running === 0 && $queued === 0) {
       foreach ($tasks as $task) {
-        $line = sprintf('  [%' . $pad . 'd/%d] %s ', $task['number'], $total_datasets, $task['dataset']);
+        $line = sprintf('  [%' . $pad . 'd/%d] %s ', $task['number'], $total, $task['dataset']);
         if ($task['status'] === 'success') {
           verbose("%s✓ %ss\n", $line, $task['elapsed']);
         }
@@ -1100,7 +1100,7 @@ function render_progress(array $tasks, int $total_datasets, bool $is_tty, int $j
   $visible_end = min($task_count, $scroll_offset + $viewport_height);
   for ($i = $scroll_offset; $i < $visible_end; $i++) {
     $task = $tasks[$i];
-    $prefix = sprintf('  [%' . $pad . 'd/%d] %-20s ', $task['number'], $total_datasets, $task['dataset']);
+    $prefix = sprintf('  [%' . $pad . 'd/%d] %-20s ', $task['number'], $total, $task['dataset']);
 
     switch ($task['status']) {
       case 'queued':

--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -44,22 +44,22 @@ class Comparer implements ComparerInterface {
    * {@inheritdoc}
    */
   public function compare(): static {
-    $dir_left_files = $this->left->getFiles();
-    $dir_right_files = $this->right->getFiles();
+    $left_files = $this->left->getFiles();
+    $right_files = $this->right->getFiles();
 
     // Process all left files and matching right files.
-    foreach ($dir_left_files as $path => $left_file) {
+    foreach ($left_files as $path => $left_file) {
       $this->addLeftFile($left_file);
-      if (isset($dir_right_files[$path])) {
-        $this->addRightFile($dir_right_files[$path]);
+      if (isset($right_files[$path])) {
+        $this->addRightFile($right_files[$path]);
         // Mark as processed to avoid duplicate processing.
-        unset($dir_right_files[$path]);
+        unset($right_files[$path]);
       }
     }
 
     // Process remaining right files that don't exist in left.
-    foreach ($dir_right_files as $dir_right_file) {
-      $this->addRightFile($dir_right_file);
+    foreach ($right_files as $right_file) {
+      $this->addRightFile($right_file);
     }
 
     return $this;
@@ -167,9 +167,9 @@ class Comparer implements ComparerInterface {
 
     $absent_left = $comparer->getAbsentLeftDiffs();
     $absent_right = $comparer->getAbsentRightDiffs();
-    $file_diffs = $comparer->getContentDiffs();
+    $content_diffs = $comparer->getContentDiffs();
 
-    if (empty($absent_left) && empty($absent_right) && empty($file_diffs)) {
+    if (empty($absent_left) && empty($absent_right) && empty($content_diffs)) {
       return NULL;
     }
 
@@ -188,18 +188,18 @@ class Comparer implements ComparerInterface {
         $render .= sprintf("  %s\n", $file);
       }
     }
-    if (!empty($file_diffs)) {
+    if (!empty($content_diffs)) {
       $render .= "Files that differ in content:\n";
 
-      $file_diffs_render_count = is_int($options['show_diff_file_limit']) ? $options['show_diff_file_limit'] : count($file_diffs);
-      foreach ($file_diffs as $file => $diff) {
+      $content_diffs_render_count = is_int($options['show_diff_file_limit']) ? $options['show_diff_file_limit'] : count($content_diffs);
+      foreach ($content_diffs as $file => $diff) {
         $render .= sprintf("  %s\n", $file);
 
-        if ($options['show_diff'] && $file_diffs_render_count > 0 && $diff instanceof Diff) {
+        if ($options['show_diff'] && $content_diffs_render_count > 0 && $diff instanceof Diff) {
           $render .= '--- DIFF START ---' . PHP_EOL;
           $render .= $diff->render();
           $render .= '--- DIFF END ---' . PHP_EOL;
-          $file_diffs_render_count--;
+          $content_diffs_render_count--;
         }
       }
     }

--- a/src/Compare/Diff.php
+++ b/src/Compare/Diff.php
@@ -144,10 +144,10 @@ class Diff implements DiffInterface {
       return $diff->getLeft()->getContent();
     }
 
-    $src_content = $diff->getLeft()->getContent();
-    $dst_content = $diff->getRight()->getContent();
+    $left_content = $diff->getLeft()->getContent();
+    $right_content = $diff->getRight()->getContent();
 
-    return (new Differ(new UnifiedDiffOutputBuilder('', TRUE)))->diff($src_content, $dst_content);
+    return (new Differ(new UnifiedDiffOutputBuilder('', TRUE)))->diff($left_content, $right_content);
   }
 
 }

--- a/src/Patch/Patcher.php
+++ b/src/Patch/Patcher.php
@@ -121,8 +121,8 @@ class Patcher implements PatcherInterface {
 
     if (next($lines) === FALSE) {
       $current_key = key($lines);
-      $source_file = count($this->diffs) > 0 ? array_key_first($this->diffs) : '';
-      throw new PatchException('Unexpected EOF', $source_file, $current_key);
+      $src_file = count($this->diffs) > 0 ? array_key_first($this->diffs) : '';
+      throw new PatchException('Unexpected EOF', $src_file, $current_key);
     }
 
     return [
@@ -211,8 +211,8 @@ class Patcher implements PatcherInterface {
     }
 
     // Verify source lines match the expected ones before applying.
-    $source_hunk_slice = array_slice($this->srcLines[$src], $src_idx, count($src_hunk));
-    if ($source_hunk_slice !== $src_hunk) {
+    $src_hunk_slice = array_slice($this->srcLines[$src], $src_idx, count($src_hunk));
+    if ($src_hunk_slice !== $src_hunk) {
       throw new PatchException('Source file verification failed', $src, key($lines));
     }
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -115,17 +115,17 @@ class Snapshot {
 
     // Files in actual but not in baseline - copy to output.
     foreach (array_keys($absent_left) as $file) {
-      $src = $actual . DIRECTORY_SEPARATOR . $file;
-      $dst = $output . DIRECTORY_SEPARATOR . $file;
-      File::mkdir(dirname($dst));
-      File::copy($src, $dst);
+      $source = $actual . DIRECTORY_SEPARATOR . $file;
+      $destination = $output . DIRECTORY_SEPARATOR . $file;
+      File::mkdir(dirname($destination));
+      File::copy($source, $destination);
     }
 
     // Files in baseline but not in actual - create deletion marker.
     foreach (array_keys($absent_right) as $file) {
-      $dst = $output . DIRECTORY_SEPARATOR . dirname((string) $file);
-      File::mkdir($dst);
-      File::dump($dst . DIRECTORY_SEPARATOR . '-' . basename((string) $file), '');
+      $destination = $output . DIRECTORY_SEPARATOR . dirname((string) $file);
+      File::mkdir($destination);
+      File::dump($destination . DIRECTORY_SEPARATOR . '-' . basename((string) $file), '');
     }
 
     // Files with content differences - save diff.

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -178,14 +178,14 @@ trait SnapshotTrait {
   protected function snapshotUpdateBaseline(string $baseline, string $actual, string $tmp): void {
     fwrite(STDERR, PHP_EOL . '[SNAPSHOT] Updating baseline' . PHP_EOL);
 
-    $ic = Snapshot::IGNORECONTENT;
-    File::copyIfExists($baseline . '/' . $ic, $actual . '/' . $ic);
-    File::copyIfExists($baseline . '/' . $ic, $tmp . '/' . $ic);
+    $ignorecontent = Snapshot::IGNORECONTENT;
+    File::copyIfExists($baseline . '/' . $ignorecontent, $actual . '/' . $ignorecontent);
+    File::copyIfExists($baseline . '/' . $ignorecontent, $tmp . '/' . $ignorecontent);
 
     File::rmdir($baseline);
     Snapshot::sync($actual, $baseline);
 
-    File::copyIfExists($tmp . '/' . $ic, $baseline . '/' . $ic);
+    File::copyIfExists($tmp . '/' . $ignorecontent, $baseline . '/' . $ignorecontent);
 
     fwrite(STDERR, '[SNAPSHOT] Baseline updated' . PHP_EOL);
   }
@@ -207,13 +207,13 @@ trait SnapshotTrait {
   protected function snapshotUpdateDiffs(string $baseline, string $snapshots, string $actual, string $tmp): void {
     fwrite(STDERR, PHP_EOL . '[SNAPSHOT] Updating diffs' . PHP_EOL);
 
-    $ic = Snapshot::IGNORECONTENT;
-    File::copyIfExists($snapshots . '/' . $ic, $tmp . '/' . $ic);
+    $ignorecontent = Snapshot::IGNORECONTENT;
+    File::copyIfExists($snapshots . '/' . $ignorecontent, $tmp . '/' . $ignorecontent);
 
     File::rmdir($snapshots);
     Snapshot::diff($baseline, $actual, $snapshots);
 
-    File::copyIfExists($tmp . '/' . $ic, $snapshots . '/' . $ic);
+    File::copyIfExists($tmp . '/' . $ignorecontent, $snapshots . '/' . $ignorecontent);
 
     fwrite(STDERR, '[SNAPSHOT] Diffs updated' . PHP_EOL);
   }

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -377,7 +377,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   /**
    * Test that stderr from snapshotUpdateOnFailure() is captured separately.
    *
-   * The execute_phpunit() function uses proc_open with separate pipes for
+   * The run_phpunit() function uses proc_open with separate pipes for
    * stdout and stderr. The [SNAPSHOT] messages written to stderr by
    * snapshotUpdateOnFailure() must not be merged into stdout (no 2>&1),
    * as this can cause false PHPUnit errors.


### PR DESCRIPTION
## Summary

Autonomous internal-consistency convergence across the whole codebase, driven by the `improve-generic-project` skill: the source was re-read in full, the whole-app map reasoned over as one system, one canonical form chosen per inconsistency class, and only the **behavior-preserving, internal-reference-only** subset applied. Every change is a line-for-line rename (71 insertions / 71 deletions); no behavior changes.

Because `alexskrypnyk/snapshot` is a **published library**, every rename touching a public symbol (class / interface method / public or protected method / public constant / a public method's parameter name - all breaking for consumers via named args) was deliberately **not applied**. Those are surfaced below as judgment calls for you to decide, since they belong in a deliberate (likely major) release rather than an autonomous PR.

All six commits are one-per-class for review; tests + lint were run green after each.

## Applied changes (naming convergence, all internal)

Each was chosen by dominant convention and applied only where every reference resolves inside the repo.

| Area | Change | Signal |
|---|---|---|
| `Compare/` locals | `$src_content`/`$dst_content` → `$left_content`/`$right_content`; dropped `dir_` prefix on `$dir_left_files`/`$dir_right_files`/`$dir_right_file`; `$file_diffs` → `$content_diffs` | `left`/`right` is the namespace's dominant vocabulary (20+); `$content_diffs` already exists for the identical value in `Snapshot::diff()` |
| `Snapshot::diff()` locals | `$src`/`$dst` → `$source`/`$destination` | The facade uses full words everywhere else; these two loops were its only abbreviations |
| `SnapshotTrait` locals | `$ic` → `$ignorecontent` | Trait locals are otherwise descriptive; mirrors the `Snapshot::IGNORECONTENT` constant it holds |
| `Patcher` hunk locals | `$source_file`/`$source_hunk_slice` → `$src_file`/`$src_hunk_slice` | Converges 2 outliers onto the ~14 `src_`/`dst_` locals + hunk-info keys that form the class's unified-diff shorthand |
| `bin/update-snapshots` vars | `$max_retries` → `$retries`; `$total_datasets` → `$total`; `$updated_count`/`$failed_count`/`$timedout_count` → bare `$updated`/`$failed`/`$timedout` | Aligns with the config key `retries` and with `$total`/`$updated`/`$failed` already used by sibling functions |
| `bin/update-snapshots` functions | `execute_phpunit()` → `run_phpunit()`; `output_has_update_marker()` → `has_update_marker()`; help/`@file` self-name `snapshot-update` → `update-snapshots` | `run_*` is the dominant verb family; verb-first predicates dominate; `composer.json` installs the binary as `update-snapshots`, so the help text pointed at a binary that does not exist |

## Judgment calls deferred to you

These are real inconsistencies the convergence pass identified but did **not** touch, because resolving them changes a public contract or the library's design. Grouped by dimension; each names the competing forms so you can pick.

**Naming vocabulary**
- **`Patterns` suffix split**: `RulesInterface` exposes `getSkip()`/`getIgnoreContent()`/`getGlobal()`/`getInclude()` while `RuleSetInterface` exposes `getSkipPatterns()`/`getIgnoreContentPatterns()` for the same concept - two public interfaces in the same directory. Properties/constants already carry the suffix (11:4 in favour of `…Patterns`).
- **content-processor callback renamed at every hop**: `$match_content` (trait) → `$content_processor` (facade) → `$beforeMatchContent` (Index promoted prop) → `$processor` (builder). The facade's `$content_processor` is the most-used/documented form. (Note: this callback also has different *runtime* semantics per operation - see behavioral notes.)
- **`$cb`** abbreviation on `Comparer`/`Index` transform-callback parameters vs the full-word `$renderer`/`$filter` in the same code.
- **base-directory concept**: `getDirectory()`/`$directory` (Index) vs `getBasepath()`/`$basepath` (IndexedFile) vs ctor `$base` - the two classes hand the same value to each other.
- **output-directory parameter**: `$output` (diff) vs `$destination` (patch, sync) for the identical role.
- **`PatchException` promoted properties** `$file_path`/`$line_number`/`$line_content` use `snake_case`, violating the project's camelCase-property rule (`Syncer::$srcIndex` complies). Fixing means renaming public promoted-ctor params → next-major.
- **diff vs patch terminology** for the change-set artifact: within `Patcher` alone it is both `$diffs`/`addDiff()` and `addPatchFile()`/`patch()`. Genuine tie - pick one term (least churn: "diff files, applied by patching").
- **`Index::isPathMatchesPattern()`** (ungrammatical) vs sibling `matchesAnyPattern()`.
- **trait assertion params** `$dir1`/`$dir2` and `$tmp` hide roles vs the role-based `$actual`/`$baseline`/`$expected` used elsewhere.
- **`src`/`dst` vs `source`/`destination` at the Patch/Sync API boundary** (properties `$srcLines`/`$dstLines`, `SyncerInterface::sync($dst)`). Counter-signal: `src`/`dst` is idiomatic unified-diff shorthand - the applied change deliberately kept the hunk-machinery locals as `src`/`dst` and only touches the boundary here.
- **bin run-status tense drift**: task statuses `'success'`/`'timeout'` vs stats keys `'succeeded'`/`'timedout'`. Left unapplied because these are runtime-compared string values spread across producer/consumer sites - a missed site is a silent stats miscount, so it needs a deliberate tested pass, not a mechanical rename.

**API / interface shape**
- **mutator return convention**: `Comparer::addLeftFile()`/`addRightFile()` and `IndexedFile` setters return `void`; `Rules`/`SnapshotBuilder`/`Diff`/`Patcher`/`Syncer` mutators are fluent `: static` (18:5). Converging changes interface signatures.
- **facade operation config tail**: `scan`/`compare`/`diff` take `(?Rules, ?callable)`; `patch` drops `Rules`; `sync` drops both (takes `$permissions`/`$copy_empty_dirs`) - which is *why* `SnapshotBuilder` has to reimplement `sync`/`scan` inline instead of delegating.
- **renderer callback contract mismatch**: `Comparer::render()` invokes the injected renderer with 4 args, `Diff::render()` with 2, under one identically-documented `render(array $options, ?callable $renderer)` signature on the shared `RenderableInterface` (whose docblocks are diff-specific despite being generic).
- **assertion signature conventions**: `assertDirectoriesIdentical()` puts `$message` mid-list but is expected-first; `assertSnapshotMatchesBaseline()` puts `$message` last but is actual-first - each violates a different half of the PHPUnit convention.
- **bin outcome codes** `0/1/2/3` are bare ints whose legend is re-documented in three docblocks, while the script `define()`s named constants for every other cross-function literal.
- **Rules pattern-mutator family**: single `addSkip(string)` + bare-verb variadic `skip(...)` on `Rules`, vs variadic `addSkip(...)` on `SnapshotBuilder`, plus `global` missing its variadic - three shapes for one operation, no majority.

**Architecture / module patterns**
- **exception family shape**: `PatchException` is rich (6-arg ctor, 3 context props, getters, message auto-formatting) and inserts its context params **between** `$message` and `$code`, breaking positional compatibility with `\Exception`/`SnapshotException`; `RulesException`/`SnapshotException` are empty markers; `Sync` has no exception at all.
- **RuleSet→Rules integration**: four entry points for one conversion (`$set->toRules()`, `$set->applyTo()`, `Rules::fromRuleSet()`, `Rules::phpProject()`/`nodeProject()`), with both hierarchies coupled to each other's concretes and a hardcoded preset registry.
- **concrete-vs-interface discipline**: `Comparer` hard-instantiates and `instanceof`-checks concrete `Diff` (and `ComparerInterface` docblocks reference concrete `Diff`); `Index`/`Snapshot` accept concrete `?Rules` rather than `?RulesInterface` - while `Patcher`/`Syncer` correctly hint interfaces.
- **facade+builder duplication**: `SnapshotBuilder` delegates `compare`/`diff`/`patch` to `Snapshot` statics but reimplements `scan`/`sync` inline (duplicating the `Index`+`Syncer` wiring and the `0755`/`FALSE` default literals).
- **`bin` duplicated runner**: `run_with_timeout`+`run_phpunit` (sequential) and `start_task`/`poll_task` (parallel) duplicate proc_open setup, timeout/retry, interrupt handling, and marker classification - and have already diverged on stderr handling.
- **component→facade upward dependency**: `Index` reaches up to `Snapshot::IGNORECONTENT`; the `'-'` deletion-marker prefix (written by `diff()`, parsed by `patch()`) and the `.git/` skip are magic literals with no owning constant.

## Behavioral observations (out of scope for consistency work, flagged for you)

Not touched - these are behavior/latent-bug/doc items, not consistency classes:
- `Diff::getLeft()`/`getRight()` throw a typed-property init `Error` when a side is absent, yet absent sides are a routine `Comparer` state; only `empty()`-guarded paths avoid it.
- `Index::getFiles($cb)` persists the callback-transformed values back into the index, while `Comparer`'s equivalent transform only affects the returned copy - same-looking surface, divergent persistence.
- The "content processor" filters files (return `FALSE`) during `scan`/`compare` but is a post-write content transform in `patch()` - unifying its parameter name should not paper over the semantic split.
- `bin` parallel path merges stderr with `2>&1` while the sequential path's comment explicitly forbids it (the trait's STDERR markers must not merge into stdout).
- `SnapshotTrait` lets consumers override the env-var name (`static::$snapshotUpdateEnvVar`) but `bin/update-snapshots` hardcodes `UPDATE_SNAPSHOTS=1` - an overriding consumer silently breaks CLI update detection.
- History/caller-referencing comments (`IndexedFile` narrates a "double-read that previously occurred"; an `Index` helper docblock names its caller) belong to a docs-polish pass.

## Verification

- **Tests**: `composer test` → **240 tests, 665 assertions, OK** (run green after every one of the 6 commits).
- **Lint**: `composer lint` → PHPCS (44 files) clean, PHPStan level 9 no errors, Rector clean.
- **Idempotency**: every applied outlier form confirmed absent from the tree - a second run of the skill produces no diff.

## Before / After

Representative rename per commit - internal locals and one bin/ function/help-text family, no public API touched:

```
┌──────────────────────┬───────────────────────────────────┬────────────────────────────────┐
│ Scope                │ Before                            │ After                          │
├──────────────────────┼───────────────────────────────────┼────────────────────────────────┤
│ Comparer             │ $dir_left_files, $dir_right_files │ $left_files, $right_files      │
│ Diff::render()       │ $src_content / $dst_content       │ $left_content / $right_content │
│ Snapshot::diff()     │ $src / $dst                       │ $source / $destination         │
│ SnapshotTrait        │ $ic                               │ $ignorecontent                 │
│ Patcher hunk locals  │ $source_file                      │ $src_file                      │
│ bin/update-snapshots │ execute_phpunit()                 │ run_phpunit()                  │
│ bin --help self-name │ snapshot-update                   │ update-snapshots               │
└──────────────────────┴───────────────────────────────────┴────────────────────────────────┘
```
