### PR TITLE
Converged naming, idioms, structure and comments onto their dominant forms across the library.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,9 +170,9 @@ tests/phpunit/
 │   ├── PatcherTest.php
 │   ├── PatchExceptionTest.php
 │   ├── RulesTest.php
-│   ├── SnapshotAssertionsTraitTest.php
 │   ├── SnapshotBuilderTest.php
-│   └── SnapshotTest.php
+│   ├── SnapshotTest.php
+│   └── SnapshotTraitTest.php
 ├── Functional/              # Integration tests - subprocess testing
 │   ├── FunctionalTestCase.php
 │   ├── SnapshotTraitUpdateTest.php

--- a/benchmarks/BenchmarkDirectoryTrait.php
+++ b/benchmarks/BenchmarkDirectoryTrait.php
@@ -157,10 +157,10 @@ trait BenchmarkDirectoryTrait {
    */
   protected function directoryCreateWithStructuralDiffs(int $percent_removed = 10, int $percent_added = 10): void {
     $files = File::scandir($this->actualDir);
-    $files_count = count($files);
+    $file_count = count($files);
 
     // Remove some files.
-    $files_to_remove = (int) ceil($files_count * ($percent_removed / 100));
+    $files_to_remove = (int) ceil($file_count * ($percent_removed / 100));
     shuffle($files);
     $files_to_remove_list = array_slice($files, 0, $files_to_remove);
 
@@ -169,7 +169,7 @@ trait BenchmarkDirectoryTrait {
     }
 
     // Add extra files.
-    $files_to_add = (int) ceil($files_count * ($percent_added / 100));
+    $files_to_add = (int) ceil($file_count * ($percent_added / 100));
     $dirs = glob($this->actualDir . '/level_*', GLOB_ONLYDIR);
 
     for ($i = 1; $i <= $files_to_add; $i++) {

--- a/benchmarks/BenchmarkDirectoryTrait.php
+++ b/benchmarks/BenchmarkDirectoryTrait.php
@@ -96,7 +96,6 @@ trait BenchmarkDirectoryTrait {
         $content .= sprintf("Level: %d\n", $level);
         $content .= "Some common text that appears in all files.\n";
 
-        // Pad to reach target size.
         if (strlen($content) < $file_size) {
           $padding = str_repeat("Line of text to fill the file.\n", (int) ceil(($file_size - strlen($content)) / 30));
           $content .= $padding;
@@ -159,7 +158,6 @@ trait BenchmarkDirectoryTrait {
     $files = File::scandir($this->actualDir);
     $file_count = count($files);
 
-    // Remove some files.
     $files_to_remove = (int) ceil($file_count * ($percent_removed / 100));
     shuffle($files);
     $files_to_remove_list = array_slice($files, 0, $files_to_remove);
@@ -168,7 +166,6 @@ trait BenchmarkDirectoryTrait {
       unlink($file);
     }
 
-    // Add extra files.
     $files_to_add = (int) ceil($file_count * ($percent_added / 100));
     $dirs = glob($this->actualDir . '/level_*', GLOB_ONLYDIR);
 

--- a/benchmarks/SnapshotBench.php
+++ b/benchmarks/SnapshotBench.php
@@ -56,7 +56,6 @@ class SnapshotBench {
     $this->directoryCreateIdentical(100, 3, 1024);
     $this->directoryCreateWithContentDiffs(20);
 
-    // Create diff files first.
     $this->diffDir = $this->tmpDir . DIRECTORY_SEPARATOR . 'diff';
     mkdir($this->diffDir, 0777, TRUE);
     Snapshot::diff($this->baselineDir, $this->actualDir, $this->diffDir);

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -24,19 +24,17 @@ declare(strict_types=1);
 // Suffix appended to snapshots path to create baseline snapshots path.
 define('BASELINE_DIR', '_baseline');
 
-// Name of the baseline dataset (will be run first).
+// Name of the baseline dataset, which runs first.
 define('BASELINE_DATASET_NAME', 'baseline');
 
-// Commit message for baseline snapshots.
 define('COMMIT_MESSAGE_BASELINE', 'Updated baseline.');
 
-// Commit message for all snapshots.
 define('COMMIT_MESSAGE_SNAPSHOTS', 'Updated snapshots.');
 
 // Completion markers emitted by SnapshotTrait once a snapshot has been
-// rewritten. When a PHPUnit run exits non-zero but its output contains one of
-// these markers, the snapshot was updated successfully and the dataset must be
-// treated as updated rather than failed.
+// rewritten. When a PHPUnit run exits non-zero but its output contains one
+// of these markers, the snapshot was updated successfully. The dataset must
+// then be treated as updated rather than failed.
 define('SNAPSHOT_MARKER_BASELINE_UPDATED', '[SNAPSHOT] Baseline updated');
 define('SNAPSHOT_MARKER_DIFFS_UPDATED', '[SNAPSHOT] Diffs updated');
 
@@ -62,17 +60,14 @@ function main(array $argv, int $argc): void {
   validate_config($config);
   setup_signal_handlers();
 
-  // Change to root directory.
   chdir($config['root']);
 
-  // If datasets provided, run only specified datasets.
   if (!empty($config['datasets'])) {
     run_specified_datasets($config);
 
     return;
   }
 
-  // Run all datasets.
   run_all_datasets($config);
 }
 
@@ -107,7 +102,6 @@ function validate_config(array $config): void {
 function setup_signal_handlers(): void {
   if (function_exists('pcntl_signal')) {
     $handler = function (): void {
-      // Restore terminal if in TUI mode.
       exit_tui();
       verbose("\nInterrupted by user\n");
       exit(130);
@@ -183,7 +177,6 @@ function run_all_datasets(array $config): void {
 
   $stats = ['current' => 0, 'succeeded' => 0, 'updated' => 0, 'failed' => 0, 'timedout' => 0];
 
-  // Run baseline sequentially first.
   $scenario_datasets = $datasets;
   if ($datasets[0] === BASELINE_DATASET_NAME) {
     $stats['current']++;
@@ -209,7 +202,6 @@ function run_all_datasets(array $config): void {
     $scenario_datasets = array_slice($datasets, 1);
   }
 
-  // Run remaining scenarios in parallel.
   if (!empty($scenario_datasets)) {
     $parallel_stats = run_datasets_parallel($scenario_datasets, $stats['current'], $total, $config);
     $stats['succeeded'] += $parallel_stats['succeeded'];
@@ -218,11 +210,10 @@ function run_all_datasets(array $config): void {
     $stats['timedout'] += $parallel_stats['timedout'];
   }
 
-  // Print summary.
   print_summary($stats, $total);
 
-  // Commit any snapshot changes that were applied. This is a no-op when the
-  // working tree is clean, so it is safe to call unconditionally.
+  // A no-op when the working tree is clean, so it is safe to call
+  // unconditionally.
   commit_snapshot_changes($config, $baseline_committed);
 
   print_execution_time($start_time);
@@ -258,7 +249,6 @@ function discover_datasets(array $config): array {
     throw new \Exception('No datasets found');
   }
 
-  // Extract dataset names from test list.
   // Format: " - ClassName::testMethodName"dataset_name"".
   $pattern = '/' . preg_quote((string) $config['test_name'], '/') . '"([^"]+)"/';
   preg_match_all($pattern, $test_list, $matches);
@@ -458,29 +448,24 @@ function parse_arguments(array $argv): array {
     'jobs' => 4,
   ];
 
-  // Remove script name.
   array_shift($argv);
 
   $positional = [];
 
   foreach ($argv as $arg) {
-    // Check for help flags.
     if (in_array($arg, ['help', '--help', '-h', '-?'], TRUE)) {
       $config['help'] = TRUE;
       continue;
     }
 
-    // Parse options with values (--option=value).
     if (str_starts_with($arg, '--')) {
       $config = parse_option($arg, $config);
       continue;
     }
 
-    // Collect positional arguments.
     $positional[] = $arg;
   }
 
-  // Assign positional arguments.
   if (isset($positional[0])) {
     $config['test_name'] = $positional[0];
   }
@@ -689,7 +674,6 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total, a
   $jobs = (int) $config['jobs'];
   $is_tty = function_exists('posix_isatty') && posix_isatty(STDOUT);
 
-  // Build task list.
   $tasks = [];
   $number = $start_number;
   foreach ($datasets as $dataset) {
@@ -718,16 +702,13 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total, a
     enter_tui();
   }
 
-  // Event loop.
   while (TRUE) {
     dispatch_signals();
 
-    // Read keyboard input for scrolling (TTY only).
     if ($is_tty) {
       $scroll_offset = read_keyboard_input($scroll_offset, count($tasks));
     }
 
-    // Start phase: fill empty slots.
     $running_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
     foreach ($tasks as &$task) {
       if ($running_count >= $jobs) {
@@ -741,7 +722,6 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total, a
     }
     unset($task);
 
-    // Poll phase: check running processes.
     foreach ($tasks as &$task) {
       if ($task['status'] !== 'running') {
         continue;
@@ -750,10 +730,8 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total, a
     }
     unset($task);
 
-    // Render phase.
     render_progress($tasks, $total, $is_tty, $jobs, $scroll_offset, $start_time);
 
-    // Exit check: all done?
     $pending = array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued' || $t['status'] === 'running');
     if (empty($pending)) {
       break;
@@ -786,7 +764,6 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total, a
     }
   }
 
-  // Aggregate stats.
   $stats = ['succeeded' => 0, 'updated' => 0, 'failed' => 0, 'timedout' => 0];
   foreach ($tasks as $task) {
     if ($task['status'] === 'success') {
@@ -867,7 +844,6 @@ function poll_task(array $task, array $config): array {
   $status = proc_get_status($task['process']);
   $task['output'] = collect_output($task['pipes'], $task['output']);
 
-  // Update dots every 250ms.
   if (microtime(TRUE) - $task['last_dot_time'] >= 0.25) {
     $task['dots']++;
     $task['last_dot_time'] = microtime(TRUE);
@@ -882,7 +858,6 @@ function poll_task(array $task, array $config): array {
   // PHP < 8.3. proc_close() below only releases the handle.
   $exit_code = $status['exitcode'];
 
-  // Process finished.
   $task['output'] = collect_output($task['pipes'], $task['output']);
   fclose($task['pipes'][1]);
   fclose($task['pipes'][2]);
@@ -1060,7 +1035,6 @@ function render_progress(array $tasks, int $total, bool $is_tty, int $jobs, int 
   $pad = strlen((string) $total);
 
   if (!$is_tty) {
-    // Non-TTY: only print when all done.
     if ($running === 0 && $queued === 0) {
       foreach ($tasks as $task) {
         $line = sprintf('  [%' . $pad . 'd/%d] %s ', $task['number'], $total, $task['dataset']);
@@ -1092,11 +1066,9 @@ function render_progress(array $tasks, int $total, bool $is_tty, int $jobs, int 
   // Cursor to home.
   print "\033[H";
 
-  // Header.
   printf("\033[K  Running %d scenarios (parallel: %d)\n", $task_count, $jobs);
   print "\033[K\n";
 
-  // Visible slice of tasks.
   $visible_end = min($task_count, $scroll_offset + $viewport_height);
   for ($i = $scroll_offset; $i < $visible_end; $i++) {
     $task = $tasks[$i];
@@ -1129,7 +1101,6 @@ function render_progress(array $tasks, int $total, bool $is_tty, int $jobs, int 
     }
   }
 
-  // Footer.
   print "\033[K\n";
   printf(
     "\033[K  \033[32mDone: %d\033[0m  \033[36mUpdated: %d\033[0m  \033[31mFailed: %d\033[0m  \033[33mRunning: %d\033[0m  Queued: %d  Timeout: %d\n",
@@ -1142,7 +1113,6 @@ function render_progress(array $tasks, int $total, bool $is_tty, int $jobs, int 
   );
   printf("\033[K  Elapsed: %s\n", format_time((int) (microtime(TRUE) - $start_time)));
 
-  // Scroll indicator.
   if ($max_scroll > 0) {
     printf("\033[K\033[90m  ↑↓ Scroll (%d-%d of %d)\033[0m\n", $scroll_offset + 1, $visible_end, $task_count);
   }
@@ -1228,7 +1198,6 @@ function run_phpunit(string $filter, int $timeout, string $root): array {
   while (TRUE) {
     $status = proc_get_status($process);
 
-    // Collect output.
     $output = collect_output($pipes, $output);
 
     if (!$status['running']) {
@@ -1239,7 +1208,6 @@ function run_phpunit(string $filter, int $timeout, string $root): array {
       break;
     }
 
-    // Print progress dot every 0.25 seconds.
     if (microtime(TRUE) - $last_dot_time >= 0.25) {
       verbose('.');
       $last_dot_time = microtime(TRUE);
@@ -1249,7 +1217,6 @@ function run_phpunit(string $filter, int $timeout, string $root): array {
     dispatch_signals();
   }
 
-  // Collect remaining output.
   $output = collect_output($pipes, $output);
 
   fclose($pipes[1]);
@@ -1411,7 +1378,6 @@ if (PHP_SAPI !== 'cli' || !empty($_SERVER['REMOTE_ADDR'])) {
   die('This script can be only ran from the command line.');
 }
 
-// Allow to skip the script run.
 if (getenv('SCRIPT_RUN_SKIP') != 1) {
   set_error_handler(function (int $severity, string $message, string $file, int $line): bool {
     if ((error_reporting() & $severity) === 0) {
@@ -1425,7 +1391,7 @@ if (getenv('SCRIPT_RUN_SKIP') != 1) {
   try {
     $argv = is_array($_SERVER['argv'] ?? NULL) ? array_filter($_SERVER['argv'], is_string(...)) : [];
     $argc = is_scalar($_SERVER['argc'] ?? NULL) ? (int) $_SERVER['argc'] : 0;
-    // The function should not provide an exit code but rather throw exceptions.
+    // The function throws exceptions instead of providing an exit code.
     main($argv, $argc);
   }
   catch (\ErrorException $exception) {

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -22,7 +22,7 @@ declare(strict_types=1);
 
 // ----------------------------------------------------------------------------
 // Suffix appended to snapshots path to create baseline snapshots path.
-define('BASELINE_SUFFIX', '_baseline');
+define('BASELINE_DIR', '_baseline');
 
 // Name of the baseline dataset (will be run first).
 define('BASELINE_DATASET_NAME', 'baseline');
@@ -174,7 +174,7 @@ function run_specified_datasets(array $config): void {
 function run_all_datasets(array $config): void {
   $start_time = time();
   $baseline_committed = FALSE;
-  $baseline_path = rtrim((string) $config['snapshots_path'], '/') . '/' . BASELINE_SUFFIX;
+  $baseline_path = rtrim((string) $config['snapshots_path'], '/') . '/' . BASELINE_DIR;
 
   $datasets = discover_datasets($config);
   $total = count($datasets);

--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -146,7 +146,7 @@ class Comparer implements ComparerInterface {
    * {@inheritdoc}
    */
   public function render(array $options = [], ?callable $renderer = NULL): ?string {
-    return call_user_func($renderer ?? [static::class, 'doRender'], $this->left, $this->right, $this, $options);
+    return call_user_func($renderer ?? static::doRender(...), $this->left, $this->right, $this, $options);
   }
 
   /**
@@ -203,9 +203,9 @@ class Comparer implements ComparerInterface {
         $render .= sprintf("  %s\n", $file);
 
         if ($options['show_diff'] && $content_diffs_render_count > 0 && $diff instanceof Diff) {
-          $render .= '--- DIFF START ---' . PHP_EOL;
+          $render .= "--- DIFF START ---\n";
           $render .= $diff->render();
-          $render .= '--- DIFF END ---' . PHP_EOL;
+          $render .= "--- DIFF END ---\n";
           $content_diffs_render_count--;
         }
       }

--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -51,18 +51,16 @@ class Comparer implements ComparerInterface {
     $right_files = $this->right->getFiles();
 
     // The index keys are already the pathname relative to the base directory
-    // (the same value addLeftFile()/addRightFile() would recompute), so reuse
-    // them directly as the diff keys.
+    // that addLeftFile()/addRightFile() would recompute, so they are reused
+    // as the diff keys.
     foreach ($left_files as $path => $left_file) {
       ($this->diffs[$path] ??= new Diff())->setLeft($left_file);
       if (isset($right_files[$path])) {
         $this->diffs[$path]->setRight($right_files[$path]);
-        // Mark as processed to avoid duplicate processing.
         unset($right_files[$path]);
       }
     }
 
-    // Process remaining right files that don't exist in left.
     foreach ($right_files as $path => $right_file) {
       ($this->diffs[$path] ??= new Diff())->setRight($right_file);
     }
@@ -167,8 +165,8 @@ class Comparer implements ComparerInterface {
   protected static function doRender(IndexInterface $left, IndexInterface $right, Comparer $comparer, array $options = []): ?string {
     $options += [
       'show_diff' => TRUE,
-      // Number of files to include in the diff output. This allows to prevent
-      // an output that could potentially eat a lot of memory.
+      // Cap on the number of files rendered with a full diff; an unbounded
+      // output could consume excessive memory.
       'show_diff_file_limit' => 10,
     ];
 

--- a/src/Compare/Diff.php
+++ b/src/Compare/Diff.php
@@ -89,19 +89,18 @@ class Diff implements DiffInterface {
       return TRUE;
     }
 
-    // File fingerprinting for regular files.
     // Skip for symlinks as metadata may not work reliably.
     if (!$this->left->isLink() && !$this->right->isLink()) {
       try {
         $left_size = $this->left->getSize();
         $right_size = $this->right->getSize();
 
-        // Optimization 1: Different sizes = definitely different content.
+        // Different sizes mean different content.
         if ($left_size !== $right_size) {
           return FALSE;
         }
 
-        // Optimization 2: Same inode = same file (hard link).
+        // The same inode means the same file (hard link).
         $left_inode = $this->left->getInode();
         $right_inode = $this->right->getInode();
         if ($left_inode === $right_inode && $left_inode !== FALSE) {

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -45,7 +45,7 @@ class Index implements IndexInterface {
    * {@inheritdoc}
    */
   public function getFiles(?callable $cb = NULL): array {
-    if (is_null($this->files)) {
+    if ($this->files === NULL) {
       $this->scan();
     }
 

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -178,7 +178,7 @@ class Index implements IndexInterface {
    */
   protected function matchesAnyPattern(string $path, array $patterns): bool {
     foreach ($patterns as $pattern) {
-      if (static::isPathMatchesPattern($path, $pattern)) {
+      if (static::pathMatchesPattern($path, $pattern)) {
         return TRUE;
       }
     }
@@ -201,7 +201,7 @@ class Index implements IndexInterface {
    * @return bool
    *   TRUE if the path matches the pattern, FALSE otherwise.
    */
-  protected static function isPathMatchesPattern(string $path, string $pattern): bool {
+  protected static function pathMatchesPattern(string $path, string $pattern): bool {
     // Match directory pattern (e.g., "dir/").
     if (str_ends_with($pattern, DIRECTORY_SEPARATOR)) {
       return str_starts_with($path, $pattern);

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -9,7 +9,7 @@ use AlexSkrypnyk\Snapshot\Rules\Rules;
 use AlexSkrypnyk\Snapshot\Snapshot;
 
 /**
- * Collect and index of the files in the directory respecting the rules.
+ * Collects and indexes the files in the directory, respecting the rules.
  *
  * @see Rules::parse()
  */
@@ -84,10 +84,9 @@ class Index implements IndexInterface {
   protected function scan(): static {
     $this->files = [];
 
-    // Pre-cache pattern arrays for faster matching. The same Rules object can
-    // be shared across indexes (and re-seeded with the default skip rules by
-    // each Index constructor), so dedupe to avoid matching a pattern twice per
-    // file.
+    // Pre-cache pattern arrays for faster matching. A shared Rules object
+    // is re-seeded with the default skip rules by each constructor, so
+    // dedupe to avoid matching a pattern twice per file.
     $global_patterns = array_unique($this->rules->getGlobal());
     $include_patterns = array_unique($this->rules->getInclude());
     $skip_patterns = array_unique($this->rules->getSkip());
@@ -120,18 +119,15 @@ class Index implements IndexInterface {
 
       $relative_path = $file->getPathnameFromBasepath();
 
-      // Check include patterns (if any exist).
       $is_included = FALSE;
       if (!empty($include_patterns)) {
         $is_included = $this->matchesAnyPattern($relative_path, $include_patterns);
       }
 
-      // Only check skip if not explicitly included.
       if (!$is_included && $this->matchesAnyPattern($relative_path, $skip_patterns)) {
         continue;
       }
 
-      // Check ignore content patterns.
       $is_ignore_content = FALSE;
       if (!$is_included && $this->matchesAnyPattern($relative_path, $ignore_content_patterns)) {
         $is_ignore_content = TRUE;
@@ -146,8 +142,6 @@ class Index implements IndexInterface {
         // @codeCoverageIgnoreEnd
       }
       elseif (is_callable($this->beforeMatchContent)) {
-        // Allow to skip files that do not match the content by returning FALSE
-        // from the callback.
         $ret = call_user_func($this->beforeMatchContent, $file);
         if ($ret === FALSE) {
           continue;
@@ -164,9 +158,6 @@ class Index implements IndexInterface {
 
   /**
    * Checks if a path matches any of the given patterns.
-   *
-   * This is a helper method to reduce code duplication and improve
-   * readability in the scan() method.
    *
    * @param string $path
    *   The path to check.

--- a/src/Index/IndexedFile.php
+++ b/src/Index/IndexedFile.php
@@ -142,7 +142,7 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
    * {@inheritdoc}
    */
   public function setContent(?string $content): void {
-    if (!is_null($content)) {
+    if ($content !== NULL) {
       $this->content = $content;
       $this->hash = $this->hash($this->content);
       $this->contentLoaded = TRUE;

--- a/src/Index/IndexedFile.php
+++ b/src/Index/IndexedFile.php
@@ -126,8 +126,7 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
    * {@inheritdoc}
    */
   public function isIgnoreContent(): bool {
-    // If content is explicitly set, check it.
-    // If not loaded yet, it can't be the ignore marker.
+    // Content that has not been loaded cannot be the ignore marker.
     return $this->contentLoaded && $this->content === static::CONTENT_IGNORED_MARKER;
   }
 
@@ -165,7 +164,6 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
 
     if ($this->isLink()) {
       $link_target = $this->getLinkTarget();
-      // If the link target is absolute and within basepath, make it relative.
       if (str_starts_with($link_target, $this->basepath)) {
         $this->content = static::stripBasepath($this->basepath, $link_target);
       }
@@ -175,9 +173,6 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
       $this->hash = $this->hash($this->content);
     }
     elseif ($this->getSize() <= static::LARGE_FILE_THRESHOLD) {
-      // Small files: read content once and compute hash from in-memory buffer.
-      // This eliminates the double-read that previously occurred when both
-      // getHash() and getContent() were called on the same file.
       $this->content = (string) file_get_contents($this->getRealPath());
       $this->hash = $this->hash($this->content);
     }

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -32,7 +32,7 @@ class Rules implements RulesInterface {
    *
    * @var array<int, string>
    */
-  protected array $global = [];
+  protected array $globalPatterns = [];
 
   /**
    * Patterns for files to explicitly include.
@@ -104,7 +104,7 @@ class Rules implements RulesInterface {
    * {@inheritdoc}
    */
   public function getGlobal(): array {
-    return $this->global;
+    return $this->globalPatterns;
   }
 
   /**
@@ -134,7 +134,7 @@ class Rules implements RulesInterface {
    * {@inheritdoc}
    */
   public function addGlobal(string $pattern): static {
-    $this->global[] = $pattern;
+    $this->globalPatterns[] = $pattern;
     return $this;
   }
 
@@ -218,7 +218,7 @@ class Rules implements RulesInterface {
         $this->ignoreContentPatterns[] = substr($line, 1);
       }
       elseif (!str_contains($line, DIRECTORY_SEPARATOR)) {
-        $this->global[] = $line;
+        $this->globalPatterns[] = $line;
       }
       else {
         $this->skipPatterns[] = $line;

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -87,6 +87,34 @@ class Rules implements RulesInterface {
   }
 
   /**
+   * Creates a Rules instance from a file.
+   *
+   * @param string $file
+   *   The path to the rules file.
+   *
+   * @return self
+   *   A new Rules instance.
+   *
+   * @throws \AlexSkrypnyk\Snapshot\Exception\SnapshotException
+   *   If the file does not exist or cannot be read.
+   */
+  public static function fromFile(string $file): self {
+    if (!File::exists($file)) {
+      throw new SnapshotException(sprintf('File %s does not exist.', $file));
+    }
+
+    try {
+      $content = File::read($file);
+    }
+    // @codeCoverageIgnoreStart
+    catch (\Exception $exception) {
+      throw new RulesException(sprintf('Failed to read the %s file.', $file), $exception->getCode(), $exception);
+    }
+    // @codeCoverageIgnoreEnd
+    return (new self())->parse($content);
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getIgnoreContent(): array {
@@ -226,34 +254,6 @@ class Rules implements RulesInterface {
     }
 
     return $this;
-  }
-
-  /**
-   * Creates a Rules instance from a file.
-   *
-   * @param string $file
-   *   The path to the rules file.
-   *
-   * @return self
-   *   A new Rules instance.
-   *
-   * @throws \AlexSkrypnyk\Snapshot\Exception\SnapshotException
-   *   If the file does not exist or cannot be read.
-   */
-  public static function fromFile(string $file): self {
-    if (!File::exists($file)) {
-      throw new SnapshotException(sprintf('File %s does not exist.', $file));
-    }
-
-    try {
-      $content = File::read($file);
-    }
-    // @codeCoverageIgnoreStart
-    catch (\Exception $exception) {
-      throw new RulesException(sprintf('Failed to read the %s file.', $file), $exception->getCode(), $exception);
-    }
-    // @codeCoverageIgnoreEnd
-    return (new self())->parse($content);
   }
 
   /**

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -128,7 +128,6 @@ class Snapshot {
       File::dump($destination . DIRECTORY_SEPARATOR . '-' . basename((string) $file), '');
     }
 
-    // Files with content differences - save diff.
     foreach ($content_diffs as $file => $diff) {
       if ($diff instanceof Diff) {
         $rendered = $diff->render();
@@ -173,14 +172,12 @@ class Snapshot {
         File::copy($file->getPathname(), $destination . DIRECTORY_SEPARATOR . $relative_path);
       }
       else {
-        // Patch file - queue for patching.
         $patcher->addPatchFile($file);
       }
     }
 
     $patcher->patch();
 
-    // Apply content processor to all files in destination if provided.
     if ($content_processor !== NULL) {
       $files = File::scandir($destination);
       foreach ($files as $file_path) {

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -158,7 +158,7 @@ class SnapshotBuilder {
    *   The directory index.
    */
   public function scan(string $directory): Index {
-    return new Index($directory, $this->rules, $this->contentProcessor);
+    return Snapshot::scan($directory, $this->rules, $this->contentProcessor);
   }
 
   /**

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -12,8 +12,8 @@ use AlexSkrypnyk\Snapshot\Sync\Syncer;
 /**
  * Configurable snapshot builder for repeated operations.
  *
- * Use this class when you need to configure rules or content processors
- * and perform multiple operations with the same settings.
+ * Use this class to configure rules or content processors and perform
+ * multiple operations with the same settings.
  *
  * @code
  * $builder = SnapshotBuilder::create()

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -122,7 +122,6 @@ trait SnapshotTrait {
     $tmp ??= sys_get_temp_dir();
     $baseline = Snapshot::getBaselinePath($snapshots);
 
-    // Hook for preprocessing.
     $this->snapshotUpdateBefore($actual);
 
     if (Snapshot::isBaseline($snapshots)) {

--- a/tests/phpunit/Functional/FunctionalTestCase.php
+++ b/tests/phpunit/Functional/FunctionalTestCase.php
@@ -8,11 +8,6 @@ use AlexSkrypnyk\PhpunitHelpers\Traits\EnvTrait;
 use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
 use AlexSkrypnyk\Snapshot\Tests\UnitTestCase;
 
-/**
- * Base functional test case for snapshot package tests.
- *
- * Extends UnitTestCase and adds ProcessTrait for subprocess testing.
- */
 abstract class FunctionalTestCase extends UnitTestCase {
 
   use EnvTrait;

--- a/tests/phpunit/Functional/SnapshotTraitUpdateTest.php
+++ b/tests/phpunit/Functional/SnapshotTraitUpdateTest.php
@@ -9,43 +9,29 @@ use AlexSkrypnyk\Snapshot\Snapshot;
 use AlexSkrypnyk\Snapshot\Testing\SnapshotTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * Functional tests for SnapshotTrait auto-update functionality.
- *
- * These tests run PHPUnit in a subprocess to verify that the trait correctly
- * updates snapshots when tests fail due to directory comparison mismatches.
- */
 #[CoversClass(SnapshotTrait::class)]
 final class SnapshotTraitUpdateTest extends FunctionalTestCase {
 
-  /**
-   * Test that snapshotUpdateOnFailure() updates baseline when test fails.
-   */
   public function testUpdateBaselineOnFailure(): void {
-    // Create the test structure.
     $test_dir = self::$sut . DIRECTORY_SEPARATOR . 'test_project';
     File::mkdir($test_dir);
 
-    // Create snapshots directory with baseline.
     $snapshots_dir = $test_dir . DIRECTORY_SEPARATOR . 'snapshots';
     $baseline_dir = $snapshots_dir . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR;
     File::mkdir($baseline_dir);
     file_put_contents($baseline_dir . DIRECTORY_SEPARATOR . 'file1.txt', "original content\n");
     file_put_contents($baseline_dir . DIRECTORY_SEPARATOR . 'file2.txt', "content 2\n");
 
-    // Create actual output directory (different from baseline).
     $actual_dir = $test_dir . DIRECTORY_SEPARATOR . 'actual';
     File::mkdir($actual_dir);
     file_put_contents($actual_dir . DIRECTORY_SEPARATOR . 'file1.txt', "modified content\n");
     file_put_contents($actual_dir . DIRECTORY_SEPARATOR . 'file2.txt', "content 2\n");
     file_put_contents($actual_dir . DIRECTORY_SEPARATOR . 'file3.txt', "new file\n");
 
-    // Create a temporary test class that uses the trait.
     $test_class_content = $this->createTestClass($baseline_dir, $actual_dir);
     $test_class_file = $test_dir . DIRECTORY_SEPARATOR . 'BaselineUpdateTest.php';
     file_put_contents($test_class_file, $test_class_content);
 
-    // Run PHPUnit without UPDATE_SNAPSHOTS - should fail.
     $this->processCwd = $test_dir;
     $this->processRun(
       self::$root . '/vendor/bin/phpunit',
@@ -55,12 +41,10 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
     $this->assertProcessFailed();
     $this->assertProcessOutputContains('Differences between directories');
 
-    // Verify baseline is unchanged.
     $this->assertFileExists($baseline_dir . DIRECTORY_SEPARATOR . 'file1.txt');
     $this->assertStringEqualsFile($baseline_dir . DIRECTORY_SEPARATOR . 'file1.txt', "original content\n");
     $this->assertFileDoesNotExist($baseline_dir . DIRECTORY_SEPARATOR . 'file3.txt');
 
-    // Run PHPUnit with UPDATE_SNAPSHOTS=1 - should update baseline.
     $this->processRun(
       self::$root . '/vendor/bin/phpunit',
       ['--no-configuration', $test_class_file],
@@ -74,12 +58,10 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
     $this->assertProcessErrorOutputContains('[SNAPSHOT] Updating baseline');
     $this->assertProcessErrorOutputContains('[SNAPSHOT] Baseline updated');
 
-    // Verify baseline was updated.
     $this->assertStringEqualsFile($baseline_dir . DIRECTORY_SEPARATOR . 'file1.txt', "modified content\n");
     $this->assertFileExists($baseline_dir . DIRECTORY_SEPARATOR . 'file3.txt');
     $this->assertStringEqualsFile($baseline_dir . DIRECTORY_SEPARATOR . 'file3.txt', "new file\n");
 
-    // Run PHPUnit again without UPDATE_SNAPSHOTS - should now pass.
     $this->processRun(
       self::$root . '/vendor/bin/phpunit',
       ['--no-configuration', $test_class_file],
@@ -88,38 +70,29 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
     $this->assertProcessSuccessful();
   }
 
-  /**
-   * Test that snapshotUpdateOnFailure() updates diffs when scenario test fails.
-   */
   public function testUpdateDiffsOnFailure(): void {
-    // Create the test structure.
     $test_dir = self::$sut . DIRECTORY_SEPARATOR . 'test_project_diffs';
     File::mkdir($test_dir);
 
-    // Create snapshots directory with baseline.
     $snapshots_dir = $test_dir . DIRECTORY_SEPARATOR . 'snapshots';
     $baseline_dir = $snapshots_dir . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR;
     File::mkdir($baseline_dir);
     file_put_contents($baseline_dir . DIRECTORY_SEPARATOR . 'file1.txt', "original line 1\noriginal line 2\n");
     file_put_contents($baseline_dir . DIRECTORY_SEPARATOR . 'file2.txt', "content 2\n");
 
-    // Create scenario diff directory (initially empty - no changes from
-    // baseline).
+    // The scenario diff directory starts empty: no changes from the baseline.
     $scenario_dir = $snapshots_dir . DIRECTORY_SEPARATOR . 'scenario1';
     File::mkdir($scenario_dir);
 
-    // Create actual output directory (different from baseline).
     $actual_dir = $test_dir . DIRECTORY_SEPARATOR . 'actual';
     File::mkdir($actual_dir);
     file_put_contents($actual_dir . DIRECTORY_SEPARATOR . 'file1.txt', "modified line 1\noriginal line 2\n");
     file_put_contents($actual_dir . DIRECTORY_SEPARATOR . 'file2.txt', "content 2\n");
 
-    // Create a temporary test class that uses the trait for scenario testing.
     $test_class_content = $this->createScenarioTestClass($scenario_dir, $baseline_dir, $actual_dir);
     $test_class_file = $test_dir . DIRECTORY_SEPARATOR . 'ScenarioUpdateTest.php';
     file_put_contents($test_class_file, $test_class_content);
 
-    // Run PHPUnit without UPDATE_SNAPSHOTS - should fail.
     $this->processCwd = $test_dir;
     $this->processRun(
       self::$root . '/vendor/bin/phpunit',
@@ -129,11 +102,9 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
     $this->assertProcessFailed();
     $this->assertProcessOutputContains('Differences between directories');
 
-    // Verify diffs directory is empty.
     $this->assertDirectoryExists($scenario_dir);
     $this->assertEmpty(glob($scenario_dir . DIRECTORY_SEPARATOR . '*'));
 
-    // Run PHPUnit with UPDATE_SNAPSHOTS=1 - should update diffs.
     $this->processRun(
       self::$root . '/vendor/bin/phpunit',
       ['--no-configuration', $test_class_file],
@@ -146,7 +117,6 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
     $this->assertProcessErrorOutputContains('[SNAPSHOT] Updating diffs');
     $this->assertProcessErrorOutputContains('[SNAPSHOT] Diffs updated');
 
-    // Verify diff file was created.
     $diff_file = $scenario_dir . DIRECTORY_SEPARATOR . 'file1.txt';
     $this->assertFileExists($diff_file);
     $diff_content = file_get_contents($diff_file);
@@ -154,7 +124,6 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
     $this->assertStringContainsString('-original line 1', $diff_content);
     $this->assertStringContainsString('+modified line 1', $diff_content);
 
-    // Run PHPUnit again without UPDATE_SNAPSHOTS - should now pass.
     $this->processRun(
       self::$root . '/vendor/bin/phpunit',
       ['--no-configuration', $test_class_file],
@@ -163,31 +132,23 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
     $this->assertProcessSuccessful();
   }
 
-  /**
-   * Test that snapshotUpdateOnFailure() does nothing without env variable.
-   */
   public function testNoUpdateWithoutEnvVariable(): void {
-    // Create the test structure.
     $test_dir = self::$sut . DIRECTORY_SEPARATOR . 'test_project_no_update';
     File::mkdir($test_dir);
 
-    // Create snapshots directory with baseline.
     $snapshots_dir = $test_dir . DIRECTORY_SEPARATOR . 'snapshots';
     $baseline_dir = $snapshots_dir . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR;
     File::mkdir($baseline_dir);
     file_put_contents($baseline_dir . DIRECTORY_SEPARATOR . 'file1.txt', "original content\n");
 
-    // Create actual output directory (different from baseline).
     $actual_dir = $test_dir . DIRECTORY_SEPARATOR . 'actual';
     File::mkdir($actual_dir);
     file_put_contents($actual_dir . DIRECTORY_SEPARATOR . 'file1.txt', "modified content\n");
 
-    // Create a temporary test class that uses the trait.
     $test_class_content = $this->createTestClass($baseline_dir, $actual_dir);
     $test_class_file = $test_dir . DIRECTORY_SEPARATOR . 'NoUpdateTest.php';
     file_put_contents($test_class_file, $test_class_content);
 
-    // Run PHPUnit multiple times without UPDATE_SNAPSHOTS.
     $this->processCwd = $test_dir;
 
     for ($i = 0; $i < 3; $i++) {
@@ -200,35 +161,26 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
       $this->assertProcessErrorOutputNotContains('[SNAPSHOT]');
     }
 
-    // Verify baseline is unchanged.
     $this->assertStringEqualsFile($baseline_dir . DIRECTORY_SEPARATOR . 'file1.txt', "original content\n");
   }
 
-  /**
-   * Test that non-snapshot failures don't trigger updates.
-   */
   public function testNoUpdateForNonSnapshotFailures(): void {
-    // Create the test structure.
     $test_dir = self::$sut . DIRECTORY_SEPARATOR . 'test_project_non_snapshot';
     File::mkdir($test_dir);
 
-    // Create snapshots directory with baseline.
     $snapshots_dir = $test_dir . DIRECTORY_SEPARATOR . 'snapshots';
     $baseline_dir = $snapshots_dir . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR;
     File::mkdir($baseline_dir);
     file_put_contents($baseline_dir . DIRECTORY_SEPARATOR . 'file1.txt', "content\n");
 
-    // Create actual output directory (same as baseline).
     $actual_dir = $test_dir . DIRECTORY_SEPARATOR . 'actual';
     File::mkdir($actual_dir);
     file_put_contents($actual_dir . DIRECTORY_SEPARATOR . 'file1.txt', "content\n");
 
-    // Create a test class that fails for a non-snapshot reason.
     $test_class_content = $this->createNonSnapshotFailingTestClass($baseline_dir, $actual_dir);
     $test_class_file = $test_dir . DIRECTORY_SEPARATOR . 'NonSnapshotFailTest.php';
     file_put_contents($test_class_file, $test_class_content);
 
-    // Run PHPUnit with UPDATE_SNAPSHOTS=1.
     $this->processCwd = $test_dir;
     $this->processRun(
       self::$root . '/vendor/bin/phpunit',
@@ -238,7 +190,6 @@ final class SnapshotTraitUpdateTest extends FunctionalTestCase {
     );
 
     $this->assertProcessFailed();
-    // Should not trigger snapshot update.
     $this->assertProcessErrorOutputNotContains('[SNAPSHOT]');
   }
 

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -222,9 +222,9 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertSame(2, $commit_count, 'Expected initial + update commit');
 
     // Assert: commit message contains "Updated".
-    $last_commit_msg = $this->getLastCommitMessage();
+    $last_commit_message = $this->getLastCommitMessage();
     $this->assertTrue(
-      str_contains($last_commit_msg, 'Updated baseline') || str_contains($last_commit_msg, 'Updated snapshots'),
+      str_contains($last_commit_message, 'Updated baseline') || str_contains($last_commit_message, 'Updated snapshots'),
       'Expected commit message containing "Updated"'
     );
 
@@ -355,9 +355,9 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertSame(2, $commit_count, 'Expected initial + update commit');
 
     // Assert: commit message contains "Updated".
-    $last_commit_msg = $this->getLastCommitMessage();
+    $last_commit_message = $this->getLastCommitMessage();
     $this->assertTrue(
-      str_contains($last_commit_msg, 'Updated baseline') || str_contains($last_commit_msg, 'Updated snapshots'),
+      str_contains($last_commit_message, 'Updated baseline') || str_contains($last_commit_message, 'Updated snapshots'),
       'Expected commit message containing "Updated"'
     );
 
@@ -620,8 +620,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $commit_count = $this->getCommitCount();
     $this->assertSame(2, $commit_count, 'Expected initial + update commit');
 
-    $last_commit_msg = $this->getLastCommitMessage();
-    $this->assertStringContainsString('Updated', $last_commit_msg);
+    $last_commit_message = $this->getLastCommitMessage();
+    $this->assertStringContainsString('Updated', $last_commit_message);
   }
 
   /**

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\Snapshot\Tests\Functional;
 
-use PHPUnit\Framework\Exception;
 use AlexSkrypnyk\File\File;
+use AlexSkrypnyk\Snapshot\Snapshot;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Exception;
 
 /**
  * Functional tests for the update-snapshots CLI script.
@@ -230,8 +231,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
     // Assert: baseline files match expected.
     $this->assertDirectoriesIdentical(
-      $this->fixturesDir . '/baseline_change/expected/_baseline',
-      $this->projectDir . '/tests/snapshots/_baseline'
+      $this->fixturesDir . '/baseline_change/expected/' . Snapshot::BASELINE_DIR,
+      $this->projectDir . '/tests/snapshots/' . Snapshot::BASELINE_DIR
     );
   }
 
@@ -311,8 +312,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
     // Assert: baseline files match expected (includes scenario_file.txt).
     $this->assertDirectoriesIdentical(
-      $this->fixturesDir . '/both_change/expected/_baseline',
-      $this->projectDir . '/tests/snapshots/_baseline'
+      $this->fixturesDir . '/both_change/expected/' . Snapshot::BASELINE_DIR,
+      $this->projectDir . '/tests/snapshots/' . Snapshot::BASELINE_DIR
     );
 
     // Assert: only 1 commit (initial - specified dataset mode doesn't commit).
@@ -363,8 +364,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
     // Assert: baseline files match expected (includes scenario_file.txt).
     $this->assertDirectoriesIdentical(
-      $this->fixturesDir . '/both_change/expected/_baseline',
-      $this->projectDir . '/tests/snapshots/_baseline'
+      $this->fixturesDir . '/both_change/expected/' . Snapshot::BASELINE_DIR,
+      $this->projectDir . '/tests/snapshots/' . Snapshot::BASELINE_DIR
     );
 
     // Assert: scenario1 should remain empty (just metadata files like .gitkeep
@@ -472,8 +473,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertSame(2, $commit_count, 'Expected initial + update commit');
 
     $this->assertDirectoriesIdentical(
-      $this->fixturesDir . '/baseline_change/expected/_baseline',
-      $this->projectDir . '/tests/snapshots/_baseline'
+      $this->fixturesDir . '/baseline_change/expected/' . Snapshot::BASELINE_DIR,
+      $this->projectDir . '/tests/snapshots/' . Snapshot::BASELINE_DIR
     );
   }
 
@@ -501,8 +502,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertSame(2, $commit_count, 'Expected initial + update commit');
 
     $this->assertDirectoriesIdentical(
-      $this->fixturesDir . '/both_change/expected/_baseline',
-      $this->projectDir . '/tests/snapshots/_baseline'
+      $this->fixturesDir . '/both_change/expected/' . Snapshot::BASELINE_DIR,
+      $this->projectDir . '/tests/snapshots/' . Snapshot::BASELINE_DIR
     );
 
     $scenario_path = $this->projectDir . '/tests/snapshots/scenario1';

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -21,19 +21,10 @@ use PHPUnit\Framework\Exception;
 #[CoversNothing]
 final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
-  /**
-   * Path to the update-snapshots script.
-   */
   protected string $scriptPath;
 
-  /**
-   * Path to the test project directory in $sut.
-   */
   protected string $projectDir;
 
-  /**
-   * Path to the functional_update fixtures.
-   */
   protected string $fixturesDir;
 
   /**
@@ -46,9 +37,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->fixturesDir = self::$fixtures . DIRECTORY_SEPARATOR . 'functional_update';
   }
 
-  /**
-   * Test that help is displayed with --help flag.
-   */
   public function testHelpFlag(): void {
     $this->processRun('php', [$this->scriptPath, '--help']);
 
@@ -66,9 +54,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessOutputContains('Examples:');
   }
 
-  /**
-   * Test that help is displayed with -h flag.
-   */
   public function testHelpShortFlag(): void {
     $this->processRun('php', [$this->scriptPath, '-h']);
 
@@ -76,9 +61,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessOutputContains('Update test snapshots');
   }
 
-  /**
-   * Test that error is shown when test-name argument is missing.
-   */
   public function testMissingTestNameArgument(): void {
     $this->processRun('php', [$this->scriptPath]);
 
@@ -86,9 +68,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessOutputContains('Missing required argument: <test-name>');
   }
 
-  /**
-   * Test that error is shown when snapshots-path argument is missing.
-   */
   public function testMissingSnapshotsPathArgument(): void {
     $this->processRun('php', [$this->scriptPath, 'testSomeMethod']);
 
@@ -96,9 +75,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessOutputContains('Missing required argument: <snapshots-path>');
   }
 
-  /**
-   * Test that error is shown when root directory does not exist.
-   */
   public function testInvalidRootDirectory(): void {
     $this->processRun('php', [
       $this->scriptPath,
@@ -111,9 +87,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessOutputContains('Root directory does not exist');
   }
 
-  /**
-   * Test that error is shown when PHPUnit is not found.
-   */
   public function testPhpunitNotFound(): void {
     $temp_dir = self::$sut . DIRECTORY_SEPARATOR . 'no_phpunit';
     File::mkdir($temp_dir);
@@ -129,9 +102,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessOutputContains('PHPUnit not found');
   }
 
-  /**
-   * Test that SCRIPT_QUIET environment variable suppresses output.
-   */
   public function testQuietMode(): void {
     $this->processRun(
       'php',
@@ -144,9 +114,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertEmpty($this->processGet()->getOutput());
   }
 
-  /**
-   * Test that script can be skipped with SCRIPT_RUN_SKIP environment variable.
-   */
   public function testSkipScript(): void {
     $this->processRun(
       'php',
@@ -170,7 +137,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   public function testNoChangeNoCommits(): void {
     $this->setupTestProject('no_change');
 
-    // Run update-snapshots for all datasets.
     $this->processRun('php', [
       $this->scriptPath,
       '--root=' . $this->projectDir,
@@ -180,12 +146,10 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'tests/snapshots',
     ]);
 
-    // Assert: datasets discovered, all pass.
     $this->assertProcessSuccessful();
     $this->assertProcessOutputContains('Discovering datasets');
     $this->assertProcessOutputContains('Found');
 
-    // Assert: only 1 commit (initial commit).
     $commit_count = $this->getCommitCount();
     $this->assertSame(1, $commit_count, 'Expected only initial commit');
   }
@@ -201,7 +165,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   public function testBaselineChangeCreatesCommit(): void {
     $this->setupTestProject('baseline_change');
 
-    // Run update-snapshots for all datasets.
     $this->processRun('php', [
       $this->scriptPath,
       '--root=' . $this->projectDir,
@@ -211,25 +174,21 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'tests/snapshots',
     ]);
 
-    // Assert: a successful update exits 0. Only genuine failures exit non-zero.
+    // A successful update exits 0. Only genuine failures exit non-zero.
     $this->assertProcessSuccessful();
 
-    // Assert: datasets discovered.
     $this->assertProcessOutputContains('Discovering datasets');
     $this->assertProcessOutputContains('Found');
 
-    // Assert: 2 commits (initial + update).
     $commit_count = $this->getCommitCount();
     $this->assertSame(2, $commit_count, 'Expected initial + update commit');
 
-    // Assert: commit message contains "Updated".
     $last_commit_message = $this->getLastCommitMessage();
     $this->assertTrue(
       str_contains($last_commit_message, 'Updated baseline') || str_contains($last_commit_message, 'Updated snapshots'),
       'Expected commit message containing "Updated"'
     );
 
-    // Assert: baseline files match expected.
     $this->assertDirectoriesIdentical(
       $this->fixturesDir . '/baseline_change/expected/' . Snapshot::BASELINE_DIR,
       $this->projectDir . '/tests/snapshots/' . Snapshot::BASELINE_DIR
@@ -248,8 +207,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   public function testScenarioChangeUpdatesFiles(): void {
     $this->setupTestProject('scenario_change');
 
-    // Run update-snapshots for ONLY scenario1 dataset.
-    // Specified dataset mode doesn't create commits.
     $this->processRun('php', [
       $this->scriptPath,
       '--root=' . $this->projectDir,
@@ -260,22 +217,18 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'scenario1',
     ]);
 
-    // Assert: a successful update exits 0 even in specified dataset mode.
+    // A successful update exits 0 even in specified dataset mode.
     $this->assertProcessSuccessful();
 
-    // Assert: specified dataset mode ran.
     $this->assertProcessOutputContains('Running 1 specified dataset(s)');
     $this->assertProcessOutputContains('scenario1');
 
-    // Assert: scenario diff file was created.
     $scenario_file = $this->projectDir . '/tests/snapshots/scenario1/scenario_file.txt';
     $this->assertFileExists($scenario_file);
 
-    // Assert: content matches expected.
     $expected_file = $this->fixturesDir . '/scenario_change/expected/scenario1/scenario_file.txt';
     $this->assertFileEquals($expected_file, $scenario_file);
 
-    // Assert: only 1 commit (initial - specified dataset mode doesn't commit).
     $commit_count = $this->getCommitCount();
     $this->assertSame(1, $commit_count, 'Specified dataset mode should not create commits');
   }
@@ -290,7 +243,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   public function testMultipleDatasetsUpdatesFiles(): void {
     $this->setupTestProject('both_change');
 
-    // Run update-snapshots for baseline AND scenario1 datasets.
     $this->processRun('php', [
       $this->scriptPath,
       '--root=' . $this->projectDir,
@@ -302,21 +254,18 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'scenario1',
     ]);
 
-    // Assert: a successful update exits 0 with multiple specified datasets.
+    // A successful update exits 0 with multiple specified datasets.
     $this->assertProcessSuccessful();
 
-    // Assert: both datasets were scanned.
     $this->assertProcessOutputContains('Running 2 specified dataset(s)');
     $this->assertProcessOutputContains('baseline');
     $this->assertProcessOutputContains('scenario1');
 
-    // Assert: baseline files match expected (includes scenario_file.txt).
     $this->assertDirectoriesIdentical(
       $this->fixturesDir . '/both_change/expected/' . Snapshot::BASELINE_DIR,
       $this->projectDir . '/tests/snapshots/' . Snapshot::BASELINE_DIR
     );
 
-    // Assert: only 1 commit (initial - specified dataset mode doesn't commit).
     $commit_count = $this->getCommitCount();
     $this->assertSame(1, $commit_count, 'Specified dataset mode should not create commits');
   }
@@ -333,7 +282,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   public function testBothChangeCreatesCommit(): void {
     $this->setupTestProject('both_change');
 
-    // Run update-snapshots for all datasets.
     $this->processRun('php', [
       $this->scriptPath,
       '--root=' . $this->projectDir,
@@ -343,33 +291,28 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'tests/snapshots',
     ]);
 
-    // Assert: a successful update exits 0 even when baseline and scenario both
-    // change.
+    // A successful update exits 0 even when baseline and scenario both change.
     $this->assertProcessSuccessful();
 
-    // Assert: datasets discovered.
     $this->assertProcessOutputContains('Discovering datasets');
     $this->assertProcessOutputContains('Found');
 
-    // Assert: 2 commits (initial + update, possibly amended).
     $commit_count = $this->getCommitCount();
     $this->assertSame(2, $commit_count, 'Expected initial + update commit');
 
-    // Assert: commit message contains "Updated".
     $last_commit_message = $this->getLastCommitMessage();
     $this->assertTrue(
       str_contains($last_commit_message, 'Updated baseline') || str_contains($last_commit_message, 'Updated snapshots'),
       'Expected commit message containing "Updated"'
     );
 
-    // Assert: baseline files match expected (includes scenario_file.txt).
     $this->assertDirectoriesIdentical(
       $this->fixturesDir . '/both_change/expected/' . Snapshot::BASELINE_DIR,
       $this->projectDir . '/tests/snapshots/' . Snapshot::BASELINE_DIR
     );
 
-    // Assert: scenario1 should remain empty (just metadata files like .gitkeep
-    // and .ignorecontent - no actual diff files).
+    // The scenario1 directory holds only metadata files (.gitkeep,
+    // .ignorecontent), no diff files.
     $scenario_path = $this->projectDir . '/tests/snapshots/scenario1';
     $scenario_files = array_diff(scandir($scenario_path), ['.', '..', '.gitkeep', '.ignorecontent']);
     $this->assertCount(0, $scenario_files, 'scenario1 should not contain any diff files');
@@ -405,8 +348,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
     $output = $this->processGet()->getOutput();
 
-    // The [SNAPSHOT] messages should appear in debug output, captured from
-    // PHPUnit's stderr pipe.
     $this->assertStringContainsString('[SNAPSHOT]', $output, 'stderr messages should be captured in debug output');
 
     // Stderr messages must not cause PHPUnit to wrap them as exceptions.
@@ -416,7 +357,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       'stderr messages should not cause PHPUnit framework exceptions'
     );
 
-    // Files must still be updated correctly despite stderr output.
     $scenario_file = $this->projectDir . '/tests/snapshots/scenario1/scenario_file.txt';
     $this->assertFileExists($scenario_file);
 
@@ -424,9 +364,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertFileEquals($expected_file, $scenario_file);
   }
 
-  /**
-   * Test no_change scenario works with parallel jobs.
-   */
   public function testNoChangeParallelJobs(): void {
     $this->setupTestProject('no_change');
 
@@ -449,9 +386,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertSame(1, $commit_count, 'Expected only initial commit');
   }
 
-  /**
-   * Test baseline_change scenario works with parallel jobs.
-   */
   public function testBaselineChangeParallelJobs(): void {
     $this->setupTestProject('baseline_change');
 
@@ -478,9 +412,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     );
   }
 
-  /**
-   * Test both_change scenario works with parallel jobs.
-   */
   public function testBothChangeParallelJobs(): void {
     $this->setupTestProject('both_change');
 
@@ -511,9 +442,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertCount(0, $scenario_files, 'scenario1 should not contain any diff files');
   }
 
-  /**
-   * Test that --jobs=1 works as sequential fallback.
-   */
   public function testJobsOneSequential(): void {
     $this->setupTestProject('no_change');
 
@@ -560,14 +488,10 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->assertProcessFailed();
     $this->assertProcessOutputContains('Some tests failed');
 
-    // No update commit should be created.
     $commit_count = $this->getCommitCount();
     $this->assertSame(1, $commit_count, 'Genuine failure should not create a commit');
   }
 
-  /**
-   * Test that a genuine failure in specified dataset mode exits non-zero.
-   */
   public function testGenuineFailureSpecifiedDatasetExitsNonZero(): void {
     $this->setupTestProject('genuine_failure');
 
@@ -614,10 +538,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     // A scenario updated in parallel is a success, not a failure.
     $this->assertProcessSuccessful();
 
-    // The stale diff file was removed by the update.
     $this->assertFileDoesNotExist($stale_file);
 
-    // The update was committed (initial + update).
     $commit_count = $this->getCommitCount();
     $this->assertSame(2, $commit_count, 'Expected initial + update commit');
 
@@ -632,11 +554,9 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
    *   Scenario name (no_change, baseline_change, scenario_change, both_change).
    */
   protected function setupTestProject(string $scenario): void {
-    // Copy complete scenario fixture to $sut.
     $scenario_dir = $this->fixturesDir . DIRECTORY_SEPARATOR . $scenario;
     File::copy($scenario_dir, $this->projectDir);
 
-    // Create vendor directory with symlinks to root's vendor.
     $vendor_dir = $this->projectDir . '/vendor';
     File::mkdir($vendor_dir . '/bin');
     symlink(
@@ -664,7 +584,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
       $vendor_dir . '/sebastian'
     );
 
-    // Initialize git repository.
     $this->processCwd = $this->projectDir;
     $this->processRun('git', ['init']);
     $this->processRun('git', ['config', 'user.email', 'test@test.com']);
@@ -673,18 +592,12 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->processRun('git', ['commit', '-m', 'Initial commit']);
   }
 
-  /**
-   * Get the number of commits in the test project.
-   */
   protected function getCommitCount(): int {
     $this->processCwd = $this->projectDir;
     $this->processRun('git', ['rev-list', '--count', 'HEAD']);
     return (int) trim($this->processGet()->getOutput());
   }
 
-  /**
-   * Get the last commit message in the test project.
-   */
   protected function getLastCommitMessage(): string {
     $this->processCwd = $this->projectDir;
     $this->processRun('git', ['log', '-1', '--format=%s']);

--- a/tests/phpunit/Unit/DiffTest.php
+++ b/tests/phpunit/Unit/DiffTest.php
@@ -195,7 +195,7 @@ final class DiffTest extends UnitTestCase {
     $diff->setRight($file_info2);
 
     $result = self::callProtectedMethod(Diff::class, 'doRender', [$diff]);
-    $this->assertEquals('test content', $result);
+    $this->assertSame('test content', $result);
 
     // Test with different content.
     file_put_contents($file_path1, "line1\n");
@@ -208,7 +208,7 @@ final class DiffTest extends UnitTestCase {
     $diff->setRight($file_info2);
 
     $result = self::callProtectedMethod(Diff::class, 'doRender', [$diff]);
-    assert(is_string($result));
+    $this->assertIsString($result);
     $this->assertStringContainsString('@@ -1 +1 @@', $result);
     $this->assertStringContainsString('-line1', $result);
     $this->assertStringContainsString('+line2', $result);

--- a/tests/phpunit/Unit/DiffTest.php
+++ b/tests/phpunit/Unit/DiffTest.php
@@ -172,7 +172,7 @@ final class DiffTest extends UnitTestCase {
     $this->assertSame('test content', $rendered);
 
     // Test with custom renderer.
-    $custom_renderer = (fn(Diff $diff, array $options = []): string => 'Custom rendered content');
+    $custom_renderer = fn(Diff $diff, array $options = []): string => 'Custom rendered content';
 
     $rendered = $diff->render([], $custom_renderer);
     $this->assertSame('Custom rendered content', $rendered);
@@ -276,6 +276,10 @@ final class DiffTest extends UnitTestCase {
   }
 
   public function testIsSameContentWithSymlinks(): void {
+    if (!function_exists('symlink')) {
+      $this->markTestSkipped('Symlinks are not supported on this system.');
+    }
+
     $diff = new Diff();
 
     $target_path = self::$sut . DIRECTORY_SEPARATOR . 'target.txt';
@@ -298,13 +302,17 @@ final class DiffTest extends UnitTestCase {
   }
 
   public function testIsSameContentSkipsSizeCheckForSymlinks(): void {
+    if (!function_exists('symlink')) {
+      $this->markTestSkipped('Symlinks are not supported on this system.');
+    }
+
     $diff = new Diff();
 
     // Create symlinks to directories (getSize() would fail).
     $dir1 = self::$sut . DIRECTORY_SEPARATOR . 'dir1';
     $dir2 = self::$sut . DIRECTORY_SEPARATOR . 'dir2';
-    mkdir($dir1);
-    mkdir($dir2);
+    mkdir($dir1, 0777, TRUE);
+    mkdir($dir2, 0777, TRUE);
 
     $link_path1 = self::$sut . DIRECTORY_SEPARATOR . 'link1';
     $link_path2 = self::$sut . DIRECTORY_SEPARATOR . 'link2';

--- a/tests/phpunit/Unit/DiffTest.php
+++ b/tests/phpunit/Unit/DiffTest.php
@@ -17,12 +17,12 @@ final class DiffTest extends UnitTestCase {
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($file_path, 'test content');
 
-    $file_info = new IndexedFile($file_path, self::$sut);
+    $indexed_file = new IndexedFile($file_path, self::$sut);
 
-    $result = $diff->setLeft($file_info);
+    $result = $diff->setLeft($indexed_file);
 
     $this->assertInstanceOf(Diff::class, $result);
-    $this->assertSame($file_info, $diff->getLeft());
+    $this->assertSame($indexed_file, $diff->getLeft());
   }
 
   public function testSetGetRight(): void {
@@ -30,12 +30,12 @@ final class DiffTest extends UnitTestCase {
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($file_path, 'test content');
 
-    $file_info = new IndexedFile($file_path, self::$sut);
+    $indexed_file = new IndexedFile($file_path, self::$sut);
 
-    $result = $diff->setRight($file_info);
+    $result = $diff->setRight($indexed_file);
 
     $this->assertInstanceOf(Diff::class, $result);
-    $this->assertSame($file_info, $diff->getRight());
+    $this->assertSame($indexed_file, $diff->getRight());
   }
 
   public function testExistsLeft(): void {
@@ -45,9 +45,9 @@ final class DiffTest extends UnitTestCase {
 
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($file_path, 'test content');
-    $file_info = new IndexedFile($file_path, self::$sut);
+    $indexed_file = new IndexedFile($file_path, self::$sut);
 
-    $diff->setLeft($file_info);
+    $diff->setLeft($indexed_file);
     $this->assertTrue($diff->existsLeft());
   }
 
@@ -58,9 +58,9 @@ final class DiffTest extends UnitTestCase {
 
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($file_path, 'test content');
-    $file_info = new IndexedFile($file_path, self::$sut);
+    $indexed_file = new IndexedFile($file_path, self::$sut);
 
-    $diff->setRight($file_info);
+    $diff->setRight($indexed_file);
     $this->assertTrue($diff->existsRight());
   }
 
@@ -73,14 +73,14 @@ final class DiffTest extends UnitTestCase {
     // Only left file set.
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($file_path, 'test content');
-    $file_info = new IndexedFile($file_path, self::$sut);
+    $indexed_file = new IndexedFile($file_path, self::$sut);
 
-    $diff->setLeft($file_info);
+    $diff->setLeft($indexed_file);
     $this->assertFalse($diff->isSameContent());
 
     // Reset and set only right file.
     $diff = new Diff();
-    $diff->setRight($file_info);
+    $diff->setRight($indexed_file);
     $this->assertFalse($diff->isSameContent());
   }
 
@@ -93,11 +93,11 @@ final class DiffTest extends UnitTestCase {
     file_put_contents($file_path1, 'test content');
     file_put_contents($file_path2, 'test content');
 
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     $this->assertTrue($diff->isSameContent());
   }
@@ -111,11 +111,11 @@ final class DiffTest extends UnitTestCase {
     file_put_contents($file_path1, 'test content 1');
     file_put_contents($file_path2, 'test content 2');
 
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     $this->assertFalse($diff->isSameContent());
   }
@@ -129,25 +129,25 @@ final class DiffTest extends UnitTestCase {
     file_put_contents($file_path1, 'test content 1');
     file_put_contents($file_path2, 'test content 2');
 
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
     // Set left file to ignore content.
-    $file_info1->setIgnoreContent(TRUE);
+    $indexed_file1->setIgnoreContent(TRUE);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     $this->assertTrue($diff->isSameContent());
 
     // Reset and set right file to ignore content.
     $diff = new Diff();
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
-    $file_info2->setIgnoreContent(TRUE);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file2->setIgnoreContent(TRUE);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     $this->assertTrue($diff->isSameContent());
   }
@@ -161,11 +161,11 @@ final class DiffTest extends UnitTestCase {
     file_put_contents($file_path1, 'test content');
     file_put_contents($file_path2, 'test content');
 
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     // Test with default renderer.
     $rendered = $diff->render();
@@ -188,11 +188,11 @@ final class DiffTest extends UnitTestCase {
     file_put_contents($file_path1, 'test content');
     file_put_contents($file_path2, 'test content');
 
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     $result = self::callProtectedMethod(Diff::class, 'doRender', [$diff]);
     $this->assertSame('test content', $result);
@@ -201,11 +201,11 @@ final class DiffTest extends UnitTestCase {
     file_put_contents($file_path1, "line1\n");
     file_put_contents($file_path2, "line2\n");
 
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     $result = self::callProtectedMethod(Diff::class, 'doRender', [$diff]);
     $this->assertIsString($result);
@@ -217,19 +217,19 @@ final class DiffTest extends UnitTestCase {
   public function testDoRenderWithAbsentSide(): void {
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'one-side.txt';
     file_put_contents($file_path, "one side line\n");
-    $file_info = new IndexedFile($file_path, self::$sut);
+    $indexed_file = new IndexedFile($file_path, self::$sut);
 
     // Absent left (an added file) renders as a pure addition instead of
     // throwing on the uninitialized side.
     $added = new Diff();
-    $added->setRight($file_info);
+    $added->setRight($indexed_file);
     $rendered_added = self::callProtectedMethod(Diff::class, 'doRender', [$added]);
     $this->assertIsString($rendered_added);
     $this->assertStringContainsString('+one side line', $rendered_added);
 
     // Absent right (a removed file) renders as a pure deletion.
     $removed = new Diff();
-    $removed->setLeft($file_info);
+    $removed->setLeft($indexed_file);
     $rendered_removed = self::callProtectedMethod(Diff::class, 'doRender', [$removed]);
     $this->assertIsString($rendered_removed);
     $this->assertStringContainsString('-one side line', $rendered_removed);
@@ -245,11 +245,11 @@ final class DiffTest extends UnitTestCase {
     file_put_contents($file_path1, 'short');
     file_put_contents($file_path2, 'much longer content');
 
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     // Should return FALSE without reading content (optimization).
     $this->assertFalse($diff->isSameContent(), 'Files with different sizes should not be same');
@@ -265,11 +265,11 @@ final class DiffTest extends UnitTestCase {
     file_put_contents($file_path1, 'abcde');
     file_put_contents($file_path2, 'fghij');
 
-    $file_info1 = new IndexedFile($file_path1, self::$sut);
-    $file_info2 = new IndexedFile($file_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($file_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     // Should return FALSE after checking hash.
     $this->assertFalse($diff->isSameContent(), 'Files with same size but different content should not be same');
@@ -287,11 +287,11 @@ final class DiffTest extends UnitTestCase {
     symlink($target_path, $link_path1);
     symlink($target_path, $link_path2);
 
-    $file_info1 = new IndexedFile($link_path1, self::$sut);
-    $file_info2 = new IndexedFile($link_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($link_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($link_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     // Should compare symlink targets correctly.
     $this->assertTrue($diff->isSameContent(), 'Symlinks with same targets should be same');
@@ -311,11 +311,11 @@ final class DiffTest extends UnitTestCase {
     symlink($dir1, $link_path1);
     symlink($dir2, $link_path2);
 
-    $file_info1 = new IndexedFile($link_path1, self::$sut);
-    $file_info2 = new IndexedFile($link_path2, self::$sut);
+    $indexed_file1 = new IndexedFile($link_path1, self::$sut);
+    $indexed_file2 = new IndexedFile($link_path2, self::$sut);
 
-    $diff->setLeft($file_info1);
-    $diff->setRight($file_info2);
+    $diff->setLeft($indexed_file1);
+    $diff->setRight($indexed_file2);
 
     // Should not throw exception from getSize() and compare by hash.
     $this->assertFalse($diff->isSameContent(), 'Symlinks to different directories should not be same');

--- a/tests/phpunit/Unit/DiffTest.php
+++ b/tests/phpunit/Unit/DiffTest.php
@@ -67,10 +67,8 @@ final class DiffTest extends UnitTestCase {
   public function testIsSameContentWhenMissingFiles(): void {
     $diff = new Diff();
 
-    // No files set.
     $this->assertFalse($diff->isSameContent());
 
-    // Only left file set.
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($file_path, 'test content');
     $indexed_file = new IndexedFile($file_path, self::$sut);
@@ -78,7 +76,6 @@ final class DiffTest extends UnitTestCase {
     $diff->setLeft($indexed_file);
     $this->assertFalse($diff->isSameContent());
 
-    // Reset and set only right file.
     $diff = new Diff();
     $diff->setRight($indexed_file);
     $this->assertFalse($diff->isSameContent());
@@ -132,7 +129,6 @@ final class DiffTest extends UnitTestCase {
     $indexed_file1 = new IndexedFile($file_path1, self::$sut);
     $indexed_file2 = new IndexedFile($file_path2, self::$sut);
 
-    // Set left file to ignore content.
     $indexed_file1->setIgnoreContent(TRUE);
 
     $diff->setLeft($indexed_file1);
@@ -140,7 +136,6 @@ final class DiffTest extends UnitTestCase {
 
     $this->assertTrue($diff->isSameContent());
 
-    // Reset and set right file to ignore content.
     $diff = new Diff();
     $indexed_file1 = new IndexedFile($file_path1, self::$sut);
     $indexed_file2 = new IndexedFile($file_path2, self::$sut);
@@ -167,11 +162,9 @@ final class DiffTest extends UnitTestCase {
     $diff->setLeft($indexed_file1);
     $diff->setRight($indexed_file2);
 
-    // Test with default renderer.
     $rendered = $diff->render();
     $this->assertSame('test content', $rendered);
 
-    // Test with custom renderer.
     $custom_renderer = fn(Diff $diff, array $options = []): string => 'Custom rendered content';
 
     $rendered = $diff->render([], $custom_renderer);
@@ -184,7 +177,6 @@ final class DiffTest extends UnitTestCase {
     $file_path1 = self::$sut . DIRECTORY_SEPARATOR . 'test1.txt';
     $file_path2 = self::$sut . DIRECTORY_SEPARATOR . 'test2.txt';
 
-    // Test with same content.
     file_put_contents($file_path1, 'test content');
     file_put_contents($file_path2, 'test content');
 
@@ -197,7 +189,6 @@ final class DiffTest extends UnitTestCase {
     $result = self::callProtectedMethod(Diff::class, 'doRender', [$diff]);
     $this->assertSame('test content', $result);
 
-    // Test with different content.
     file_put_contents($file_path1, "line1\n");
     file_put_contents($file_path2, "line2\n");
 
@@ -241,7 +232,6 @@ final class DiffTest extends UnitTestCase {
     $file_path1 = self::$sut . DIRECTORY_SEPARATOR . 'test1.txt';
     $file_path2 = self::$sut . DIRECTORY_SEPARATOR . 'test2.txt';
 
-    // Create files with different sizes.
     file_put_contents($file_path1, 'short');
     file_put_contents($file_path2, 'much longer content');
 
@@ -251,7 +241,7 @@ final class DiffTest extends UnitTestCase {
     $diff->setLeft($indexed_file1);
     $diff->setRight($indexed_file2);
 
-    // Should return FALSE without reading content (optimization).
+    // A size mismatch returns FALSE without reading content (optimization).
     $this->assertFalse($diff->isSameContent(), 'Files with different sizes should not be same');
   }
 
@@ -261,7 +251,6 @@ final class DiffTest extends UnitTestCase {
     $file_path1 = self::$sut . DIRECTORY_SEPARATOR . 'test1.txt';
     $file_path2 = self::$sut . DIRECTORY_SEPARATOR . 'test2.txt';
 
-    // Create files with same size but different content.
     file_put_contents($file_path1, 'abcde');
     file_put_contents($file_path2, 'fghij');
 
@@ -271,7 +260,7 @@ final class DiffTest extends UnitTestCase {
     $diff->setLeft($indexed_file1);
     $diff->setRight($indexed_file2);
 
-    // Should return FALSE after checking hash.
+    // The comparison returns FALSE after checking the hash.
     $this->assertFalse($diff->isSameContent(), 'Files with same size but different content should not be same');
   }
 
@@ -285,7 +274,6 @@ final class DiffTest extends UnitTestCase {
     $target_path = self::$sut . DIRECTORY_SEPARATOR . 'target.txt';
     file_put_contents($target_path, 'target content');
 
-    // Create two symlinks pointing to the same target.
     $link_path1 = self::$sut . DIRECTORY_SEPARATOR . 'link1.txt';
     $link_path2 = self::$sut . DIRECTORY_SEPARATOR . 'link2.txt';
     symlink($target_path, $link_path1);
@@ -297,7 +285,6 @@ final class DiffTest extends UnitTestCase {
     $diff->setLeft($indexed_file1);
     $diff->setRight($indexed_file2);
 
-    // Should compare symlink targets correctly.
     $this->assertTrue($diff->isSameContent(), 'Symlinks with same targets should be same');
   }
 

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -159,7 +159,6 @@ final class IndexTest extends UnitTestCase {
 
     $index = new Index($dir);
 
-    // Transforming through the callback must not corrupt the cached index.
     $index->getFiles(fn(IndexedFile $file): string => 'transformed:' . $file->getFilename());
 
     $this->assertContainsOnlyInstancesOf(IndexedFile::class, $index->getFiles());
@@ -189,8 +188,6 @@ final class IndexTest extends UnitTestCase {
     $dir = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal_advanced' . DIRECTORY_SEPARATOR . 'directory2');
 
     $before_match_content =
-        // Only include files containing the text "specific content"
-        // Skip files that don't contain the specific content.
         (fn(IndexedFile $file): bool => str_contains($file->getContent(), 'specific content'));
 
     $test_file = $dir . DIRECTORY_SEPARATOR . 'test_before_match.txt';
@@ -277,15 +274,13 @@ final class IndexTest extends UnitTestCase {
     $file1 = $test_dir . DIRECTORY_SEPARATOR . 'dir1' . DIRECTORY_SEPARATOR . 'file1.txt';
     file_put_contents($file1, 'Original file content');
 
-    // Create a symlink to the file.
     $symlink_file = $test_dir . DIRECTORY_SEPARATOR . 'symlink_file.txt';
     symlink($file1, $symlink_file);
 
-    // Create a symlink to the directory.
     $symlink_dir = $test_dir . DIRECTORY_SEPARATOR . 'symlink_dir';
     symlink($test_dir . DIRECTORY_SEPARATOR . 'dir1', $symlink_dir);
 
-    // Create a broken symlink to test handling of non-existent targets.
+    // A broken symlink covers handling of non-existent targets.
     $broken_symlink = $test_dir . DIRECTORY_SEPARATOR . 'broken_symlink';
     symlink($test_dir . DIRECTORY_SEPARATOR . 'nonexistent_file.txt', $broken_symlink);
 
@@ -298,22 +293,18 @@ final class IndexTest extends UnitTestCase {
 
       $this->assertArrayHasKey('symlink_dir', $files);
 
-      // Note: Whether a broken symlink is included depends on implementation
-      // details.
-      // So we don't test for its presence or absence here.
-      // The original file should be indexed through both the direct path and
-      // the symlink.
+      // Whether a broken symlink is included depends on implementation
+      // details, so neither its presence nor its absence is asserted here.
+      // The original file is indexed through both the direct path and the
+      // symlink.
       $this->assertArrayHasKey('dir1/file1.txt', $files);
 
-      // Verify that symlinked files have the correct content.
       $this->assertSame('Original file content', $files['dir1/file1.txt']->getContent());
 
-      // Check that symlinks are properly identified.
       $this->assertTrue($files['symlink_file.txt']->isLink());
       $this->assertTrue($files['symlink_dir']->isLink());
     }
     finally {
-      // Clean up.
       if (file_exists($symlink_file)) {
         unlink($symlink_file);
       }
@@ -354,7 +345,7 @@ final class IndexTest extends UnitTestCase {
     // Wildcard match.
     yield ['dir/file.txt', '*.txt', TRUE];
     yield ['dir/file.md', '*.txt', FALSE];
-    // Should not match nested paths.
+    // Nested paths do not match.
     yield ['dir/nested/file.txt', 'dir/*.txt', FALSE];
     // Pattern with a wildcard in the middle.
     yield ['dir/abc_file.txt', 'dir/abc_*.txt', TRUE];
@@ -368,11 +359,10 @@ final class IndexTest extends UnitTestCase {
   }
 
   public function testScanDirectorySkipLogic(): void {
-    // Create a test class that extends Index to override the iterator method.
     $test_class = new class($this->locationsTmp()) extends Index {
 
       protected function iterator(string $directory): \RecursiveIteratorIterator {
-        // Use SELF_FIRST to ensure directories are returned during iteration.
+        // SELF_FIRST makes the iterator return directories during iteration.
         return new \RecursiveIteratorIterator(
           new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
           \RecursiveIteratorIterator::SELF_FIRST
@@ -381,24 +371,20 @@ final class IndexTest extends UnitTestCase {
 
     };
 
-    // Create test directory structure.
     $test_dir = $this->locationsTmp() . DIRECTORY_SEPARATOR . 'test_dir_skip';
     File::mkdir($test_dir);
     File::mkdir($test_dir . DIRECTORY_SEPARATOR . 'sub_directory');
     file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'test_file.txt', 'content');
 
     try {
-      // Override the directory property using reflection.
       $reflection = new \ReflectionClass($test_class);
       $property = $reflection->getProperty('directory');
       $property->setValue($test_class, $test_dir);
 
       $files = $test_class->getFiles();
 
-      // The file should be included.
       $this->assertArrayHasKey('test_file.txt', $files);
 
-      // The directory should not be included (gets skipped).
       $this->assertArrayNotHasKey('sub_directory', $files);
     }
     finally {

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -26,7 +26,7 @@ final class IndexTest extends UnitTestCase {
     $index = new Index($dir, $rules, $before_match_content);
     $this->callProtectedMethod($index, 'scan');
 
-    $this->assertEquals($expected, array_keys($index->getFiles()));
+    $this->assertSame($expected, array_keys($index->getFiles()));
   }
 
   public static function dataProviderIndexScan(): \Iterator {

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -337,7 +337,7 @@ final class IndexTest extends UnitTestCase {
 
   #[DataProvider('dataProviderIsPathMatchesPattern')]
   public function testIsPathMatchesPattern(string $path, string $pattern, bool $expected): void {
-    $result = self::callProtectedMethod(Index::class, 'isPathMatchesPattern', [$path, $pattern]);
+    $result = self::callProtectedMethod(Index::class, 'pathMatchesPattern', [$path, $pattern]);
     $this->assertSame($expected, $result);
   }
 

--- a/tests/phpunit/Unit/IndexedFileTest.php
+++ b/tests/phpunit/Unit/IndexedFileTest.php
@@ -79,7 +79,7 @@ final class IndexedFileTest extends UnitTestCase {
     $indexed_file = new IndexedFile($file_path, self::$sut, $preset_content);
 
     $this->assertSame($expected, $indexed_file->getContent());
-    // Call twice to test caching.
+    // The second call covers caching.
     $this->assertSame($expected, $indexed_file->getContent());
   }
 
@@ -145,7 +145,6 @@ final class IndexedFileTest extends UnitTestCase {
     $indexed_file->setContent($new_content);
 
     if ($new_content === NULL) {
-      // When NULL, content loads from file.
       $this->assertSame($file_content, $indexed_file->getContent());
       $this->assertSame(sha1($file_content), $indexed_file->getHash());
     }
@@ -302,23 +301,22 @@ final class IndexedFileTest extends UnitTestCase {
 
     $indexed_file = new IndexedFile($file_path, self::$sut);
 
-    // Getting hash should also load content in a single read for small files.
+    // For small files, getHash() loads the content in a single read.
     $this->assertSame(sha1($content), $indexed_file->getHash());
-    // Content should already be available without a second file read.
+    // The content is then available without a second file read.
     $this->assertSame($content, $indexed_file->getContent());
   }
 
   public function testLargeFileStreamingHash(): void {
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'large_streaming.txt';
-    // Create a file larger than 1MB to trigger streaming hash path.
+    // A file over 1MB triggers the streaming hash path.
     $content = str_repeat('x', 1048577);
     file_put_contents($file_path, $content);
 
     $indexed_file = new IndexedFile($file_path, self::$sut);
 
-    // Hash should be computed via streaming (hashFile).
+    // The hash is computed via streaming (hashFile).
     $this->assertSame(sha1($content), $indexed_file->getHash());
-    // Content should still be loadable on demand.
     $this->assertSame($content, $indexed_file->getContent());
   }
 
@@ -329,14 +327,12 @@ final class IndexedFileTest extends UnitTestCase {
 
     $indexed_file = new IndexedFile($file_path, self::$sut);
 
-    // After getHash(), content should remain NULL for large files (streaming).
+    // After getHash(), content remains NULL for large files (streaming).
     $indexed_file->getHash();
 
-    // Use reflection to check that content is NULL after hash-only access.
     $reflection = new \ReflectionProperty($indexed_file, 'content');
     $this->assertNull($reflection->getValue($indexed_file), 'Large file content should remain NULL after hash-only access');
 
-    // But getContent() should still return the content when explicitly called.
     $this->assertSame($content, $indexed_file->getContent());
   }
 

--- a/tests/phpunit/Unit/PatchExceptionTest.php
+++ b/tests/phpunit/Unit/PatchExceptionTest.php
@@ -14,13 +14,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 final class PatchExceptionTest extends UnitTestCase {
 
   #[DataProvider('dataProviderMessageFormatting')]
-  public function testMessageFormatting(
-    string $message,
-    ?string $file_path,
-    int|string|null $line_number,
-    ?string $line_content,
-    string $expected_message,
-  ): void {
+  public function testMessageFormatting(string $message, ?string $file_path, int|string|null $line_number, ?string $line_content, string $expected_message): void {
     $exception = new PatchException($message, $file_path, $line_number, $line_content);
     $this->assertSame($expected_message, $exception->getMessage());
   }
@@ -117,12 +111,7 @@ final class PatchExceptionTest extends UnitTestCase {
     $line_number = 42;
     $line_content = 'Line content';
 
-    $exception = new PatchException(
-      'Test message',
-      $file_path,
-      $line_number,
-      $line_content
-    );
+    $exception = new PatchException('Test message', $file_path, $line_number, $line_content);
 
     $this->assertSame($file_path, $exception->getFilePath());
     $this->assertSame($line_number, $exception->getLineNumber());

--- a/tests/phpunit/Unit/PatcherTest.php
+++ b/tests/phpunit/Unit/PatcherTest.php
@@ -34,7 +34,7 @@ final class PatcherTest extends UnitTestCase {
       file_put_contents($file_path, "Some content\n@@ -1,1 +1,1 @@\n");
     }
     else {
-      file_put_contents($file_path, "Some content without patch markers");
+      file_put_contents($file_path, 'Some content without patch markers');
     }
 
     $result = Patcher::isPatchFile($file_path);
@@ -67,7 +67,7 @@ final class PatcherTest extends UnitTestCase {
   }
 
   public function testAddPatchFileInvalid(): void {
-    $content = "Not a patch file";
+    $content = 'Not a patch file';
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'not_a_patch.txt';
     file_put_contents($file_path, $content);
 
@@ -92,7 +92,7 @@ final class PatcherTest extends UnitTestCase {
     $result1 = $patcher->addDiff($diff_string, 'test.txt');
     $this->assertInstanceOf(Patcher::class, $result1);
 
-    $diff_array = ["@@ -1,1 +1,1 @@", "-old line", "+new line"];
+    $diff_array = ['@@ -1,1 +1,1 @@', '-old line', '+new line'];
     $result2 = $patcher->addDiff($diff_array, 'test2.txt');
     $this->assertInstanceOf(Patcher::class, $result2);
   }
@@ -141,11 +141,11 @@ final class PatcherTest extends UnitTestCase {
 
   public function testFindHunk(): void {
     $lines = [
-      "@@ -1,3 +1,3 @@",
-      " line1",
-      "-line2",
-      "+new line 2",
-      " line3",
+      '@@ -1,3 +1,3 @@',
+      ' line1',
+      '-line2',
+      '+new line 2',
+      ' line3',
     ];
     reset($lines);
 
@@ -159,11 +159,11 @@ final class PatcherTest extends UnitTestCase {
       'dst_size' => 3,
     ];
     $this->assertEquals($expected, $result);
-    $this->assertSame(" line1", current($lines));
+    $this->assertSame(' line1', current($lines));
   }
 
   public function testFindHunkNull(): void {
-    $lines = ["Not a hunk header"];
+    $lines = ['Not a hunk header'];
     reset($lines);
 
     $patcher = new Patcher(self::$sut, self::$sut);
@@ -173,7 +173,7 @@ final class PatcherTest extends UnitTestCase {
   }
 
   public function testFindHunkUnexpectedEof(): void {
-    $lines = ["@@ -1,3 +1,3 @@"];
+    $lines = ['@@ -1,3 +1,3 @@'];
     reset($lines);
 
     $patcher = new Patcher(self::$sut, self::$sut);
@@ -193,10 +193,10 @@ final class PatcherTest extends UnitTestCase {
     file_put_contents($source_file, "line1\nline2\nline3\n");
 
     $diff = [
-      " line1",
-      "-line2",
-      "+new line 2",
-      " line3",
+      ' line1',
+      '-line2',
+      '+new line 2',
+      ' line3',
     ];
     reset($diff);
 
@@ -233,10 +233,10 @@ final class PatcherTest extends UnitTestCase {
     file_put_contents($source_file, "line1\nline2\nline3");
 
     $diff = [
-      " line1",
-      "-line2",
-      "+new line 2",
-      " line3",
+      ' line1',
+      '-line2',
+      '+new line 2',
+      ' line3',
       "\\ No newline at end of file",
     ];
     reset($diff);
@@ -275,10 +275,10 @@ final class PatcherTest extends UnitTestCase {
     file_put_contents($source_file, $content);
 
     $diff = [
-      " line1",
-      "-line2",
-      "+new line 2",
-      " line3",
+      ' line1',
+      '-line2',
+      '+new line 2',
+      ' line3',
     ];
     reset($diff);
 
@@ -313,8 +313,8 @@ final class PatcherTest extends UnitTestCase {
     file_put_contents($source_file, "line1\nline2\nline3\n");
 
     $diff = [
-      " line1",
-      "-line2",
+      ' line1',
+      '-line2',
     ];
     reset($diff);
 
@@ -373,10 +373,10 @@ final class PatcherTest extends UnitTestCase {
 
     // Create a diff with too many removal lines.
     $diff = [
-      " line1",
-      "-line2",
-      "-extra removal line",
-      " line3",
+      ' line1',
+      '-line2',
+      '-extra removal line',
+      ' line3',
     ];
     reset($diff);
 
@@ -422,10 +422,10 @@ final class PatcherTest extends UnitTestCase {
 
     // Create a diff with too many addition lines.
     $diff = [
-      " line1",
-      "+new line",
-      "+extra addition line",
-      " line3",
+      ' line1',
+      '+new line',
+      '+extra addition line',
+      ' line3',
     ];
     reset($diff);
 
@@ -500,11 +500,11 @@ final class PatcherTest extends UnitTestCase {
     // Create a diff where "No newline at end of file" appears during
     // processing.
     $diff = [
-      " line1",
+      ' line1',
       "\\ No newline at end of file",
-      "-line2",
-      "+new line 2",
-      " line3",
+      '-line2',
+      '+new line 2',
+      ' line3',
     ];
     reset($diff);
 

--- a/tests/phpunit/Unit/PatcherTest.php
+++ b/tests/phpunit/Unit/PatcherTest.php
@@ -342,21 +342,21 @@ final class PatcherTest extends UnitTestCase {
   public function testUpdateDestinations(): void {
     $patcher = new Patcher(self::$sut, self::$sut);
 
-    $dest_file1 = self::$sut . DIRECTORY_SEPARATOR . 'file1.txt';
-    $dest_file2 = self::$sut . DIRECTORY_SEPARATOR . 'file2.txt';
+    $dst_file1 = self::$sut . DIRECTORY_SEPARATOR . 'file1.txt';
+    $dst_file2 = self::$sut . DIRECTORY_SEPARATOR . 'file2.txt';
 
     self::setProtectedValue($patcher, 'dstLines', [
-      $dest_file1 => ['line1', 'line2'],
-      $dest_file2 => ['line3', 'line4'],
+      $dst_file1 => ['line1', 'line2'],
+      $dst_file2 => ['line3', 'line4'],
     ]);
 
     $result = self::callProtectedMethod($patcher, 'updateDestinations', []);
 
     $this->assertSame(2, $result);
-    $this->assertFileExists($dest_file1);
-    $this->assertFileExists($dest_file2);
-    $this->assertSame("line1\nline2", file_get_contents($dest_file1));
-    $this->assertSame("line3\nline4", file_get_contents($dest_file2));
+    $this->assertFileExists($dst_file1);
+    $this->assertFileExists($dst_file2);
+    $this->assertSame("line1\nline2", file_get_contents($dst_file1));
+    $this->assertSame("line3\nline4", file_get_contents($dst_file2));
   }
 
   /**

--- a/tests/phpunit/Unit/PatcherTest.php
+++ b/tests/phpunit/Unit/PatcherTest.php
@@ -54,11 +54,7 @@ final class PatcherTest extends UnitTestCase {
     $patch_file_path = self::$sut . DIRECTORY_SEPARATOR . 'test.patch';
     file_put_contents($patch_file_path, $patch_content);
 
-    $file_info = new IndexedFile(
-      $patch_file_path,
-      '',
-      ''
-    );
+    $file_info = new IndexedFile($patch_file_path, '', '');
 
     $patcher = new Patcher(self::$sut, self::$sut);
     $result = $patcher->addPatchFile($file_info);
@@ -71,11 +67,7 @@ final class PatcherTest extends UnitTestCase {
     $file_path = self::$sut . DIRECTORY_SEPARATOR . 'not_a_patch.txt';
     file_put_contents($file_path, $content);
 
-    $file_info = new IndexedFile(
-      $file_path,
-      '',
-      ''
-    );
+    $file_info = new IndexedFile($file_path, '', '');
 
     $patcher = new Patcher(self::$sut, self::$sut);
 
@@ -466,12 +458,7 @@ final class PatcherTest extends UnitTestCase {
     $line_number = 42;
     $line_content = 'Test line content';
 
-    $exception = new PatchException(
-      $message,
-      $file_path,
-      $line_number,
-      $line_content
-    );
+    $exception = new PatchException($message, $file_path, $line_number, $line_content);
 
     // Test getters.
     $this->assertSame($file_path, $exception->getFilePath());

--- a/tests/phpunit/Unit/PatcherTest.php
+++ b/tests/phpunit/Unit/PatcherTest.php
@@ -63,7 +63,7 @@ final class PatcherTest extends UnitTestCase {
     $patcher = new Patcher(self::$sut, self::$sut);
     $result = $patcher->addPatchFile($file_info);
 
-    $this->assertInstanceOf(Patcher::class, $result);
+    $this->assertSame($patcher, $result);
   }
 
   public function testAddPatchFileInvalid(): void {
@@ -90,11 +90,11 @@ final class PatcherTest extends UnitTestCase {
 
     $diff_string = "@@ -1,1 +1,1 @@\n-old line\n+new line\n";
     $result1 = $patcher->addDiff($diff_string, 'test.txt');
-    $this->assertInstanceOf(Patcher::class, $result1);
+    $this->assertSame($patcher, $result1);
 
     $diff_array = ['@@ -1,1 +1,1 @@', '-old line', '+new line'];
     $result2 = $patcher->addDiff($diff_array, 'test2.txt');
-    $this->assertInstanceOf(Patcher::class, $result2);
+    $this->assertSame($patcher, $result2);
   }
 
   public function testSplitLines(): void {
@@ -103,18 +103,18 @@ final class PatcherTest extends UnitTestCase {
     $result = self::callProtectedMethod(Patcher::class, 'splitLines', [$content]);
 
     $expected = ['line1', 'line2', 'line3', 'line4'];
-    $this->assertEquals($expected, $result);
+    $this->assertSame($expected, $result);
   }
 
   public function testSplitLinesEdgeCases(): void {
     $result1 = self::callProtectedMethod(Patcher::class, 'splitLines', ['']);
-    $this->assertEquals([''], $result1);
+    $this->assertSame([''], $result1);
 
     $result2 = self::callProtectedMethod(Patcher::class, 'splitLines', ['single line']);
-    $this->assertEquals(['single line'], $result2);
+    $this->assertSame(['single line'], $result2);
 
     $result3 = self::callProtectedMethod(Patcher::class, 'splitLines', ["\n\n\n"]);
-    $this->assertEquals(['', '', '', ''], $result3);
+    $this->assertSame(['', '', '', ''], $result3);
   }
 
   public function testFilePatch(): void {
@@ -158,7 +158,7 @@ final class PatcherTest extends UnitTestCase {
       'dst_idx' => 1,
       'dst_size' => 3,
     ];
-    $this->assertEquals($expected, $result);
+    $this->assertSame($expected, $result);
     $this->assertSame(' line1', current($lines));
   }
 
@@ -293,7 +293,7 @@ final class PatcherTest extends UnitTestCase {
     $dst_file = $dest_dir . DIRECTORY_SEPARATOR . 'test.txt';
 
     $this->expectException(PatchException::class);
-    $this->expectExceptionMessageMatches('/Source file verification failed/');
+    $this->expectExceptionMessage('Source file verification failed');
 
     self::callProtectedMethod($patcher, 'applyHunk', [
       &$diff,
@@ -329,7 +329,7 @@ final class PatcherTest extends UnitTestCase {
     $dst_file = $dest_dir . DIRECTORY_SEPARATOR . 'test.txt';
 
     $this->expectException(PatchException::class);
-    $this->expectExceptionMessageMatches('/Hunk mismatch/');
+    $this->expectExceptionMessage('Hunk mismatch');
 
     self::callProtectedMethod($patcher, 'applyHunk', [
       &$diff,
@@ -352,7 +352,7 @@ final class PatcherTest extends UnitTestCase {
 
     $result = self::callProtectedMethod($patcher, 'updateDestinations', []);
 
-    $this->assertEquals(2, $result);
+    $this->assertSame(2, $result);
     $this->assertFileExists($dest_file1);
     $this->assertFileExists($dest_file2);
     $this->assertSame("line1\nline2", file_get_contents($dest_file1));

--- a/tests/phpunit/Unit/PatcherTest.php
+++ b/tests/phpunit/Unit/PatcherTest.php
@@ -351,9 +351,6 @@ final class PatcherTest extends UnitTestCase {
     $this->assertSame("line3\nline4", file_get_contents($dst_file2));
   }
 
-  /**
-   * Tests the unexpected removal line exception.
-   */
   public function testUnexpectedRemovalLine(): void {
     $source_dir = self::$sut . DIRECTORY_SEPARATOR . 'source';
     $dest_dir = self::$sut . DIRECTORY_SEPARATOR . 'dest';
@@ -363,7 +360,6 @@ final class PatcherTest extends UnitTestCase {
     $source_file = $source_dir . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($source_file, "line1\nline2\nline3\n");
 
-    // Create a diff with too many removal lines.
     $diff = [
       ' line1',
       '-line2',
@@ -374,7 +370,7 @@ final class PatcherTest extends UnitTestCase {
 
     $info = [
       'src_idx' => 1,
-      // Source size is only 2, but we're trying to remove 3 lines.
+      // Source size is only 2, but the hunk removes 3 lines.
       'src_size' => 2,
       'dst_idx' => 1,
       'dst_size' => 2,
@@ -400,9 +396,6 @@ final class PatcherTest extends UnitTestCase {
     }
   }
 
-  /**
-   * Tests the unexpected addition line exception.
-   */
   public function testUnexpectedAdditionLine(): void {
     $source_dir = self::$sut . DIRECTORY_SEPARATOR . 'source';
     $dest_dir = self::$sut . DIRECTORY_SEPARATOR . 'dest';
@@ -412,7 +405,6 @@ final class PatcherTest extends UnitTestCase {
     $source_file = $source_dir . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($source_file, "line1\nline2\nline3\n");
 
-    // Create a diff with too many addition lines.
     $diff = [
       ' line1',
       '+new line',
@@ -425,7 +417,7 @@ final class PatcherTest extends UnitTestCase {
       'src_idx' => 1,
       'src_size' => 2,
       'dst_idx' => 1,
-      // Destination size is only 2, but we're trying to add 3 lines.
+      // Destination size is only 2, but the hunk adds 3 lines.
       'dst_size' => 2,
     ];
 
@@ -449,9 +441,6 @@ final class PatcherTest extends UnitTestCase {
     }
   }
 
-  /**
-   * Tests PatchException constructor and properties.
-   */
   public function testPatchExceptionProperties(): void {
     $message = 'Test message';
     $file_path = '/path/to/file.txt';
@@ -460,21 +449,16 @@ final class PatcherTest extends UnitTestCase {
 
     $exception = new PatchException($message, $file_path, $line_number, $line_content);
 
-    // Test getters.
     $this->assertSame($file_path, $exception->getFilePath());
     $this->assertSame($line_number, $exception->getLineNumber());
     $this->assertSame($line_content, $exception->getLineContent());
 
-    // Test message formatting.
     $this->assertStringContainsString($message, $exception->getMessage());
     $this->assertStringContainsString($file_path, $exception->getMessage());
     $this->assertStringContainsString((string) $line_number, $exception->getMessage());
     $this->assertStringContainsString($line_content, $exception->getMessage());
   }
 
-  /**
-   * Test applying hunk with "No newline at end of file" line in the middle.
-   */
   public function testApplyHunkWithNoNewlineInMiddle(): void {
     $source_dir = self::$sut . DIRECTORY_SEPARATOR . 'source';
     $dest_dir = self::$sut . DIRECTORY_SEPARATOR . 'dest';
@@ -484,8 +468,6 @@ final class PatcherTest extends UnitTestCase {
     $source_file = $source_dir . DIRECTORY_SEPARATOR . 'test.txt';
     file_put_contents($source_file, "line1\nline2\nline3\n");
 
-    // Create a diff where "No newline at end of file" appears during
-    // processing.
     $diff = [
       ' line1',
       "\\ No newline at end of file",

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -19,7 +19,7 @@ final class RulesTest extends UnitTestCase {
   #[DataProvider('dataProviderRulesFromFile')]
   public function testRulesFromFile(?string $content, array $expected): void {
     $file = self::$sut . DIRECTORY_SEPARATOR . 'test.txt';
-    if (!is_null($content)) {
+    if ($content !== NULL) {
       file_put_contents($file, $content);
     }
     else {

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -128,7 +128,6 @@ final class RulesTest extends UnitTestCase {
   }
 
   public function testParseMethodChaining(): void {
-    // Test chained parse calls.
     $rules = new Rules();
     $result = $rules->parse('!include-rule')
       ->parse('^ignore-content-rule')
@@ -157,7 +156,6 @@ final class RulesTest extends UnitTestCase {
   }
 
   public function testAddMethodChaining(): void {
-    // Test method chaining.
     $rules = new Rules();
     $result = $rules->addIgnoreContent('pattern1')
       ->addSkip('pattern2')
@@ -172,8 +170,8 @@ final class RulesTest extends UnitTestCase {
   }
 
   public function testFromFileReadException(): void {
-    // Since system permission changes might not work in all test environments,
-    // let's use a mock to simulate a file read exception.
+    // System permission changes might not work in all test environments,
+    // so a mock simulates the file read exception.
     $rules_class = new class() extends Rules {
 
       public static function fromFile(string $file): Rules {
@@ -188,7 +186,6 @@ final class RulesTest extends UnitTestCase {
   }
 
   public function testCustomRulesImport(): void {
-    // Create a test rules file with all types of patterns.
     $rules_file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('rules_test_', TRUE) . '.txt';
     $content = <<<EOT
 # This is a comment
@@ -201,17 +198,14 @@ EOT;
     file_put_contents($rules_file, $content);
 
     try {
-      // Test loading from file.
       $rules = Rules::fromFile($rules_file);
 
-      // Check all the rules were loaded correctly.
       $this->assertSame(['include-pattern', 'include-ignore-content-pattern'], $rules->getInclude());
       $this->assertSame(['ignore-content-pattern'], $rules->getIgnoreContent());
       $this->assertSame(['global-pattern'], $rules->getGlobal());
       $this->assertSame(['path/to/file.txt'], $rules->getSkip());
     }
     finally {
-      // Clean up.
       if (file_exists($rules_file)) {
         unlink($rules_file);
       }

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -61,7 +61,7 @@ final class RulesTest extends UnitTestCase {
       ] + $default,
     ];
     yield 'ignore content rules' => [
-      "^ignore-content",
+      '^ignore-content',
       [
         'content' => ['ignore-content'],
       ] + $default,
@@ -120,9 +120,9 @@ final class RulesTest extends UnitTestCase {
 
   public static function dataProviderParseEdgeCases(): \Iterator {
     yield 'empty lines and whitespace' => ["\n  \n\t\n", [], [], [], []];
-    yield 'special characters in include rule' => ["!special@chars", ["special@chars"], [], [], []];
-    yield 'regex special characters as global rule' => ["[regex].special+chars?{test}", [], [], ["[regex].special+chars?{test}"], []];
-    yield 'very long pattern' => [str_repeat("a", 1000), [], [], [str_repeat("a", 1000)], []];
+    yield 'special characters in include rule' => ['!special@chars', ['special@chars'], [], [], []];
+    yield 'regex special characters as global rule' => ['[regex].special+chars?{test}', [], [], ['[regex].special+chars?{test}'], []];
+    yield 'very long pattern' => [str_repeat('a', 1000), [], [], [str_repeat('a', 1000)], []];
     yield 'lone negation prefix is ignored' => ['!', [], [], [], []];
     yield 'negation of content marker only is ignored' => ['!^', [], [], [], []];
   }
@@ -130,10 +130,10 @@ final class RulesTest extends UnitTestCase {
   public function testParseMethodChaining(): void {
     // Test chained parse calls.
     $rules = new Rules();
-    $result = $rules->parse("!include-rule")
-      ->parse("^ignore-content-rule")
-      ->parse("global-rule")
-      ->parse("some/path/");
+    $result = $rules->parse('!include-rule')
+      ->parse('^ignore-content-rule')
+      ->parse('global-rule')
+      ->parse('some/path/');
 
     $this->assertSame($rules, $result);
     $this->assertSame(['include-rule'], $rules->getInclude());

--- a/tests/phpunit/Unit/SnapshotAssertionsTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotAssertionsTraitTest.php
@@ -38,7 +38,7 @@ final class SnapshotAssertionsTraitTest extends TestCase {
 
   protected function tearDown(): void {
     if (is_dir($this->tmpDir)) {
-      File::remove($this->tmpDir);
+      File::rmdir($this->tmpDir);
     }
   }
 

--- a/tests/phpunit/Unit/SnapshotAssertionsTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotAssertionsTraitTest.php
@@ -215,7 +215,7 @@ final class SnapshotAssertionsTraitTest extends TestCase {
     // Create a patch file with unexpected EOF.
     mkdir($this->diffDir, 0777, TRUE);
     // Missing the content completely.
-    $diff_content = "@@ -1,3 +1,3 @@";
+    $diff_content = '@@ -1,3 +1,3 @@';
     file_put_contents($this->diffDir . DIRECTORY_SEPARATOR . 'file1.txt', $diff_content);
 
     mkdir($this->actualDir, 0777, TRUE);

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -123,10 +123,9 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $builder = SnapshotBuilder::create();
     $result = $builder->diff($baseline, $dst, self::$sut);
 
-    // Verify fluent return.
     $this->assertSame($builder, $result);
 
-    // No diff should be generated for equal directories.
+    // Equal directories generate no diff.
     $files = glob(self::$sut . '/*');
     $this->assertEmpty($files);
   }
@@ -139,7 +138,6 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $builder = SnapshotBuilder::create();
     $result = $builder->patch($baseline, $diff, self::$sut);
 
-    // Verify fluent return.
     $this->assertSame($builder, $result);
 
     $this->assertDirectoriesIdentical($expected, self::$sut);
@@ -154,7 +152,6 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $builder = SnapshotBuilder::create();
     $result = $builder->sync($src, self::$sut);
 
-    // Verify fluent return.
     $this->assertSame($builder, $result);
 
     $this->assertDirectoriesIdentical($expected, self::$sut);
@@ -207,7 +204,6 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $dir1 = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . 'directory1');
     $dir2 = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . 'directory2');
 
-    // Create builder once, use multiple times.
     $builder = SnapshotBuilder::create()->withRules(Rules::phpProject());
 
     $index = $builder->scan($src);

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -61,7 +61,7 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $this->assertSame(['important.log'], $rules->getInclude());
   }
 
-  public function testFluentChaining(): void {
+  public function testFluentMethodChaining(): void {
     $builder = SnapshotBuilder::create()
       ->withRules(Rules::phpProject())
       ->addSkip('custom/')

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -66,7 +66,7 @@ final class SnapshotBuilderTest extends UnitTestCase {
       ->withRules(Rules::phpProject())
       ->addSkip('custom/')
       ->addIgnoreContent('custom.lock')
-      ->withContentProcessor(fn($c) => $c);
+      ->withContentProcessor(fn(string $content): string => $content);
 
     $rules = $builder->getRules();
     $this->assertInstanceOf(Rules::class, $rules);
@@ -117,7 +117,7 @@ final class SnapshotBuilderTest extends UnitTestCase {
   }
 
   public function testDiff(): void {
-    $baseline = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . '/../baseline');
+    $baseline = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'baseline');
     $dst = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . 'result');
 
     $builder = SnapshotBuilder::create();

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -298,7 +298,6 @@ ABSENT,
 
     Snapshot::patch($baseline, $diff, self::$sut, $processor);
 
-    // Verify content was actually modified on disk.
     $files = File::scandir(self::$sut);
     $modified = FALSE;
     foreach ($files as $file_path) {
@@ -311,7 +310,6 @@ ABSENT,
   }
 
   public function testGetBaselinePath(): void {
-    // Create the baseline directory structure.
     $parent = self::$sut;
     $baseline_dir = $parent . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR;
     $snapshot_dir = $parent . DIRECTORY_SEPARATOR . 'snapshot';
@@ -347,7 +345,7 @@ ABSENT,
     $rules = Rules::create();
     Snapshot::diff($baseline, $dst, self::$sut, $rules);
 
-    // No diff should be generated for equal directories.
+    // Equal directories generate no diff.
     $files = glob(self::$sut . '/*');
     $this->assertEmpty($files);
   }
@@ -374,12 +372,12 @@ ABSENT,
 
     $comparer = Snapshot::compare($dir1, $dir2);
 
-    // First call - should be empty (directories are identical).
+    // The directories are identical, so the first call returns empty results.
     $this->assertEmpty($comparer->getAbsentLeftDiffs());
     $this->assertEmpty($comparer->getAbsentRightDiffs());
     $this->assertEmpty($comparer->getContentDiffs());
 
-    // Second call - should return same cached results.
+    // The second call returns the same cached results.
     $this->assertEmpty($comparer->getAbsentLeftDiffs());
     $this->assertEmpty($comparer->getContentDiffs());
   }
@@ -395,16 +393,15 @@ ABSENT,
 
     $comparer = Snapshot::compare($dir1, $dir2);
 
-    // Populate cache.
+    // The first read populates the cache.
     $this->assertEmpty($comparer->getAbsentLeftDiffs());
 
-    // Add a new file to the left side - this should invalidate cache.
+    // Adding a file to the left side invalidates the cache.
     $new_file_path = $dir1 . DIRECTORY_SEPARATOR . 'f2.txt';
     file_put_contents($new_file_path, 'new content');
     $new_file = new IndexedFile($new_file_path, $dir1);
     $comparer->addLeftFile($new_file);
 
-    // Cache should be invalidated - absent right should now include f2.txt.
     $absent_right = $comparer->getAbsentRightDiffs();
     $this->assertArrayHasKey('f2.txt', $absent_right);
   }
@@ -435,7 +432,6 @@ ABSENT,
     $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
     mkdir($src, 0777, TRUE);
 
-    // Create various file types.
     file_put_contents($src . DIRECTORY_SEPARATOR . 'regular.txt', 'regular content');
     mkdir($src . DIRECTORY_SEPARATOR . 'subdir', 0777, TRUE);
     file_put_contents($src . DIRECTORY_SEPARATOR . 'subdir' . DIRECTORY_SEPARATOR . 'nested.txt', 'nested content');
@@ -443,7 +439,6 @@ ABSENT,
 
     Snapshot::sync($src, $dst);
 
-    // Verify all files were copied correctly.
     $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'regular.txt');
     $this->assertSame('regular content', file_get_contents($dst . DIRECTORY_SEPARATOR . 'regular.txt'));
     $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'subdir' . DIRECTORY_SEPARATOR . 'nested.txt');

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -39,9 +39,9 @@ final class SnapshotTest extends UnitTestCase {
       'dir2' => $diff->getRight()->getContent(),
     ]);
 
-    $this->assertEquals($expected_diffs['absent_dir1'] ?? [], array_keys($absent_dir1));
-    $this->assertEquals($expected_diffs['absent_dir2'] ?? [], array_keys($absent_dir2));
-    $this->assertEquals($expected_diffs['content'] ?? [], $content);
+    $this->assertSame($expected_diffs['absent_dir1'] ?? [], array_keys($absent_dir1));
+    $this->assertSame($expected_diffs['absent_dir2'] ?? [], array_keys($absent_dir2));
+    $this->assertSame($expected_diffs['content'] ?? [], $content);
   }
 
   public static function dataProviderCompare(): \Iterator {

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\Snapshot\Tests\Unit;
 
-use AlexSkrypnyk\Snapshot\Index\IndexedFile;
 use AlexSkrypnyk\File\Exception\FileException;
 use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Compare\Comparer;
 use AlexSkrypnyk\Snapshot\Compare\Diff;
+use AlexSkrypnyk\Snapshot\Index\IndexedFile;
 use AlexSkrypnyk\Snapshot\Patch\Patcher;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
 use AlexSkrypnyk\Snapshot\Snapshot;

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -119,7 +119,7 @@ final class SnapshotTest extends UnitTestCase {
       return;
     }
 
-    if (is_null($content)) {
+    if ($content === NULL) {
       $this->fail('Expected content, but got NULL.');
     }
 
@@ -214,7 +214,7 @@ ABSENT,
 
   #[DataProvider('dataProviderDiff')]
   public function testDiff(): void {
-    $baseline = File::dir($this->locationsFixtureDir() . DIRECTORY_SEPARATOR . '/../baseline');
+    $baseline = File::dir($this->locationsFixtureDir() . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'baseline');
     $dst = File::dir($this->locationsFixtureDir() . DIRECTORY_SEPARATOR . 'result');
 
     Snapshot::diff($baseline, $dst, self::$sut);
@@ -252,7 +252,7 @@ ABSENT,
 
   #[DataProvider('dataProviderPatch')]
   public function testPatch(): void {
-    $baseline = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . '/../baseline');
+    $baseline = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'baseline');
     $diff = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'diff');
 
     Snapshot::patch($baseline, $diff, self::$sut);
@@ -294,7 +294,7 @@ ABSENT,
     $baseline = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'baseline');
     $diff = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . 'diff');
 
-    $processor = (fn(string $content): string => str_replace('f1l1', 'REPLACED', $content));
+    $processor = fn(string $content): string => str_replace('f1l1', 'REPLACED', $content);
 
     Snapshot::patch($baseline, $diff, self::$sut, $processor);
 
@@ -315,8 +315,8 @@ ABSENT,
     $parent = self::$sut;
     $baseline_dir = $parent . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR;
     $snapshot_dir = $parent . DIRECTORY_SEPARATOR . 'snapshot';
-    mkdir($baseline_dir, 0755, TRUE);
-    mkdir($snapshot_dir, 0755, TRUE);
+    mkdir($baseline_dir, 0777, TRUE);
+    mkdir($snapshot_dir, 0777, TRUE);
 
     $result = Snapshot::getBaselinePath($snapshot_dir);
 
@@ -341,7 +341,7 @@ ABSENT,
   }
 
   public function testDiffWithRules(): void {
-    $baseline = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . '/../baseline');
+    $baseline = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'baseline');
     $dst = File::dir($this->locationsFixtureDir('diff') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . 'result');
 
     $rules = Rules::create();
@@ -366,8 +366,8 @@ ABSENT,
   public function testComparerCacheInvalidation(): void {
     $dir1 = self::$sut . DIRECTORY_SEPARATOR . 'dir1';
     $dir2 = self::$sut . DIRECTORY_SEPARATOR . 'dir2';
-    mkdir($dir1);
-    mkdir($dir2);
+    mkdir($dir1, 0777, TRUE);
+    mkdir($dir2, 0777, TRUE);
 
     file_put_contents($dir1 . DIRECTORY_SEPARATOR . 'f1.txt', 'content1');
     file_put_contents($dir2 . DIRECTORY_SEPARATOR . 'f1.txt', 'content1');
@@ -387,8 +387,8 @@ ABSENT,
   public function testComparerCacheInvalidatedOnAddFile(): void {
     $dir1 = self::$sut . DIRECTORY_SEPARATOR . 'dir1';
     $dir2 = self::$sut . DIRECTORY_SEPARATOR . 'dir2';
-    mkdir($dir1);
-    mkdir($dir2);
+    mkdir($dir1, 0777, TRUE);
+    mkdir($dir2, 0777, TRUE);
 
     file_put_contents($dir1 . DIRECTORY_SEPARATOR . 'f1.txt', 'content1');
     file_put_contents($dir2 . DIRECTORY_SEPARATOR . 'f1.txt', 'content1');
@@ -412,7 +412,7 @@ ABSENT,
   public function testSyncRespectsContentIgnored(): void {
     $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
     $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
-    mkdir($src);
+    mkdir($src, 0777, TRUE);
 
     file_put_contents($src . DIRECTORY_SEPARATOR . 'regular.txt', 'regular content');
     file_put_contents($src . DIRECTORY_SEPARATOR . 'ignored.txt', 'actual secret content');
@@ -427,13 +427,17 @@ ABSENT,
   }
 
   public function testSyncUsesFileCopy(): void {
+    if (!function_exists('symlink')) {
+      $this->markTestSkipped('Symlinks are not supported on this system.');
+    }
+
     $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
     $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
-    mkdir($src);
+    mkdir($src, 0777, TRUE);
 
     // Create various file types.
     file_put_contents($src . DIRECTORY_SEPARATOR . 'regular.txt', 'regular content');
-    mkdir($src . DIRECTORY_SEPARATOR . 'subdir');
+    mkdir($src . DIRECTORY_SEPARATOR . 'subdir', 0777, TRUE);
     file_put_contents($src . DIRECTORY_SEPARATOR . 'subdir' . DIRECTORY_SEPARATOR . 'nested.txt', 'nested content');
     symlink($src . DIRECTORY_SEPARATOR . 'regular.txt', $src . DIRECTORY_SEPARATOR . 'link.txt');
 

--- a/tests/phpunit/Unit/SnapshotTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotTraitTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(SnapshotTrait::class)]
-final class SnapshotAssertionsTraitTest extends TestCase {
+final class SnapshotTraitTest extends TestCase {
 
   use SnapshotTrait;
 

--- a/tests/phpunit/Unit/SnapshotTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotTraitTest.php
@@ -190,9 +190,8 @@ final class SnapshotTraitTest extends TestCase {
     mkdir($this->baselineDir, 0777, TRUE);
     file_put_contents($this->baselineDir . DIRECTORY_SEPARATOR . 'file1.txt', "line1\nline2\nline3\n");
 
-    // Create a patch file with a hunk mismatch (incomplete hunk)
     mkdir($this->diffDir, 0777, TRUE);
-    // Missing the rest of the hunk.
+    // The rest of the hunk is missing.
     $diff_content = "@@ -1,3 +1,3 @@\n line1\n-line2\n";
     file_put_contents($this->diffDir . DIRECTORY_SEPARATOR . 'file1.txt', $diff_content);
 
@@ -212,9 +211,7 @@ final class SnapshotTraitTest extends TestCase {
     mkdir($this->baselineDir, 0777, TRUE);
     file_put_contents($this->baselineDir . DIRECTORY_SEPARATOR . 'file1.txt', "line1\nline2\nline3\n");
 
-    // Create a patch file with unexpected EOF.
     mkdir($this->diffDir, 0777, TRUE);
-    // Missing the content completely.
     $diff_content = '@@ -1,3 +1,3 @@';
     file_put_contents($this->diffDir . DIRECTORY_SEPARATOR . 'file1.txt', $diff_content);
 
@@ -257,23 +254,18 @@ final class SnapshotTraitTest extends TestCase {
   }
 
   public function testAssertSnapshotMatchesBaselineWithCustomMessage(): void {
-    // Set up baseline directory.
     mkdir($this->baselineDir, 0777, TRUE);
     file_put_contents($this->baselineDir . DIRECTORY_SEPARATOR . 'file1.txt', 'Original content');
 
-    // Set up diff directory.
     mkdir($this->diffDir, 0777, TRUE);
     file_put_contents($this->diffDir . DIRECTORY_SEPARATOR . 'file1.txt', 'Original content');
 
-    // Set up actual directory.
     mkdir($this->actualDir, 0777, TRUE);
     file_put_contents($this->actualDir . DIRECTORY_SEPARATOR . 'file1.txt', 'Original content');
 
-    // Test successful assertion with custom message.
     $this->assertSnapshotMatchesBaseline($this->actualDir, $this->baselineDir, $this->diffDir, NULL, 'Custom success message');
     $this->addToAssertionCount(1);
 
-    // Test failed assertion with custom message (nonexistent baseline).
     $nonexistent_dir = $this->tmpDir . DIRECTORY_SEPARATOR . 'nonexistent';
     try {
       $this->assertSnapshotMatchesBaseline($this->actualDir, $nonexistent_dir, $this->diffDir, NULL, 'Custom failure message');

--- a/tests/phpunit/UnitTestCase.php
+++ b/tests/phpunit/UnitTestCase.php
@@ -12,11 +12,6 @@ use AlexSkrypnyk\Snapshot\Testing\SnapshotTrait;
  *
  * This base class uses SnapshotTrait to demonstrate usage of this package's
  * functionality in testing.
- *
- * For snapshot update functionality to work, tests should call
- * snapshotUpdateOnFailure() in tearDown() with the fixture and actual
- * output directories. Set the UPDATE_SNAPSHOTS environment variable to enable
- * auto-updates.
  */
 abstract class UnitTestCase extends BaseUnitTestCase {
 


### PR DESCRIPTION
## Summary

This PR runs an internal-consistency convergence pass across the library, resolving divergent forms that accumulated across incremental changes into a single dominant form per case: string-literal quoting, test assertion idioms, identifier vocabulary, the baseline directory naming, `use` block ordering, structural and expression idioms, the renderer callable syntax, builder delegation, a misnamed test class, and the register of source comments. Every commit is gated on the full test suite (244 tests) and lint, both green, and the whole run is verified idempotent - a second pass over the converged tree produces no diff. All renamed symbols are `protected` or local; no public API symbol was renamed.

## Changes

- **String literals** - Converted 51 double-quoted string literals in the unit tests that carried neither an escape sequence nor an embedded single quote to single quotes, using a PHP tokenizer rather than a regex; `src/` and `bin/` were already clean.
- **Assertion idioms** - Replaced the native `assert(is_string())` type check with `assertIsString()`, 11 `assertEquals()` calls with `assertSame()`, three fluent-return `assertInstanceOf()` checks with identity `assertSame()`, two metacharacter-free `expectExceptionMessageMatches()` calls with `expectExceptionMessage()`, and directory teardown `File::remove()` with `File::rmdir()`.
- **Identifier vocabulary** - Renamed `Rules::$global` to `$globalPatterns` to match its three sibling pattern properties, `Index::isPathMatchesPattern()` to `pathMatchesPattern()` to match sibling `matchesAnyPattern()`, and local variables including `$file_info` to `$indexed_file`, `$files_count` to `$file_count`, `$last_commit_msg` to `$last_commit_message`, and `PatcherTest`'s `$dest_file1`/`$dest_file2` to the `dst` vocabulary the patcher itself uses; also renamed `testFluentChaining()` to `testFluentMethodChaining()`. All renamed symbols are `protected` or local.
- **Baseline naming and import order** - Renamed the script define `BASELINE_SUFFIX` to `BASELINE_DIR` since it names a directory and is joined as one, replaced ten hardcoded `'_baseline'` literals in the functional test with `Snapshot::BASELINE_DIR`, and sorted two `use` blocks that interleaved vendors out of alphabetical order (`phpcs` does not check import order in test files).
- **Structural and expression idioms** - Grouped `Rules::fromFile()` with its four sibling static factories, replaced four `is_null()` calls with identity comparisons, gave every native `mkdir()` call the recursive three-argument form, removed redundant parentheses from assigned arrow functions and typed one previously untyped closure, joined signatures and calls that wrapped below the line-length limit, fixed a doubled path separator (`DIRECTORY_SEPARATOR . '/../baseline'`) at four sites, and added a missing symlink capability guard to three tests that called `symlink()` unguarded.
- **Renderer and builder delegation** - `Comparer::render()` now uses the first-class callable syntax `Diff::render()` already used elsewhere in the class, two `PHP_EOL` concatenations inside one rendered string became the `\n` literal the other seven lines already use, and `SnapshotBuilder::scan()` now delegates to `Snapshot::scan()` the way `compare()`, `diff()` and `patch()` already do.
- **Test naming** - Renamed `SnapshotAssertionsTraitTest` to `SnapshotTraitTest` to match the trait it covers, and updated the file listing in `AGENTS.md`.
- **Source comments** - Deleted 197 comments that restated the code, narrated a past change, or labelled a block the reader could already see; reworded 41 that stated a real reason but read as prose; left 340 untouched. Comments decoding genuinely opaque behaviour were kept, including the timeout and interrupt exit codes, the ANSI escape sequences, and the deliberate absence of a stderr redirect in the sequential spawner. Every changed line in this commit is a comment or a blank line - no claim was changed.

## Deliberately left unfixed

This run classified but did not fix a set of pre-existing defects and API-shape questions, filing each as a separate issue (#45-#60) rather than folding a behavior change into a naming/idiom convergence pass. Notable ones:

- #45 - Include patterns (`!pattern`) do not override glob or bare-filename patterns, because the global-pattern check in `Index::scan()` short-circuits before include patterns are consulted; the README's own headline example for the feature does not work.
- #46 - `SnapshotTrait` has four `@codeCoverageIgnoreStart` markers against one `@codeCoverageIgnoreEnd`.
- #47 - `isBaseline()` matches any path containing `_baseline` as a substring, so it can match paths beside the baseline directory as well as inside it.
- #51 - A comment in `Diff::isSameContent()` is load-bearing for lint: Rector's `SimplifyUselessVariableRector` only skips the assign-then-return pattern while a comment is attached to it.
- #57 and #58 - Public API argument-order and interface-shape inconsistencies between `Rules` and `RuleSet` that need a major version to fix.

## Screenshots

N/A - this change has no visual/UI dimension.

## Before / After

```
BEFORE (divergent forms)                    AFTER (one dominant form)
──────────────────────────────────────     ──────────────────────────────────────
Rules::$global                          →   Rules::$globalPatterns
Index::isPathMatchesPattern()           →   Index::pathMatchesPattern()
BASELINE_SUFFIX ('_baseline')           →   BASELINE_DIR ('_baseline')
assertEquals() / assertInstanceOf()     →   assertSame()
File::remove() for dir teardown         →   File::rmdir() for dir teardown
"double-quoted, escape-free" literals   →   'single-quoted, escape-free' literals
SnapshotAssertionsTraitTest             →   SnapshotTraitTest
[static::class, 'doRender']             →   static::doRender(...)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Standardized internal naming, quoting, assertions, null checks, imports, paths, comments, and test conventions.
- Renamed protected and local symbols without changing public APIs.
- Standardized baseline directory handling and added symlink guards.
- Updated `SnapshotBuilder` delegation and snapshot update tests.
- Updated `AGENTS.md` for renamed test files.
- Verified the 244-test suite and lint pass.

Pre-existing defects and API-shape questions remain documented in issues `#45`–#60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->