### PR TITLE
[#51] Polished source comments, corrected ignore rule documentation and added 'SECURITY.md'.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,51 @@
 # Contributing
 
 Thank you for considering a contribution to this project. This guide covers
-setting up a local environment and running the linting and tests.
+setting up a local environment and running the linting, tests and benchmarks.
 
+## Local setup
 
-    composer install
-    composer lint
-    composer test
+```bash
+composer install
+```
 
+## Linting
 
+`composer lint` runs PHP_CodeSniffer, PHPStan and Rector in check mode.
+`composer lint-fix` applies the fixes that Rector and PHP Code Beautifier can
+make automatically.
 
+```bash
+composer lint
+composer lint-fix
+```
+
+## Tests
+
+```bash
+# Run the whole suite.
+composer test
+
+# Run the suite with coverage reports in .logs/.
+composer test-coverage
+
+# Run a single file or a single test.
+vendor/bin/phpunit tests/phpunit/Unit/SnapshotTest.php
+vendor/bin/phpunit --filter testMethodName
+```
+
+## Performance benchmarks
+
+PHPBench measures the core operations against a stored baseline. CI compares
+each run to that baseline and fails when a benchmark moves by more than 5%.
+
+```bash
+# Run benchmarks against the stored baseline.
+composer benchmark
+
+# Create or update the stored baseline.
+composer benchmark-baseline
+
+# Verify a benchmark runs, without the full suite.
+vendor/bin/phpbench run benchmarks/SnapshotBench.php --iterations=1 --revs=1
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="" rel="noopener">
-  <img width=200px height=200px src="logo.png" alt="Snapshot logo"/>
+  <img width=200px height=200px src="logo.png" alt="Snapshot logo"></a>
 </p>
 
 <h1 align="center">Directory snapshot, diff, and patch system useful for test fixtures</h1>
@@ -19,16 +19,18 @@
 
 ---
 
-## Features
+## ✨ Features
 
 - **Directory comparison** - Compare two directories for identical structure and content
 - **Baseline + diff architecture** - Store a baseline once, then only diffs per test scenario
 - **Unified diff format** - Human-readable patch files that can be reviewed in PRs
 - **Auto-update snapshots** - Automatically update snapshots when tests fail
+- **Batch update CLI** - Regenerate many snapshots at once, in parallel, with timeouts and retries
+- **Version normalization** - Replace volatile versions, hashes and timestamps before snapshots are written
 - **Flexible ignore rules** - Skip files, directories, or ignore content differences
 - **PHPUnit integration** - Simple trait with intuitive assertions
 
-## Use Cases
+## 🎯 Use Cases
 
 This library is designed for testing systems that generate file output:
 
@@ -44,7 +46,7 @@ For example, if you maintain a project template with customizable options (like
 choosing a database driver or enabling optional features), you can use this
 library to test each combination of options produces the correct files.
 
-## Concepts
+## 🧩 Concepts
 
 ### Baseline
 
@@ -102,11 +104,11 @@ Snapshot directories can also contain:
 - **Deletion markers** - Files prefixed with `-` (e.g., `-README.md`) indicate
   the file should not exist in this scenario
 
-## Installation
+## 📦 Installation
 
     composer require --dev alexskrypnyk/snapshot
 
-## Usage
+## 🚀 Usage
 
 ### Basic Directory Comparison
 
@@ -185,7 +187,7 @@ vendor/bin/update-snapshots testMySnapshot tests/snapshots baseline scenario1
 vendor/bin/update-snapshots --jobs=8 testMySnapshot tests/snapshots
 
 # Specify project root (useful when running from subdirectory)
-vendor/bin/update-snapshots --root=/path/to/project testMySnapshot tests/snapshots
+vendor/bin/update-snapshots --root=../.. testMySnapshot tests/snapshots
 ```
 
 The tool:
@@ -203,6 +205,10 @@ Options:
 - `--jobs=<count>` - Number of parallel jobs for scenarios (default: 4)
 - `--debug` - Show PHPUnit output for failed tests
 
+#### Exit Codes
+
+Updating a snapshot is the expected outcome, so the tool exits `0` when it updates one. It exits non-zero only when a dataset genuinely cannot be updated - a failure that is not a snapshot mismatch, or a run that keeps timing out. A single PHPUnit run still exits non-zero after updating a snapshot, because the assertion fails before `tearDown()` rewrites the files; the tool reclassifies those runs as updated.
+
 #### Parallel Execution
 
 When updating all datasets, the baseline is always run first (since other
@@ -219,18 +225,26 @@ Create a `.ignorecontent` file in your baseline directory to control which files
 are compared and how.
 
 ```
-# Skip files entirely - they won't be compared at all
+# Skip by file name, anywhere in the tree
 *.log
-cache/
+.DS_Store
+
+# Skip by path, relative to this directory
 node_modules/
+build/cache/
 
-# Include specific files (override a previous skip rule)
-!important.log
+# Include a file that a path rule would otherwise skip
+!build/cache/manifest.json
 
-# Ignore content differences - verify file exists, but allow any content
+# Ignore content differences - verify the file exists, but allow any content
 ^composer.lock
 ^package-lock.json
 ```
+
+A pattern is matched in one of two ways, depending on whether it contains a `/`:
+
+- **Without a `/`** the pattern is matched against the file name alone, so `*.log` skips every `.log` file at any depth. Name patterns are applied before everything else, and a `!` rule does not override them.
+- **With a `/`** the pattern is matched against the path relative to the directory being indexed, so `build/cache/` only skips that one directory. A `!` rule does override a path rule.
 
 #### Why Ignore Content?
 
@@ -248,10 +262,12 @@ Using `^filename` ensures the file exists without failing on content differences
 
 | Pattern | Effect |
 |---------|--------|
-| `*.log` | Skip all files matching the glob pattern |
-| `cache/` | Skip the entire directory and its contents |
-| `!important.log` | Include this file even if a previous rule would skip it |
-| `^composer.lock` | Check that file exists, but don't compare its content |
+| `*.log` | Skip every file whose name matches the glob, at any depth |
+| `cache/` | Skip the directory and everything under it |
+| `cache/*` | Skip the files directly in the directory, but not its subdirectories |
+| `!cache/keep.txt` | Include this file even though a path rule would skip it |
+| `^composer.lock` | Check that the file exists, but do not compare its content |
+| `^cache/` | Check that files under the directory exist, but do not compare their content |
 
 ### Programmatic API
 
@@ -290,6 +306,7 @@ $builder = SnapshotBuilder::create()
     ->withRules(Rules::phpProject())
     ->addSkip('custom/')
     ->addIgnoreContent('custom.lock')
+    ->addInclude('custom/keep.txt')
     ->withContentProcessor(fn($content) => trim($content));
 
 // Use the builder for multiple operations
@@ -316,10 +333,31 @@ $rules = Rules::nodeProject(); // Skips node_modules/, ignores lock files
 $rules = Rules::create()
     ->skip('vendor/', 'node_modules/', '.git/')
     ->ignoreContent('composer.lock', 'package-lock.json')
-    ->include('important.log');
+    ->include('vendor/autoload.php');
+
+// Or load them from an existing .ignorecontent file
+$rules = Rules::fromFile($baseline . '/.ignorecontent');
 
 // Use rules with Snapshot operations
 $comparer = Snapshot::compare($baseline, $actual, $rules);
+```
+
+The presets are built from rule sets. Extend `AbstractRuleSet` to define your
+own reusable set and turn it into rules with `Rules::fromRuleSet()`:
+
+```php
+use AlexSkrypnyk\Snapshot\Rules\AbstractRuleSet;
+use AlexSkrypnyk\Snapshot\Rules\Rules;
+
+class MyProjectRuleSet extends AbstractRuleSet {
+
+    protected const SKIP_PATTERNS = ['dist/', '.cache/'];
+
+    protected const IGNORE_CONTENT_PATTERNS = ['build-manifest.json'];
+
+}
+
+$rules = Rules::fromRuleSet(new MyProjectRuleSet());
 ```
 
 ### Version Normalization
@@ -353,10 +391,12 @@ Override `snapshotUpdateBefore()` to customize the replacement behavior:
 ```php
 protected function snapshotUpdateBefore(string $actual): void {
     // Use default patterns but add custom ones
+    $build = Replacement::create('build', '/BUILD-\d+/', '__BUILD__');
+
     File::getReplacer()
         ->addVersionReplacements()
         ->setMaxReplacements(0)
-        ->addReplacement(Replacement::create('custom', '/BUILD-\d+/', '__BUILD__'))
+        ->addReplacement($build)
         ->replaceInDir($actual);
 }
 ```
@@ -382,9 +422,12 @@ $replacer = File::getReplacer()->addVersionReplacements();
 $replacer->replaceInDir($directory);
 
 // Or create custom replacer
+$version = Replacement::create('version', '/v\d+\.\d+\.\d+/', '__VERSION__');
+$date = Replacement::create('date', '/\d{4}-\d{2}-\d{2}/', '__DATE__');
+
 $replacer = File::getReplacer()
-    ->addReplacement(Replacement::create('version', '/v\d+\.\d+\.\d+/', '__VERSION__'))
-    ->addReplacement(Replacement::create('date', '/\d{4}-\d{2}-\d{2}/', '__DATE__'));
+    ->addReplacement($version)
+    ->addReplacement($date);
 
 // Apply to string content
 $content = 'Version: v1.2.3';
@@ -394,25 +437,15 @@ $replacer->replace($content);  // $content is now 'Version: __VERSION__'
 $replacer->replaceInDir($directory);
 ```
 
-## Maintenance
+## 🤝 Contributing
 
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local development setup, the
+linting and testing commands, and how to run the performance benchmarks.
 
-    composer install
-    composer lint
-    composer test
+## 🔄 Updating
 
-### Performance Benchmarks
-
-Run benchmarks to measure performance of core operations:
-
-    # Run benchmarks with baseline comparison
-    composer benchmark
-
-    # Create or update baseline
-    composer benchmark-baseline
-
-    # Quick test (verify benchmarks work)
-    ./vendor/bin/phpbench run benchmarks/SnapshotBench.php --iterations=1 --revs=1
+To pull the latest infrastructure from the template into this project, ask
+Claude Code to "update scaffold" - see [`AGENTS.md`](AGENTS.md) for details.
 
 ---
 _This repository was created using the [Scaffold](https://getscaffold.dev/) project template_

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released for the latest `1.x` release. Older releases do not
+receive backported fixes.
+
+| Version | Supported          |
+|---------|--------------------|
+| 1.x     | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.
+
+Report them privately through
+[GitHub Security Advisories](https://github.com/alexskrypnyk/snapshot/security/advisories/new).
+Include the affected version, a description of the issue, and the steps needed
+to reproduce it.
+
+You can expect an initial response within 7 days. If the report is accepted, a
+fix is released and an advisory published crediting you, unless you ask to
+remain anonymous.

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -764,23 +764,7 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total, a
     }
   }
 
-  $stats = ['succeeded' => 0, 'updated' => 0, 'failed' => 0, 'timedout' => 0];
-  foreach ($tasks as $task) {
-    if ($task['status'] === 'success') {
-      $stats['succeeded']++;
-    }
-    elseif ($task['status'] === 'updated') {
-      $stats['updated']++;
-    }
-    elseif ($task['status'] === 'timeout') {
-      $stats['timedout']++;
-    }
-    else {
-      $stats['failed']++;
-    }
-  }
-
-  return $stats;
+  return ['succeeded' => $succeeded, 'updated' => $updated, 'failed' => $failed, 'timedout' => $timedout];
 }
 
 /**
@@ -1120,34 +1104,6 @@ function render_progress(array $tasks, int $total, bool $is_tty, int $jobs, int 
     print "\033[K\n";
   }
   // @codeCoverageIgnoreEnd
-}
-
-/**
- * Kill all running processes in task list.
- *
- * @param array<int, array<string, mixed>> $tasks
- *   All tasks.
- */
-function kill_all_tasks(array &$tasks): void {
-  foreach ($tasks as &$task) {
-    if ($task['status'] === 'running' && is_resource($task['process'])) {
-      $status = proc_get_status($task['process']);
-      if ($status['running'] && $status['pid'] > 0) {
-        posix_kill($status['pid'], SIGTERM);
-      }
-      if (is_resource($task['pipes'][1])) {
-        fclose($task['pipes'][1]);
-      }
-      if (is_resource($task['pipes'][2])) {
-        fclose($task['pipes'][2]);
-      }
-      proc_close($task['process']);
-      $task['status'] = 'failed';
-      $task['process'] = NULL;
-      $task['pipes'] = [];
-    }
-  }
-  unset($task);
 }
 
 /**

--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -193,6 +193,7 @@ class Comparer implements ComparerInterface {
         $render .= sprintf("  %s\n", $file);
       }
     }
+
     if (!empty($content_diffs)) {
       $render .= "Files that differ in content:\n";
 

--- a/src/Compare/Diff.php
+++ b/src/Compare/Diff.php
@@ -114,10 +114,7 @@ class Diff implements DiffInterface {
       // @codeCoverageIgnoreEnd
     }
 
-    // Final check: Content hash comparison.
-    $is_same_hash = $this->left->getHash() === $this->right->getHash();
-
-    return $is_same_hash;
+    return $this->left->getHash() === $this->right->getHash();
   }
 
   /**

--- a/src/Index/IndexedFile.php
+++ b/src/Index/IndexedFile.php
@@ -188,8 +188,6 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
   /**
    * Creates a hash for the given content.
    *
-   * Uses SHA-1 instead of MD5 for better performance.
-   *
    * @param string $content
    *   The content to hash.
    *

--- a/src/Patch/Patcher.php
+++ b/src/Patch/Patcher.php
@@ -9,10 +9,10 @@ use AlexSkrypnyk\Snapshot\Exception\PatchException;
 use AlexSkrypnyk\Snapshot\Index\IndexedFileInterface;
 
 /**
- * Class Patcher.
+ * Applies unified diffs to files.
  *
- * A limited implementation of the patch command that applies unified diffs
- * to files. Does not handle file removals or renames.
+ * A limited implementation of the patch command. Does not handle file
+ * removals or renames.
  */
 class Patcher implements PatcherInterface {
 
@@ -154,7 +154,6 @@ class Patcher implements PatcherInterface {
     $src_idx--;
     $dst_idx--;
 
-    // Load the source and destination lines if they are not already loaded.
     $this->srcLines[$src] ??= static::splitLines(File::read($src));
     // Use source lines as destination lines if the destination file does not
     // exist.
@@ -210,13 +209,11 @@ class Patcher implements PatcherInterface {
       throw new PatchException('Hunk mismatch', $src, key($lines));
     }
 
-    // Verify source lines match the expected ones before applying.
     $src_hunk_slice = array_slice($this->srcLines[$src], $src_idx, count($src_hunk));
     if ($src_hunk_slice !== $src_hunk) {
       throw new PatchException('Source file verification failed', $src, key($lines));
     }
 
-    // Replace lines in destination lines with the lines from the hunk.
     array_splice($this->dstLines[$dst], $dst_idx, count($src_hunk), $dst_hunk);
   }
 
@@ -239,9 +236,6 @@ class Patcher implements PatcherInterface {
   /**
    * Splits a string into lines.
    *
-   * Optimized to use string replacement + explode instead of preg_split
-   * for performance improvement.
-   *
    * @param string $content
    *   The content to split.
    *
@@ -249,7 +243,6 @@ class Patcher implements PatcherInterface {
    *   Array of lines.
    */
   protected static function splitLines(string $content): array {
-    // Normalize line endings to \n, then use fast explode.
     $normalized = str_replace(["\r\n", "\r"], "\n", $content);
     return explode("\n", $normalized);
   }

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -191,7 +191,6 @@ final class SnapshotBuilderTest extends UnitTestCase {
 
     copy($expected . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT, self::$sut . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT);
 
-    // Test that void operations can be chained.
     $builder = SnapshotBuilder::create()
       ->addSkip('custom/')
       ->sync($src, self::$sut);


### PR DESCRIPTION
Closes #51

## Summary

A polish pass over the library: the code is treated as the source of truth, and documentation, comments and structure are brought into agreement with it. No behaviour changes - every edit is a deletion, a wording correction, or a move.

The largest correction is to the `.ignorecontent` documentation. The README presented `*.log` plus `!important.log` as the canonical example of the include feature, but a pattern without a `/` becomes a global name pattern that `Index::scan()` matches and `continue`s on before include patterns are ever consulted, so that example never worked. The README now describes the two match modes the parser actually implements. The underlying semantics question stays open in #45.

Five findings this pass recorded but deliberately did not resolve are filed as #62, #63, #64, #65 and #66.

## Changes

**Source readability**

- Removed `kill_all_tasks()` from `bin/update-snapshots`. The function was never called from anywhere, so the interrupt path it was written for does not exist. The gap it left behind is filed as #62.
- Replaced the duplicated per-status counting loop at the end of `run_datasets_parallel()` with the four counts the function had already computed twenty lines earlier. The loop's `else` branch and the earlier strict `'failed'` comparison are equivalent, because the polling loop only exits once no task is `queued` or `running`.
- Collapsed the assign-then-return pair in `Diff::isSameContent()` into a direct return, which is the first option #51 lists. Rector's `SimplifyUselessVariableRector` was being held off only by the comment attached to the assignment, so removing both leaves the rule nothing to rewrite and `composer lint` stays green.
- Added the missing blank line before the `$content_diffs` block in `Comparer::doRender()`, where the two neighbouring blocks already had one.

**Comments**

Applied the existence question before the wording question, per `~/.claude/code-comments.md`. Seven comments deleted, none rewritten, and every other comment in `src/`, `bin/`, `benchmarks/` and `tests/phpunit/` left untouched.

- Deleted two comparative claims that describe what the code is not: `Uses SHA-1 instead of MD5 for better performance.` on `IndexedFile::hash()`, and `Optimized to use string replacement + explode instead of preg_split for performance improvement.` on `Patcher::splitLines()`. Both narrate a change rather than the code.
- Deleted four comments in `Patcher` that restate the line below them, and one in `SnapshotBuilderTest` that restates its own test method name.
- Replaced the `Class Patcher.` boilerplate summary with the sentence the docblock already contained, matching how every other class in the library opens.

**Documentation**

- Corrected the `.ignorecontent` section: the sample file now groups name patterns and path patterns separately, a new paragraph states which of the two a pattern becomes and that `!` overrides only the path kind, and the Pattern Reference table gains the `cache/*` and `^cache/` rows the parser supports.
- Documented public API the README did not mention: `SnapshotBuilder::addInclude()`, `Rules::fromFile()`, `Rules::fromRuleSet()`, and extending `AbstractRuleSet` to define a reusable rule set.
- Documented the `update-snapshots` exit-code contract, which is surprising enough to be worth stating: updating a snapshot exits `0` even though the PHPUnit run under it exits non-zero.
- Replaced the `!important.log` and `->include('important.log')` examples with ones that work: `!build/cache/manifest.json` and `->include('vendor/autoload.php')` both override a path rule that would otherwise skip them.
- Fixed the unclosed `</a>` in the logo block, added the two missing feature bullets (the batch update CLI and version normalization), changed the `--root` example to the `../..` form the script's own help uses, and reflowed the `Replacement::create()` examples so no embedded code line exceeds 80 columns.

**Audience routing**

- Moved the `Maintenance` section out of the README. `CONTRIBUTING.md` now carries local setup, linting, tests and the benchmark commands; the README keeps a two-line pointer to it, plus the template's `Updating` section.

**OSS files**

- Added `SECURITY.md`. `README.md`, `LICENSE` and `CONTRIBUTING.md` were already present with correct casing.

## Verification

- `composer lint` - PHPCS, PHPStan level 9 and Rector all clean.
- `composer test` - 244 tests, 679 assertions, all passing.
- `gitleaks detect` over all 99 commits - no leaks. No tracked `.env` files, private-key blocks, AWS keys or hardcoded credential assignments.

## Before / After

The README's include example, against what the indexer does:

```
BEFORE (documented)                      BEFORE (actual)
┌──────────────────────────┐             ┌──────────────────────────────┐
│ *.log                    │             │ *.log        → global set    │
│ !important.log           │             │ !important.log → include set │
└──────────────────────────┘             └──────────────────────────────┘
             │                                          │
             ▼                                          ▼
   important.log is kept                    Index::scan()
                                            ├─ global match? → continue ──┐
                                            ├─ include match?  (never run)│
                                            └─ skip match?     (never run)│
                                                                          ▼
                                                            important.log dropped

AFTER (documented)                       AFTER (actual)
┌──────────────────────────┐             ┌──────────────────────────────┐
│ build/cache/             │             │ build/cache/  → skip set     │
│ !build/cache/manifest... │             │ !build/...    → include set  │
└──────────────────────────┘             └──────────────────────────────┘
             │                                          │
             ▼                                          ▼
   manifest.json is kept                     Index::scan()
                                             ├─ global match?  no
                                             ├─ include match? YES ───┐
                                             └─ skip bypassed         ▼
                                                            manifest.json kept
```

Where contributor content lives:

```
BEFORE                                   AFTER
README.md                                README.md
├── Features                             ├── Features
├── Usage                                ├── Usage
└── Maintenance          ◄── contributor └── Contributing ──┐  (pointer)
    ├── composer install      content in     Updating       │
    ├── composer lint         a user-facing                 │
    ├── composer test         document                      │
    └── Performance Benchmarks                              ▼
                                         CONTRIBUTING.md
CONTRIBUTING.md                          ├── Local setup
└── composer install/lint/test            ├── Linting
    (unlabelled block)                    ├── Tests
                                          └── Performance benchmarks
```
