### PR TITLE
Optimized core paths and fixed several defects.

### DIFF
--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -47,20 +47,26 @@ class Comparer implements ComparerInterface {
     $left_files = $this->left->getFiles();
     $right_files = $this->right->getFiles();
 
-    // Process all left files and matching right files.
+    // The index keys are already the pathname relative to the base directory
+    // (the same value addLeftFile()/addRightFile() would recompute), so reuse
+    // them directly as the diff keys.
     foreach ($left_files as $path => $left_file) {
-      $this->addLeftFile($left_file);
+      ($this->diffs[$path] ??= new Diff())->setLeft($left_file);
       if (isset($right_files[$path])) {
-        $this->addRightFile($right_files[$path]);
+        $this->diffs[$path]->setRight($right_files[$path]);
         // Mark as processed to avoid duplicate processing.
         unset($right_files[$path]);
       }
     }
 
     // Process remaining right files that don't exist in left.
-    foreach ($right_files as $right_file) {
-      $this->addRightFile($right_file);
+    foreach ($right_files as $path => $right_file) {
+      ($this->diffs[$path] ??= new Diff())->setRight($right_file);
     }
+
+    // Filter results derive from $this->diffs; reset the cache once after the
+    // full rebuild instead of on every added file.
+    $this->cache = [];
 
     return $this;
   }

--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -44,6 +44,9 @@ class Comparer implements ComparerInterface {
    * {@inheritdoc}
    */
   public function compare(): static {
+    // Full rebuild: drop any diffs retained from a previous invocation.
+    $this->diffs = [];
+
     $left_files = $this->left->getFiles();
     $right_files = $this->right->getFiles();
 

--- a/src/Compare/Diff.php
+++ b/src/Compare/Diff.php
@@ -144,8 +144,11 @@ class Diff implements DiffInterface {
       return $diff->getLeft()->getContent();
     }
 
-    $left_content = $diff->getLeft()->getContent();
-    $right_content = $diff->getRight()->getContent();
+    // A one-sided diff (a file present on only one side) renders as a pure
+    // addition or deletion; treat the missing side as empty content rather than
+    // reading an uninitialized property.
+    $left_content = $diff->existsLeft() ? $diff->getLeft()->getContent() : '';
+    $right_content = $diff->existsRight() ? $diff->getRight()->getContent() : '';
 
     return (new Differ(new UnifiedDiffOutputBuilder('', TRUE)))->diff($left_content, $right_content);
   }

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -80,11 +80,14 @@ class Index implements IndexInterface {
   protected function scan(): static {
     $this->files = [];
 
-    // Pre-cache pattern arrays for faster matching.
-    $global_patterns = $this->rules->getGlobal();
-    $include_patterns = $this->rules->getInclude();
-    $skip_patterns = $this->rules->getSkip();
-    $ignore_content_patterns = $this->rules->getIgnoreContent();
+    // Pre-cache pattern arrays for faster matching. The same Rules object can
+    // be shared across indexes (and re-seeded with the default skip rules by
+    // each Index constructor), so dedupe to avoid matching a pattern twice per
+    // file.
+    $global_patterns = array_unique($this->rules->getGlobal());
+    $include_patterns = array_unique($this->rules->getInclude());
+    $skip_patterns = array_unique($this->rules->getSkip());
+    $ignore_content_patterns = array_unique($this->rules->getIgnoreContent());
 
     foreach ($this->iterator($this->directory) as $resource) {
       if (!$resource instanceof \SplFileInfo) {

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -51,13 +51,17 @@ class Index implements IndexInterface {
 
     $this->files ??= [];
 
-    if (is_callable($cb)) {
-      foreach ($this->files as $path => $file) {
-        $this->files[$path] = $cb($file);
-      }
+    if (!is_callable($cb)) {
+      return $this->files;
     }
 
-    return $this->files;
+    // Transform a copy so the callback never mutates the cached index.
+    $files = [];
+    foreach ($this->files as $path => $file) {
+      $files[$path] = $cb($file);
+    }
+
+    return $files;
   }
 
   /**

--- a/src/Index/IndexedFile.php
+++ b/src/Index/IndexedFile.php
@@ -22,6 +22,11 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
   protected string $basepath;
 
   /**
+   * Memoized pathname relative to the base path.
+   */
+  protected ?string $relativePathname = NULL;
+
+  /**
    * Content hash value.
    */
   protected ?string $hash = NULL;
@@ -66,6 +71,7 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
    */
   public function setBasepath(string $basepath): void {
     $this->basepath = rtrim($basepath, DIRECTORY_SEPARATOR);
+    $this->relativePathname = NULL;
   }
 
   /**
@@ -113,7 +119,7 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
    * {@inheritdoc}
    */
   public function getPathnameFromBasepath(): string {
-    return static::stripBasepath($this->getBasepath(), $this->getPathname());
+    return $this->relativePathname ??= static::stripBasepath($this->getBasepath(), $this->getPathname());
   }
 
   /**
@@ -254,7 +260,7 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
       throw new SnapshotException(sprintf('Path %s does not start with basepath %s', $path, $basepath));
     }
 
-    return ltrim(str_replace($basepath, '', $path), DIRECTORY_SEPARATOR);
+    return ltrim(substr($path, strlen($basepath)), DIRECTORY_SEPARATOR);
   }
 
 }

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -209,7 +209,10 @@ class Rules implements RulesInterface {
         continue;
       }
       if ($line[0] === '!') {
-        $this->includePatterns[] = $line[1] === '^' ? substr($line, 2) : substr($line, 1);
+        $pattern = ($line[1] ?? '') === '^' ? substr($line, 2) : substr($line, 1);
+        if ($pattern !== '') {
+          $this->includePatterns[] = $pattern;
+        }
       }
       elseif ($line[0] === '^') {
         $this->ignoreContentPatterns[] = substr($line, 1);

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -173,8 +173,10 @@ class Snapshot {
         File::copy($file->getPathname(), $destination . DIRECTORY_SEPARATOR . $relative_path);
       }
       else {
-        // Patch file - queue for patching.
-        $patcher->addPatchFile($file);
+        // Patch file - queue for patching. The isPatchFile() check above
+        // already validated it, so add the diff directly and skip
+        // addPatchFile()'s redundant re-read of the same file.
+        $patcher->addDiff($file->getContent(), $relative_path);
       }
     }
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -173,10 +173,8 @@ class Snapshot {
         File::copy($file->getPathname(), $destination . DIRECTORY_SEPARATOR . $relative_path);
       }
       else {
-        // Patch file - queue for patching. The isPatchFile() check above
-        // already validated it, so add the diff directly and skip
-        // addPatchFile()'s redundant re-read of the same file.
-        $patcher->addDiff($file->getContent(), $relative_path);
+        // Patch file - queue for patching.
+        $patcher->addPatchFile($file);
       }
     }
 

--- a/tests/phpunit/Unit/DiffTest.php
+++ b/tests/phpunit/Unit/DiffTest.php
@@ -214,6 +214,27 @@ final class DiffTest extends UnitTestCase {
     $this->assertStringContainsString('+line2', $result);
   }
 
+  public function testDoRenderWithAbsentSide(): void {
+    $file_path = self::$sut . DIRECTORY_SEPARATOR . 'one-side.txt';
+    file_put_contents($file_path, "one side line\n");
+    $file_info = new IndexedFile($file_path, self::$sut);
+
+    // Absent left (an added file) renders as a pure addition instead of
+    // throwing on the uninitialized side.
+    $added = new Diff();
+    $added->setRight($file_info);
+    $rendered_added = self::callProtectedMethod(Diff::class, 'doRender', [$added]);
+    $this->assertIsString($rendered_added);
+    $this->assertStringContainsString('+one side line', $rendered_added);
+
+    // Absent right (a removed file) renders as a pure deletion.
+    $removed = new Diff();
+    $removed->setLeft($file_info);
+    $rendered_removed = self::callProtectedMethod(Diff::class, 'doRender', [$removed]);
+    $this->assertIsString($rendered_removed);
+    $this->assertStringContainsString('-one side line', $rendered_removed);
+  }
+
   public function testIsSameContentWithDifferentSizes(): void {
     $diff = new Diff();
 

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -160,7 +160,7 @@ final class IndexTest extends UnitTestCase {
     $index = new Index($dir);
 
     // Transforming through the callback must not corrupt the cached index.
-    $index->getFiles(fn(IndexedFile $file): string => 'transformed');
+    $index->getFiles(fn(IndexedFile $file): string => 'transformed:' . $file->getFilename());
 
     $this->assertContainsOnlyInstancesOf(IndexedFile::class, $index->getFiles());
   }

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -154,6 +154,17 @@ final class IndexTest extends UnitTestCase {
     $this->assertNotEmpty($result1);
   }
 
+  public function testGetFilesWithCallbackDoesNotMutateIndex(): void {
+    $dir = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal_advanced' . DIRECTORY_SEPARATOR . 'directory2');
+
+    $index = new Index($dir);
+
+    // Transforming through the callback must not corrupt the cached index.
+    $index->getFiles(fn(IndexedFile $file): string => 'transformed');
+
+    $this->assertContainsOnlyInstancesOf(IndexedFile::class, $index->getFiles());
+  }
+
   public function testConstructorWithIgnoreContentFile(): void {
     $test_dir = $this->locationsTmp() . DIRECTORY_SEPARATOR . 'test_dir_with_ignorecontent';
     File::mkdir($test_dir);

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -123,6 +123,8 @@ final class RulesTest extends UnitTestCase {
     yield 'special characters in include rule' => ["!special@chars", ["special@chars"], [], [], []];
     yield 'regex special characters as global rule' => ["[regex].special+chars?{test}", [], [], ["[regex].special+chars?{test}"], []];
     yield 'very long pattern' => [str_repeat("a", 1000), [], [], [str_repeat("a", 1000)], []];
+    yield 'lone negation prefix is ignored' => ['!', [], [], [], []];
+    yield 'negation of content marker only is ignored' => ['!^', [], [], [], []];
   }
 
   public function testParseMethodChaining(): void {


### PR DESCRIPTION
## Summary

Performance optimizations across the core scan and compare paths, plus correctness fixes, all preserving the public API. Every change is internal (private/protected bodies, local logic) - no class, interface, method signature, public constant, or public parameter name changed. Two independent analysis passes (one for performance, one for defects) drove the work; each finding was verified against the code before acting.

The branch bundles three performance optimizations and three fixes, each with tests green. It also surfaces four additional defects that are **not** fixed here because they would change the on-disk snapshot format (or an already-tested public contract); those are documented below for a deliberate decision rather than changed autonomously.

## Performance optimizations

All are behavior-preserving and covered by the existing suite. The CI benchmark job compares each against the baseline and comments the measured deltas.

| # | Change | What was wasteful | Benchmarks helped |
|---|---|---|---|
| 1 | `IndexedFile`: memoize `getPathnameFromBasepath()`; replace `str_replace($basepath, '', $path)` with `substr($path, strlen($basepath))` | The relative path was recomputed on every call (scan, then compare/sync/patch), and `str_replace` scanned the whole string despite `str_starts_with` already proving the prefix. `substr` is faster **and** correct - `str_replace` also mis-strips a basepath that recurs later in the path. | all (per-file) |
| 2 | `Index::scan()`: `array_unique()` the cached pattern arrays | `Snapshot::compare()` shares one `Rules` object across both indexes, and each `Index` constructor re-appends the default `.ignorecontent`/`.git/` skip rules, so every file was matched against duplicated patterns. | all compare + sync/patch |
| 3 | `Comparer::compare()`: reuse the index key as the diff key and reset the filter cache once | `addLeftFile()`/`addRightFile()` recomputed `getPathnameFromBasepath()` per file and did `$this->cache = []` on **every** call, though the cache is provably empty during `compare()`. The index already keys files by that exact relative path. | all compare |

`addLeftFile()`/`addRightFile()` remain unchanged for external callers - `Comparer::compare()` just stops routing through them redundantly while building the diff set.

## Defects fixed (behavior-preserving, each with a regression test)

**1. `Index::getFiles($cb)` corrupted the cached index.** The callback results were written back into `$this->files`, so a second `getFiles()` (or any later `compare()`) saw transformed values instead of `IndexedFile` objects - a `getFiles(fn)` followed by `compare()` threw a `TypeError`. Now the callback transforms a copy and the cached index is left intact (mirroring `Comparer::filterCached()`).

**2. Rendering a one-sided diff threw an uncatchable `\Error`.** `getAbsentLeftDiffs()`/`getAbsentRightDiffs()` return `Diff` objects with only one side set; calling the public `render()` on one hit `getLeft()`/`getRight()` on an uninitialized typed property and threw `Error` (not a catchable `SnapshotException`). `doRender()` now treats a missing side as empty content, rendering it as a clean addition or deletion.

**3. A lone `!` line in `.ignorecontent` raised a PHP warning.** `parse()` read `$line[1]` unconditionally, so a bare `!` (or `!^`) produced an "Uninitialized string offset" warning - a hard error under PHPUnit's strict handler. The index access is now guarded and a degenerate negation line is ignored.

## Defects found but NOT fixed here (need a format / contract decision)

These are real, reproduced defects. They are left for a deliberate decision because fixing them changes the on-disk snapshot format or an already-tested public contract - not something to do silently in an autonomous PR.

**A. `diff` -> `patch` round-trip corrupts a changed trailing newline (high).** If a file's trailing-newline state differs between baseline and actual, the round-trip silently adds or drops the final newline. `Diff::doRender()` uses `UnifiedDiffOutputBuilder('', TRUE)`, which never emits `\ No newline at end of file` markers, so the trailing-newline state is absent from the diff and `Patcher`'s `implode("\n", ...)` re-derives it from the leftover baseline lines. Repro: baseline `f.txt` = `"old\n"`, actual `f.txt` = `"newval"` (no newline) -> after diff+patch the result is `"newval\n"`. Fix requires emitting and honouring the "no newline" marker end-to-end, which changes the diff-file format.

**B. An added file whose name starts with `-` collides with the deletion-marker convention (medium).** Deletions are encoded as a sibling file whose basename is prefixed with `-`. An added file legitimately named `-report.txt` is copied verbatim by `diff()`, then `patch()` reads the leading `-` as a deletion marker: the added file is dropped, and `-keep.txt` would even delete a real `keep.txt`. Fix requires escaping the marker (a format change).

**C. `CONTENT_IGNORED_MARKER` sentinel can collide with real content (low).** "Ignore content" is stored as the sentinel string `content_ignored` inside `$content`, and `isIgnoreContent()` compares content to it - so a real file whose bytes are exactly `content_ignored` is mis-detected as ignore-content. The clean fix (a dedicated boolean) would break the tested public contract that setting content to `IndexedFile::CONTENT_IGNORED_MARKER` marks a file ignore-content (`IndexedFileTest` asserts exactly this), so it needs a contract decision.

**D. `isSameContent()` inode shortcut ignores the device id (low).** Two same-size files on different filesystems with a coincidentally equal inode are reported identical without hashing. `SplFileInfo` exposes no `st_dev`, so a sound fix means adding a `stat()` (or dropping the inode optimization) - a change to the comparison core's performance profile.

## Verification

- **Tests**: `composer test` -> **244 tests, 678 assertions, OK** (4 new regression tests; green after every commit).
- **Lint**: `composer lint` -> PHPCS (44 files), PHPStan level 9, Rector all clean.
- **Performance**: measured by the CI benchmark job against the committed baseline; the ±5% assertion passes on speedups, so these changes will not trip it.

## Before / After

```
 Comparer::compare() filter cache
 ┌───────────────────────────────────────────────────────────────┐
 │ BEFORE: for each file -> addLeftFile()/addRightFile()          │
 │           -> $this->cache = []   (N resets, path recomputed)   │
 ├───────────────────────────────────────────────────────────────┤
 │ AFTER:  for each file -> set diff on the index key directly    │
 │         -> $this->cache = []     (1 reset, after the loop)     │
 └───────────────────────────────────────────────────────────────┘

 Index::getFiles($cb)
 ┌───────────────────────────────────────────────────────────────┐
 │ BEFORE:  $this->files[$path] = $cb($file);   // cache mutated  │
 │          return $this->files;                // now corrupt    │
 ├───────────────────────────────────────────────────────────────┤
 │ AFTER:   $copy[$path] = $cb($file);          // cache intact   │
 │          return $copy;                       // transformed    │
 └───────────────────────────────────────────────────────────────┘

 Diff::render() on a one-sided diff (added file)
 ┌───────────────────────────────────────────────────────────────┐
 │ BEFORE:  getLeft()->getContent()  ->  \Error: must not be      │
 │          accessed before initialization          (uncatchable) │
 ├───────────────────────────────────────────────────────────────┤
 │ AFTER:   existsLeft() ? ... : ''  ->  clean "+file added"      │
 │          unified diff output                                   │
 └───────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Optimized scan, compare, sync, and patch paths while preserving the public API.
- Added pathname memoization and pattern deduplication.
- Reduced comparison cache resets and clarified patch-file handling.
- Fixed cached-index corruption from callback-based file retrieval.
- Fixed rendering of one-sided diffs.
- Prevented warnings from lone negation lines in `.ignorecontent`.
- Added regression tests for the fixes and edge cases.

## Validation

- 244 tests and 678 assertions passing
- Lint, static analysis, Rector, and benchmark checks passing

## Possibly related

- Possibly related to `#1` (performance benchmarks).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->