### PR TITLE
[#48] [#53] [#55] [#56] Corrected stale docblocks and test comments.

### DIFF
--- a/benchmarks/BenchmarkDirectoryTrait.php
+++ b/benchmarks/BenchmarkDirectoryTrait.php
@@ -9,8 +9,7 @@ use AlexSkrypnyk\File\File;
 /**
  * Trait for common benchmark directory operations.
  *
- * Provides helper methods for creating test directory structures
- * used across multiple benchmark classes.
+ * Provides helper methods for creating test directory structures.
  */
 trait BenchmarkDirectoryTrait {
 
@@ -42,7 +41,9 @@ trait BenchmarkDirectoryTrait {
   /**
    * Initialize directory structure.
    *
-   * Creates temporary baseline, actual, output, and destination directories.
+   * Creates the temporary, baseline, actual, and output directories. The
+   * destination directory path is assigned but left for the operation
+   * under test to create.
    */
   protected function directoryInitialize(): void {
     $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('snapshot_bench_', TRUE);

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -70,8 +70,9 @@ trait SnapshotTrait {
    * @param string $diffs
    *   Directory containing diff/patch files to apply to the baseline.
    * @param string|null $expected
-   *   Optional path where to create the expected directory. If not provided,
-   *   a '.expected' directory will be created next to the baseline.
+   *   Optional path where to create the expected directory. If NULL, a
+   *   uniquely named directory under the system temp directory is used,
+   *   unique per invocation so parallel PHPUnit processes do not collide.
    * @param string|null $message
    *   Optional custom failure message.
    */

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -71,8 +71,8 @@ trait SnapshotTrait {
    *   Directory containing diff/patch files to apply to the baseline.
    * @param string|null $expected
    *   Optional path where to create the expected directory. If NULL, a
-   *   uniquely named directory under the system temp directory is used,
-   *   unique per invocation so parallel PHPUnit processes do not collide.
+   *   directory unique to this invocation is created under the system temp
+   *   directory.
    * @param string|null $message
    *   Optional custom failure message.
    */

--- a/tests/phpunit/Fixtures/functional_update/README.md
+++ b/tests/phpunit/Fixtures/functional_update/README.md
@@ -11,7 +11,7 @@ functional_update/
 ├── README.md
 │
 ├── no_change/                    # Scenario: everything matches
-│   ├── .gitignore                # Expected dir is created per invocation under the system temp dir
+│   ├── .gitignore                # Fixture project's git ignore rules
 │   ├── phpunit.xml
 │   ├── composer.json
 │   ├── tests/
@@ -193,5 +193,5 @@ functional_update/
 
 ## Special Files
 
-- `.gitignore` - Expected dir is created per invocation under the system temp dir, outside the project
+- `.gitignore` - Ignore rules for the fixture project's git repo; its `.expected` entry is inert because the expected directory is created per invocation under the system temp dir, outside the project
 - `.ignorecontent` - Skips `.gitkeep` during snapshot comparison

--- a/tests/phpunit/Fixtures/functional_update/README.md
+++ b/tests/phpunit/Fixtures/functional_update/README.md
@@ -11,7 +11,7 @@ functional_update/
 ├── README.md
 │
 ├── no_change/                    # Scenario: everything matches
-│   ├── .gitignore                # Ignores .expected directory
+│   ├── .gitignore                # Expected dir is created per invocation under the system temp dir
 │   ├── phpunit.xml
 │   ├── composer.json
 │   ├── tests/
@@ -193,5 +193,5 @@ functional_update/
 
 ## Special Files
 
-- `.gitignore` - Prevents `.expected` temp directory from being committed
+- `.gitignore` - Expected dir is created per invocation under the system temp dir, outside the project
 - `.ignorecontent` - Skips `.gitkeep` during snapshot comparison

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\Exception;
  * 3. scenario_change - Single dataset mode (no commit, but files updated)
  * 4. both_change - Baseline fails, scenario fails → 1 commit (amended)
  * 5. genuine_failure - Non-snapshot failure → non-zero exit, no commit
- * 6. scenario_only_change - Stale scenario diff updates in parallel run
+ * 6. scenario_only_change - Stale scenario diff updates in parallel run.
  */
 #[CoversNothing]
 final class SnapshotUpdateScriptTest extends FunctionalTestCase {

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -13,10 +13,12 @@ use PHPUnit\Framework\Exception;
  * Functional tests for the update-snapshots CLI script.
  *
  * Tests the following scenarios:
- * 1. no_change      - Baseline passes, scenario passes → 0 commits
+ * 1. no_change - Baseline passes, scenario passes → 0 commits
  * 2. baseline_change - Baseline fails, scenario passes → 1 commit
  * 3. scenario_change - Single dataset mode (no commit, but files updated)
- * 4. both_change    - Baseline fails, scenario fails → 1 commit (amended)
+ * 4. both_change - Baseline fails, scenario fails → 1 commit (amended)
+ * 5. genuine_failure - Non-snapshot failure → non-zero exit, no commit
+ * 6. scenario_only_change - Stale scenario diff updates in parallel run
  */
 #[CoversNothing]
 final class SnapshotUpdateScriptTest extends FunctionalTestCase {
@@ -236,7 +238,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   /**
    * Test multiple datasets: specified datasets are all processed.
    *
-   * Scenario: scenario_change
+   * Scenario: both_change
    * - Run baseline AND scenario1 datasets
    * - Expected: Both datasets processed, files updated, no commit.
    */
@@ -551,7 +553,8 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
    * Set up a test project by copying a complete scenario fixture.
    *
    * @param string $scenario
-   *   Scenario name (no_change, baseline_change, scenario_change, both_change).
+   *   Name of a fixture scenario directory under
+   *   tests/phpunit/Fixtures/functional_update.
    */
   protected function setupTestProject(string $scenario): void {
     $scenario_dir = $this->fixturesDir . DIRECTORY_SEPARATOR . $scenario;

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -13,11 +13,11 @@ use PHPUnit\Framework\Exception;
  * Functional tests for the update-snapshots CLI script.
  *
  * Tests the following scenarios:
- * 1. no_change - Baseline passes, scenario passes → 0 commits
- * 2. baseline_change - Baseline fails, scenario passes → 1 commit
- * 3. scenario_change - Single dataset mode (no commit, but files updated)
- * 4. both_change - Baseline fails, scenario fails → 1 commit (amended)
- * 5. genuine_failure - Non-snapshot failure → non-zero exit, no commit
+ * 1. no_change - Baseline passes, scenario passes → 0 commits.
+ * 2. baseline_change - Baseline fails, scenario passes → 1 commit.
+ * 3. scenario_change - Single dataset mode (no commit, but files updated).
+ * 4. both_change - Baseline fails, scenario fails → 1 commit (amended).
+ * 5. genuine_failure - Non-snapshot failure → non-zero exit, no commit.
  * 6. scenario_only_change - Stale scenario diff updates in parallel run.
  */
 #[CoversNothing]

--- a/tests/phpunit/Unit/DiffTest.php
+++ b/tests/phpunit/Unit/DiffTest.php
@@ -295,7 +295,8 @@ final class DiffTest extends UnitTestCase {
 
     $diff = new Diff();
 
-    // Create symlinks to directories (getSize() would fail).
+    // Link metadata is unreliable, so the isLink() guard short-circuits
+    // before any size comparison.
     $dir1 = self::$sut . DIRECTORY_SEPARATOR . 'dir1';
     $dir2 = self::$sut . DIRECTORY_SEPARATOR . 'dir2';
     mkdir($dir1, 0777, TRUE);

--- a/tests/phpunit/Unit/SnapshotTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotTraitTest.php
@@ -170,7 +170,8 @@ final class SnapshotTraitTest extends TestCase {
     mkdir($this->baselineDir . DIRECTORY_SEPARATOR . 'subdir', 0777, TRUE);
     file_put_contents($this->baselineDir . DIRECTORY_SEPARATOR . 'file1.txt', "line1\nline2\nline3\n");
 
-    // Create an invalid patch file with incorrect line indices.
+    // The removal line does not match baseline content, so applyHunk()
+    // throws a source file verification failure.
     mkdir($this->diffDir, 0777, TRUE);
     $diff_content = "@@ -1,3 +1,3 @@\n line1\n-wrong line\n+new line 2\n line3\n";
     file_put_contents($this->diffDir . DIRECTORY_SEPARATOR . 'file1.txt', $diff_content);


### PR DESCRIPTION
Closes #48, closes #53, closes #55, closes #56

## Summary

This is a docs-only PR: every changed line sits inside a docblock, a comment, or the fixtures README, and none of it touches behavior. The 4 issues below each corrected a docblock or comment that no longer matched the code it was describing, from a fallback directory that isn't where it said to a scenario list that was short by 2 entries. Every claim in this PR was checked directly against the implementation before being rewritten, so nothing here is guessed at.

## Changes

- `#48`: corrected `src/Testing/SnapshotTrait.php`'s `assertSnapshotMatchesBaseline()` docblock to describe the real per-invocation system-temp default, and reworded the inert `.gitignore` annotations in `tests/phpunit/Fixtures/functional_update/README.md` to describe what the file actually does for the fixture's own repo.
- `#53`: corrected `tests/phpunit/Functional/SnapshotUpdateScriptTest.php` - the class docblock now lists all 6 fixture scenarios instead of 4, `testMultipleDatasetsUpdatesFiles()`'s docblock now names the `both_change` scenario it exercises, and `setupTestProject()`'s `$scenario` docblock points at the fixtures directory instead of a stale hardcoded list.
- `#55`: corrected `benchmarks/BenchmarkDirectoryTrait.php` - `directoryInitialize()`'s docblock now says the destination directory path is assigned but created by the operation under test, and the trait's docblock no longer claims it's shared across multiple benchmark classes.
- `#56`: corrected 2 test comments to name the real cause - `tests/phpunit/Unit/DiffTest.php` now cites the `isLink()` guard short-circuiting before any size comparison, and `tests/phpunit/Unit/SnapshotTraitTest.php` now cites `applyHunk()`'s source file verification failing on a mismatched removal line.

## Merge order

This PR is independent of the other PRs in this series and can be merged at any time, in any order.

## Before / After

```
Before                                    After
┌─────────────────────────────────┐       ┌──────────────────────────────────────────┐
│ $expected not given?             │       │ $expected not given?                      │
│ → '.expected' created            │       │ → a directory unique to this invocation   │
│   next to the baseline           │       │   is created under the system temp dir    │
└─────────────────────────────────┘       └──────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Corrected documentation for issues `#48`, `#53`, `#55`, and `#56`.
- Updated snapshot path, fixture, benchmark, and test comments.
- No production or test behavior changed.

## Details

- Documented the unique system temporary directory used by `assertSnapshotMatchesBaseline()`.
- Updated fixture README annotations.
- Documented all six `SnapshotUpdateScriptTest` scenarios.
- Clarified `BenchmarkDirectoryTrait` directory initialization.
- Corrected comments for symlink handling and invalid patch validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->