### PR TITLE
[#65] Removed deprecated skipped rules from 'rector.php'.

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -16,7 +16,6 @@ use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
@@ -26,7 +25,6 @@ use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
 use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
 use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 return RectorConfig::configure()
@@ -53,8 +51,6 @@ return RectorConfig::configure()
     CatchExceptionNameMatchingTypeRector::class,
     ChangeSwitchToMatchRector::class,
     CompleteDynamicPropertiesRector::class,
-    CountArrayToEmptyArrayComparisonRector::class,
-    DisallowedEmptyRuleFixerRector::class,
     InlineArrayReturnAssignRector::class,
     NewlineAfterStatementRector::class,
     NewlineBeforeNewAssignSetRector::class,


### PR DESCRIPTION
Closes #65

## Summary

Removed two skipped-rule entries from `rector.php`: `CountArrayToEmptyArrayComparisonRector` and `DisallowedEmptyRuleFixerRector`. Both rules are deprecated and are not registered by any of the enabled Rector sets, so skipping them was a no-op that printed four deprecation warnings on every `composer lint` run. Rector's actual behavior is otherwise unchanged, since neither rule was ever active.

## Changes

- Removed `CountArrayToEmptyArrayComparisonRector::class` from `withSkip()` and its corresponding `use` import in `rector.php`.
- Removed `DisallowedEmptyRuleFixerRector::class` from `withSkip()` and its corresponding `use` import in `rector.php`.

## Merge order

This PR is independent of the other PRs in this series and can be merged at any time, in any order.

## Before / After

```
┌──────────────────────────────────────────┐
│ composer lint - before                   │
├──────────────────────────────────────────┤
│ phpcs                                 OK │
│ phpstan                               OK │
│ rector                              WARN │
└──────────────────────────────────────────┘
  4 deprecation warnings printed, every run

┌──────────────────────────────────────────┐
│ composer lint - after                    │
├──────────────────────────────────────────┤
│ phpcs                                 OK │
│ phpstan                               OK │
│ rector                                OK │
└──────────────────────────────────────────┘
  clean run, 0 warnings
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed two deprecated Rector rules from `withSkip()` in `rector.php`.
- Removed their unused imports.
- Prevented recurring deprecation warnings without changing Rector behavior.

## Possibly related

- `#65`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->