### PR TITLE
[#59] [#62] [#54] Unified the 'update-snapshots' engines and terminated spawned processes on signals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The tool:
 - Handles timeouts with configurable retries
 - Auto-commits baseline and snapshot changes
 - Shows a live TUI progress display with scrolling when running in a terminal
+- Terminates every PHPUnit process it spawned when it receives `SIGINT` or `SIGTERM`
 
 Options:
 - `--root=<path>` - Project root directory (default: current directory)

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The tool:
 - Handles timeouts with configurable retries
 - Auto-commits baseline and snapshot changes
 - Shows a live TUI progress display with scrolling when running in a terminal
-- Terminates the running dataset processes and exits `130` (`SIGINT`) or `143` (`SIGTERM`) when signalled while datasets are running; signal handling requires the `pcntl` extension
+- Terminates every spawned dataset process and exits `130` (`SIGINT`) or `143` (`SIGTERM`) when signalled; requires the `pcntl` extension
 
 Options:
 - `--root=<path>` - Project root directory (default: current directory)

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The tool:
 - Handles timeouts with configurable retries
 - Auto-commits baseline and snapshot changes
 - Shows a live TUI progress display with scrolling when running in a terminal
-- Terminates every PHPUnit process it spawned when it receives `SIGINT` or `SIGTERM`
+- Terminates the running dataset processes and exits `130` (`SIGINT`) or `143` (`SIGTERM`) when signalled while datasets are running; signal handling requires the `pcntl` extension
 
 Options:
 - `--root=<path>` - Project root directory (default: current directory)

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -50,8 +50,19 @@ define('STATUS_TIMEOUT', 'timeout');
 // Exit code reported by 'timeout' when a run exceeds its time limit.
 define('EXIT_CODE_TIMEOUT', 124);
 
-// Exit code reported for a process terminated by SIGINT.
+// Exit codes reported for a process stopped by SIGINT and by SIGTERM.
 define('EXIT_CODE_INTERRUPTED', 130);
+define('EXIT_CODE_TERMINATED', 143);
+
+// Signal numbers used to stop spawned processes. They are spelled out because
+// the pcntl extension that defines SIGTERM and SIGKILL is optional.
+define('SIGNAL_TERM', 15);
+define('SIGNAL_KILL', 9);
+
+// Time given to a spawned process to exit after SIGTERM before it is killed,
+// as a number of steps and the length of each step in microseconds.
+define('KILL_GRACE_STEPS', 20);
+define('KILL_GRACE_INTERVAL', 100000);
 
 // ----------------------------------------------------------------------------
 
@@ -114,14 +125,26 @@ function validate_config(array $config): void {
  */
 function setup_signal_handlers(): void {
   if (function_exists('pcntl_signal')) {
-    $handler = function (): void {
-      exit_tui();
-      verbose("\nInterrupted by user\n");
-      exit(EXIT_CODE_INTERRUPTED);
-    };
-    pcntl_signal(SIGINT, $handler);
-    pcntl_signal(SIGTERM, $handler);
+    pcntl_signal(SIGINT, function (): void {
+      stop_run(EXIT_CODE_INTERRUPTED);
+    });
+    pcntl_signal(SIGTERM, function (): void {
+      stop_run(EXIT_CODE_TERMINATED);
+    });
   }
+}
+
+/**
+ * Stop the run and exit.
+ *
+ * @param int $code
+ *   Exit code to report.
+ */
+function stop_run(int $code): void {
+  exit_tui();
+  verbose("\nInterrupted - stopping running tests\n");
+  kill_all_tasks();
+  exit($code);
 }
 
 /**
@@ -635,6 +658,10 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
     }
     unset($task);
 
+    // Refresh the registry before the next signal is dispatched, so the
+    // handler sees every process spawned in this pass.
+    live_tasks($tasks);
+
     render_progress($tasks, $run);
 
     $pending = array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_QUEUED || $task['status'] === STATUS_RUNNING);
@@ -645,6 +672,8 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
 
     usleep(50000);
   }
+
+  live_tasks([]);
 
   if ($run['is_tty']) {
     // @codeCoverageIgnoreStart
@@ -754,8 +783,7 @@ function poll_task(array $task, array $config): array {
 
   // An interrupted child means the whole run is being interrupted.
   if ($exit_code === EXIT_CODE_INTERRUPTED) {
-    exit_tui();
-    exit(EXIT_CODE_INTERRUPTED);
+    stop_run(EXIT_CODE_INTERRUPTED);
   }
 
   if ($exit_code === EXIT_CODE_TIMEOUT) {
@@ -903,6 +931,78 @@ function print_debug_output(array $task, array $config): void {
   }
 
   verbose("\n--- DEBUG: %s ---\n%s\n--- END DEBUG ---\n", (string) $task['dataset'], $output);
+}
+
+/**
+ * Access the registry of tasks that may hold a live child process.
+ *
+ * The signal handler runs outside the engine and needs the current task list
+ * to reach the spawned processes.
+ *
+ * @param array<int, array<string, mixed>>|null $tasks
+ *   Tasks to store, or NULL to read the registry.
+ *
+ * @return array<int, array<string, mixed>>
+ *   Currently registered tasks.
+ */
+function live_tasks(?array $tasks = NULL): array {
+  static $registry = [];
+
+  if ($tasks !== NULL) {
+    $registry = $tasks;
+  }
+
+  return $registry;
+}
+
+/**
+ * Terminate every live child process.
+ *
+ * A spawned PHPUnit process runs with UPDATE_SNAPSHOTS=1 and keeps rewriting
+ * snapshot files, so it must not outlive the script.
+ */
+function kill_all_tasks(): void {
+  $tasks = array_filter(live_tasks(), fn(array $task): bool => is_resource($task['process']));
+
+  if (empty($tasks)) {
+    return;
+  }
+
+  foreach ($tasks as $task) {
+    proc_terminate($task['process'], SIGNAL_TERM);
+  }
+
+  for ($step = 0; $step < KILL_GRACE_STEPS; $step++) {
+    $alive = array_filter($tasks, fn(array $task): bool => is_resource($task['process']) && proc_get_status($task['process'])['running']);
+
+    if (empty($alive)) {
+      break;
+    }
+
+    usleep(KILL_GRACE_INTERVAL);
+  }
+
+  foreach ($tasks as $task) {
+    if (!is_resource($task['process'])) {
+      continue;
+    }
+
+    $status = proc_get_status($task['process']);
+
+    if ($status['running']) {
+      proc_terminate($task['process'], SIGNAL_KILL);
+    }
+
+    foreach ($task['pipes'] as $pipe) {
+      if (is_resource($pipe)) {
+        fclose($pipe);
+      }
+    }
+
+    proc_close($task['process']);
+  }
+
+  live_tasks([]);
 }
 
 /**

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -859,7 +859,13 @@ function poll_task(array $task, array $config): array {
  *   Command line to pass to the shell.
  */
 function build_phpunit_command(array $config, array $arguments, array $env = [], ?int $timeout = NULL): string {
-  $prefix = ['XDEBUG_MODE=off'];
+  // proc_open() runs the command through a shell and hands back a handle to
+  // that shell. 'exec' makes the shell replace itself so the handle points at
+  // the command, and 'env' carries the variables without turning the command
+  // into an assignment that some shells decline to exec. Without both, a
+  // shell can survive as an intermediary that dies on a signal without
+  // passing it on, orphaning everything below it.
+  $prefix = ['exec', 'env', 'XDEBUG_MODE=off'];
 
   foreach ($env as $name => $value) {
     $prefix[] = $name . '=' . $value;
@@ -981,9 +987,20 @@ function kill_all_tasks(): void {
     return;
   }
 
+  // The handle covers the process the shell became, and the sweep covers
+  // whatever that process spawned below it. Both are signalled, so the
+  // guarantee does not depend on the shape of the tree a platform builds.
+  $pids = [];
+
   foreach ($tasks as $task) {
+    $status = proc_get_status($task['process']);
+    $pids = array_merge($pids, descendant_pids((int) $status['pid']));
     proc_terminate($task['process'], SIGNAL_TERM);
   }
+
+  $pids = array_unique($pids);
+
+  signal_pids($pids, SIGNAL_TERM);
 
   for ($step = 0; $step < KILL_GRACE_STEPS; $step++) {
     $alive = array_filter($tasks, fn(array $task): bool => is_resource($task['process']) && proc_get_status($task['process'])['running']);
@@ -994,6 +1011,10 @@ function kill_all_tasks(): void {
 
     usleep(KILL_GRACE_INTERVAL);
   }
+
+  // Escalate before any handle is closed, so no reaped process number is
+  // signalled after the system is free to hand it to somebody else.
+  signal_pids($pids, SIGNAL_KILL);
 
   foreach ($tasks as $task) {
     if (!is_resource($task['process'])) {
@@ -1016,6 +1037,56 @@ function kill_all_tasks(): void {
   }
 
   live_tasks([]);
+}
+
+/**
+ * Collect a process and every process descended from it.
+ *
+ * @param int $pid
+ *   Process ID to walk from.
+ *
+ * @return array<int>
+ *   The given process ID followed by the IDs below it. Only the given ID is
+ *   returned where 'pgrep' is unavailable.
+ */
+function descendant_pids(int $pid): array {
+  if ($pid < 1) {
+    return [];
+  }
+
+  $pids = [$pid];
+  $output = [];
+  exec(sprintf('pgrep -P %d 2>/dev/null', $pid), $output);
+
+  foreach ($output as $line) {
+    $child = (int) trim($line);
+
+    if ($child > 0) {
+      $pids = array_merge($pids, descendant_pids($child));
+    }
+  }
+
+  return $pids;
+}
+
+/**
+ * Send a signal to a list of processes.
+ *
+ * @param array<int> $pids
+ *   Process IDs to signal.
+ * @param int $signal
+ *   Signal number to send.
+ */
+function signal_pids(array $pids, int $signal): void {
+  foreach ($pids as $pid) {
+    if (function_exists('posix_kill')) {
+      posix_kill($pid, $signal);
+
+      continue;
+    }
+
+    exec(sprintf('kill -%d %d 2>/dev/null', $signal, $pid));
+  }
 }
 
 /**

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -1034,10 +1034,12 @@ function is_tty(): bool {
  * Everything printed after the body reaches the restored screen, so summaries
  * survive in the scrollback.
  *
- * @param callable $body
+ * @template T
+ *
+ * @param callable(): T $body
  *   Code to run while the alternate screen is up.
  *
- * @return mixed
+ * @return T
  *   The value returned by the body.
  */
 function with_tui(callable $body): mixed {

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -163,6 +163,7 @@ function run_specified_datasets(array $config): void {
   // same list can rewrite, so datasets run one at a time.
   $tasks = run_engine($datasets, $config, 1, 0, $total);
 
+  print_debug_output($tasks, $config);
   print_summary(tally_tasks($tasks), $total);
 
   $failed = array_map(
@@ -192,33 +193,45 @@ function run_all_datasets(array $config): void {
 
   $tasks = [];
   $completed = 0;
+  $timed_out = FALSE;
   $scenario_datasets = $datasets;
 
-  if ($datasets[0] === BASELINE_DATASET_NAME) {
-    // Scenarios are diffed against the baseline, so the baseline must be
-    // rewritten before any of them runs.
-    $tasks = run_engine([BASELINE_DATASET_NAME], $config, 1, 0, $total);
-    $completed = 1;
-
-    $baseline_committed = handle_baseline_result($config);
-
-    if ($tasks[0]['status'] === STATUS_TIMEOUT) {
-      print_summary(tally_tasks($tasks), $total);
-
-      throw new \Exception('Test timed out');
-    }
-
-    $scenario_datasets = array_slice($datasets, 1);
+  // Both phases share one alternate screen, so the display is not torn down
+  // and rebuilt between them.
+  if (is_tty()) {
+    enter_tui();
   }
 
-  if (!empty($scenario_datasets)) {
-    verbose("Running %d scenarios (parallel: %d)\n", count($scenario_datasets), (int) $config['jobs']);
-    $tasks = array_merge($tasks, run_engine($scenario_datasets, $config, (int) $config['jobs'], $completed, $total));
+  try {
+    if ($datasets[0] === BASELINE_DATASET_NAME) {
+      // Scenarios are diffed against the baseline, so the baseline must be
+      // rewritten before any of them runs.
+      $tasks = run_engine([BASELINE_DATASET_NAME], $config, 1, 0, $total);
+      $completed = 1;
+
+      $baseline_committed = handle_baseline_result($config);
+
+      $timed_out = $tasks[0]['status'] === STATUS_TIMEOUT;
+      $scenario_datasets = $timed_out ? [] : array_slice($datasets, 1);
+    }
+
+    if (!empty($scenario_datasets)) {
+      verbose("Running %d scenarios (parallel: %d)\n", count($scenario_datasets), (int) $config['jobs']);
+      $tasks = array_merge($tasks, run_engine($scenario_datasets, $config, (int) $config['jobs'], $completed, $total));
+    }
+  }
+  finally {
+    finish_tui();
   }
 
   $stats = tally_tasks($tasks);
 
+  print_debug_output($tasks, $config);
   print_summary($stats, $total);
+
+  if ($timed_out) {
+    throw new \Exception('Test timed out');
+  }
 
   // A no-op when the working tree is clean, so it is safe to call
   // unconditionally.
@@ -579,7 +592,9 @@ EOF;
 /**
  * Run datasets, keeping up to a given number of PHPUnit processes alive.
  *
- * A sequential run is the same engine with a concurrency of one.
+ * A sequential run is the same engine with a concurrency of one. Progress is
+ * drawn into the alternate screen when the caller has entered TUI mode, and
+ * printed as one line per dataset otherwise.
  *
  * @param array<string> $datasets
  *   Dataset names to run.
@@ -620,19 +635,16 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
   $run = [
     'jobs' => $jobs,
     'total' => $total,
-    'is_tty' => function_exists('posix_isatty') && posix_isatty(STDOUT),
+    'retries' => (int) $config['retries'],
+    'tui' => is_tui_active(),
     'scroll_offset' => 0,
     'start_time' => microtime(TRUE),
   ];
 
-  if ($run['is_tty']) {
-    enter_tui();
-  }
-
   while (TRUE) {
     dispatch_signals();
 
-    if ($run['is_tty']) {
+    if ($run['tui']) {
       $run['scroll_offset'] = read_keyboard_input($run['scroll_offset'], count($tasks));
     }
 
@@ -677,19 +689,6 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
   }
 
   live_tasks([]);
-
-  if ($run['is_tty']) {
-    // @codeCoverageIgnoreStart
-    // Hold the final frame so the results stay readable before the alternate
-    // screen is restored.
-    sleep(2);
-    exit_tui();
-    // @codeCoverageIgnoreEnd
-  }
-
-  foreach ($tasks as $task) {
-    print_debug_output($task, $config);
-  }
 
   return $tasks;
 }
@@ -915,25 +914,31 @@ function has_update_marker(array $output): bool {
 }
 
 /**
- * Print captured output of a dataset that did not pass cleanly.
+ * Print captured output of every dataset that did not pass cleanly.
  *
- * @param array<string, mixed> $task
- *   Completed task.
+ * @param array<int, array<string, mixed>> $tasks
+ *   Completed tasks.
  * @param array<string, mixed> $config
  *   Configuration array.
  */
-function print_debug_output(array $task, array $config): void {
-  if (empty($config['debug']) || $task['status'] === STATUS_SUCCESS) {
+function print_debug_output(array $tasks, array $config): void {
+  if (empty($config['debug'])) {
     return;
   }
 
-  $output = implode('', $task['stdout']) . implode('', $task['stderr']);
+  foreach ($tasks as $task) {
+    if ($task['status'] === STATUS_SUCCESS) {
+      continue;
+    }
 
-  if ($output === '') {
-    return;
+    $output = implode('', $task['stdout']) . implode('', $task['stderr']);
+
+    if ($output === '') {
+      continue;
+    }
+
+    verbose("\n--- DEBUG: %s ---\n%s\n--- END DEBUG ---\n", (string) $task['dataset'], $output);
   }
-
-  verbose("\n--- DEBUG: %s ---\n%s\n--- END DEBUG ---\n", (string) $task['dataset'], $output);
 }
 
 /**
@@ -1009,6 +1014,16 @@ function kill_all_tasks(): void {
 }
 
 /**
+ * Check whether standard output is attached to a terminal.
+ *
+ * @return bool
+ *   TRUE if the output can carry a TUI.
+ */
+function is_tty(): bool {
+  return function_exists('posix_isatty') && posix_isatty(STDOUT);
+}
+
+/**
  * Track whether TUI mode is active.
  *
  * @param bool|null $set
@@ -1053,6 +1068,22 @@ function exit_tui(): void {
   print "\033[?1049l";
   system('stty sane');
   is_tui_active(FALSE);
+  // @codeCoverageIgnoreEnd
+}
+
+/**
+ * Leave TUI mode after holding the final frame.
+ */
+function finish_tui(): void {
+  // @codeCoverageIgnoreStart
+  if (!is_tui_active()) {
+    return;
+  }
+
+  // Hold the final frame so the results stay readable before the alternate
+  // screen is restored.
+  sleep(2);
+  exit_tui();
   // @codeCoverageIgnoreEnd
 }
 
@@ -1119,7 +1150,7 @@ function get_viewport_height(): int {
  *   Display state of the current engine run.
  */
 function render_progress(array $tasks, array $run): void {
-  if (!$run['is_tty']) {
+  if (!$run['tui']) {
     render_progress_plain($tasks, $run);
 
     return;
@@ -1149,7 +1180,7 @@ function render_progress_plain(array $tasks, array $run): void {
 
   foreach ($tasks as $task) {
     $prefix = sprintf('  [%' . $pad . 'd/%d] %s ', $task['number'], $run['total'], $task['dataset']);
-    verbose("%s%s %ss\n", $prefix, status_label((string) $task['status']), $task['elapsed']);
+    verbose("%s%s %ss%s\n", $prefix, status_label((string) $task['status']), $task['elapsed'], attempt_suffix($task, $run));
   }
 }
 
@@ -1194,7 +1225,7 @@ function render_progress_tui(array $tasks, array $run): void {
         break;
 
       default:
-        printf("\033[K%s\033[%dm%s\033[0m %ss\n", $prefix, status_color((string) $task['status']), status_label((string) $task['status']), $task['elapsed']);
+        printf("\033[K%s\033[%dm%s\033[0m %ss%s\n", $prefix, status_color((string) $task['status']), status_label((string) $task['status']), $task['elapsed'], attempt_suffix($task, $run));
         break;
     }
   }
@@ -1218,6 +1249,28 @@ function render_progress_tui(array $tasks, array $run): void {
     print "\033[K\n";
   }
   // @codeCoverageIgnoreEnd
+}
+
+/**
+ * Get the display suffix reporting how many attempts a dataset took.
+ *
+ * A dataset that timed out and was retried is otherwise indistinguishable
+ * from one that passed on its first run.
+ *
+ * @param array<string, mixed> $task
+ *   Completed task.
+ * @param array<string, mixed> $run
+ *   Display state of the current engine run.
+ *
+ * @return string
+ *   Suffix naming the attempt, or an empty string after a single attempt.
+ */
+function attempt_suffix(array $task, array $run): string {
+  if ($task['attempt'] < 2) {
+    return '';
+  }
+
+  return sprintf(' (attempt %d/%d)', $task['attempt'], $run['retries']);
 }
 
 /**

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -371,8 +371,11 @@ function commit_snapshot_changes(array $config, bool $baseline_committed): void 
  * @param array<int, array<string, mixed>> $tasks
  *   Completed tasks.
  *
- * @return array<string, int>
- *   Statistics: success, failed and timeout counts.
+ * @return array{success: int, updated: int, failed: int, timeout: int}
+ *   Number of datasets per outcome. The 'updated' count covers datasets whose
+ *   snapshot was rewritten: PHPUnit exits non-zero for those because the
+ *   assertion fails before tearDown() rewrites the files, and the completion
+ *   marker on stderr reclassifies the run.
  */
 function tally_tasks(array $tasks): array {
   $stats = [

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -162,7 +162,7 @@ function run_specified_datasets(array $config): void {
 
   // A scenario is compared against the baseline that another dataset in the
   // same list can rewrite, so datasets run one at a time.
-  $tasks = run_engine($datasets, $config, 1, 0, $total);
+  $tasks = with_tui(fn(): array => run_engine($datasets, $config, 1, 0, $total));
 
   print_debug_output($tasks, $config);
   print_summary(tally_tasks($tasks), $total);
@@ -185,58 +185,27 @@ function run_specified_datasets(array $config): void {
  */
 function run_all_datasets(array $config): void {
   $start_time = time();
-  $baseline_committed = FALSE;
 
   $datasets = discover_datasets($config);
   $total = count($datasets);
 
   verbose("Found %d unique datasets\n", $total);
 
-  $tasks = [];
-  $completed = 0;
-  $timed_out = FALSE;
-  $scenario_datasets = $datasets;
+  $result = with_tui(fn(): array => run_phases($config, $datasets));
 
-  // Both phases share one alternate screen, so the display is not torn down
-  // and rebuilt between them.
-  if (is_tty()) {
-    enter_tui();
-  }
-
-  try {
-    if ($datasets[0] === BASELINE_DATASET_NAME) {
-      // Scenarios are diffed against the baseline, so the baseline must be
-      // rewritten before any of them runs.
-      $tasks = run_engine([BASELINE_DATASET_NAME], $config, 1, 0, $total);
-      $completed = 1;
-
-      $baseline_committed = handle_baseline_result($config);
-
-      $timed_out = $tasks[0]['status'] === STATUS_TIMEOUT;
-      $scenario_datasets = $timed_out ? [] : array_slice($datasets, 1);
-    }
-
-    if (!empty($scenario_datasets)) {
-      verbose("Running %d scenarios (parallel: %d)\n", count($scenario_datasets), (int) $config['jobs']);
-      $tasks = array_merge($tasks, run_engine($scenario_datasets, $config, (int) $config['jobs'], $completed, $total));
-    }
-  }
-  finally {
-    finish_tui();
-  }
-
+  $tasks = $result['tasks'];
   $stats = tally_tasks($tasks);
 
   print_debug_output($tasks, $config);
   print_summary($stats, $total);
 
-  if ($timed_out) {
+  if ($result['timed_out']) {
     throw new \Exception('Test timed out');
   }
 
   // A no-op when the working tree is clean, so it is safe to call
   // unconditionally.
-  commit_snapshot_changes($config, $baseline_committed);
+  commit_snapshot_changes($config, $result['baseline_committed']);
 
   print_execution_time($start_time);
 
@@ -245,6 +214,50 @@ function run_all_datasets(array $config): void {
   if ($stats[STATUS_FAILED] > 0 || $stats[STATUS_TIMEOUT] > 0) {
     throw new \Exception('Some tests failed');
   }
+}
+
+/**
+ * Run the baseline dataset, then the remaining scenarios.
+ *
+ * @param array<string, mixed> $config
+ *   Configuration array.
+ * @param array<string> $datasets
+ *   Discovered dataset names, with the baseline first when it is present.
+ *
+ * @return array{tasks: array<int, array<string, mixed>>, baseline_committed: bool, timed_out: bool}
+ *   Completed tasks, whether the baseline was committed, and whether the
+ *   baseline run exhausted its retries.
+ */
+function run_phases(array $config, array $datasets): array {
+  $total = count($datasets);
+  $tasks = [];
+  $completed = 0;
+  $timed_out = FALSE;
+  $baseline_committed = FALSE;
+  $scenario_datasets = $datasets;
+
+  if ($datasets[0] === BASELINE_DATASET_NAME) {
+    // Scenarios are diffed against the baseline, so the baseline must be
+    // rewritten before any of them runs.
+    $tasks = run_engine([BASELINE_DATASET_NAME], $config, 1, 0, $total);
+    $completed = 1;
+
+    $baseline_committed = handle_baseline_result($config);
+
+    $timed_out = $tasks[0]['status'] === STATUS_TIMEOUT;
+    $scenario_datasets = $timed_out ? [] : array_slice($datasets, 1);
+  }
+
+  if (!empty($scenario_datasets)) {
+    verbose("Running %d scenarios (parallel: %d)\n", count($scenario_datasets), (int) $config['jobs']);
+    $tasks = array_merge($tasks, run_engine($scenario_datasets, $config, (int) $config['jobs'], $completed, $total));
+  }
+
+  return [
+    'tasks' => $tasks,
+    'baseline_committed' => $baseline_committed,
+    'timed_out' => $timed_out,
+  ];
 }
 
 /**
@@ -380,10 +393,11 @@ function commit_snapshot_changes(array $config, bool $baseline_committed): void 
 }
 
 /**
- * Count completed tasks per outcome.
+ * Count tasks per outcome.
  *
  * @param array<int, array<string, mixed>> $tasks
- *   Completed tasks.
+ *   Tasks in any state. Queued and running tasks hold no outcome yet and are
+ *   not counted.
  *
  * @return array{success: int, updated: int, failed: int, timeout: int}
  *   Number of datasets per outcome. The 'updated' count covers datasets whose
@@ -652,7 +666,7 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
     $running = count(array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_RUNNING));
 
     foreach ($tasks as &$task) {
-      if ($running >= $jobs) {
+      if ($running >= $run['jobs']) {
         break;
       }
 
@@ -708,9 +722,12 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
  *   Updated task array with running process.
  */
 function start_task(array $task, array $config): array {
+  // PHPUnit selects a single named dataset with a 'method@dataset' filter.
+  $filter = (string) $config['test_name'] . '@' . (string) $task['dataset'];
+
   $cmd = build_phpunit_command(
     $config,
-    ['--no-coverage', '--filter=' . escapeshellarg(dataset_filter($config, (string) $task['dataset']))],
+    ['--no-coverage', '--filter=' . escapeshellarg($filter)],
     ['UPDATE_SNAPSHOTS' => '1'],
     (int) $config['timeout']
   );
@@ -855,21 +872,6 @@ function build_phpunit_command(array $config, array $arguments, array $env = [],
   }
 
   return sprintf('%s %s/vendor/bin/phpunit %s', implode(' ', $prefix), $config['root'], implode(' ', $arguments));
-}
-
-/**
- * Build the PHPUnit filter selecting a single dataset.
- *
- * @param array<string, mixed> $config
- *   Configuration array.
- * @param string $dataset
- *   Dataset name.
- *
- * @return string
- *   Filter matching the test method and the named dataset.
- */
-function dataset_filter(array $config, string $dataset): string {
-  return $config['test_name'] . '@' . $dataset;
 }
 
 /**
@@ -1024,6 +1026,33 @@ function kill_all_tasks(): void {
  */
 function is_tty(): bool {
   return function_exists('posix_isatty') && posix_isatty(STDOUT);
+}
+
+/**
+ * Run a body inside a single TUI session when the output is a terminal.
+ *
+ * Everything printed after the body reaches the restored screen, so summaries
+ * survive in the scrollback.
+ *
+ * @param callable $body
+ *   Code to run while the alternate screen is up.
+ *
+ * @return mixed
+ *   The value returned by the body.
+ */
+function with_tui(callable $body): mixed {
+  if (!is_tty()) {
+    return $body();
+  }
+
+  enter_tui();
+
+  try {
+    return $body();
+  }
+  finally {
+    finish_tui();
+  }
 }
 
 /**

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -83,6 +83,7 @@ function main(array $argv): void {
 
   validate_config($config);
   setup_signal_handlers();
+  register_shutdown_function(kill_all_tasks(...));
 
   chdir((string) $config['root']);
 

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -646,6 +646,7 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
       'dots' => 0,
       'attempt' => 1,
       'last_dot_time' => 0.0,
+      'reported' => FALSE,
     ];
   }
 
@@ -694,7 +695,7 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
     }
     unset($task);
 
-    render_progress($tasks, $run);
+    $tasks = render_progress($tasks, $run);
 
     $pending = array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_QUEUED || $task['status'] === STATUS_RUNNING);
 
@@ -877,7 +878,9 @@ function build_phpunit_command(array $config, array $arguments, array $env = [],
     $prefix[] = sprintf('timeout --foreground %ds', $timeout);
   }
 
-  return sprintf('%s %s/vendor/bin/phpunit %s', implode(' ', $prefix), $config['root'], implode(' ', $arguments));
+  $phpunit = escapeshellarg(rtrim((string) $config['root'], '/') . '/vendor/bin/phpunit');
+
+  return sprintf('%s %s %s', implode(' ', $prefix), $phpunit, implode(' ', $arguments));
 }
 
 /**
@@ -1253,40 +1256,51 @@ function get_viewport_height(): int {
  *   All tasks.
  * @param array<string, mixed> $run
  *   Display state of the current engine run.
+ *
+ * @return array<int, array<string, mixed>>
+ *   Tasks, with the ones whose result has been printed marked as reported.
  */
-function render_progress(array $tasks, array $run): void {
+function render_progress(array $tasks, array $run): array {
   if (!$run['tui']) {
-    render_progress_plain($tasks, $run);
-
-    return;
+    return render_progress_plain($tasks, $run);
   }
 
   // @codeCoverageIgnoreStart
   render_progress_tui($tasks, $run);
   // @codeCoverageIgnoreEnd
+
+  return $tasks;
 }
 
 /**
- * Print one result line per task once every task has finished.
+ * Print the result line of every task that has settled since the last call.
+ *
+ * Without a screen to redraw, a result is printed as soon as its dataset ends
+ * rather than held until the whole batch does.
  *
  * @param array<int, array<string, mixed>> $tasks
  *   All tasks.
  * @param array<string, mixed> $run
  *   Display state of the current engine run.
+ *
+ * @return array<int, array<string, mixed>>
+ *   Tasks, with the printed ones marked as reported.
  */
-function render_progress_plain(array $tasks, array $run): void {
-  $pending = array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_QUEUED || $task['status'] === STATUS_RUNNING);
-
-  if (!empty($pending)) {
-    return;
-  }
-
+function render_progress_plain(array $tasks, array $run): array {
   $pad = strlen((string) $run['total']);
 
-  foreach ($tasks as $task) {
+  foreach ($tasks as &$task) {
+    if ($task['reported'] || $task['status'] === STATUS_QUEUED || $task['status'] === STATUS_RUNNING) {
+      continue;
+    }
+
     $prefix = sprintf('  [%' . $pad . 'd/%d] %s ', $task['number'], $run['total'], $task['dataset']);
     verbose("%s%s %ss%s\n", $prefix, status_label((string) $task['status']), $task['elapsed'], attempt_suffix($task, $run));
+    $task['reported'] = TRUE;
   }
+  unset($task);
+
+  return $tasks;
 }
 
 /**

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -664,6 +664,10 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
     }
     unset($task);
 
+    // The poll loop can end the script when a child reports an interrupt, so
+    // processes are registered before it runs and again once it returns.
+    live_tasks($tasks);
+
     foreach ($tasks as &$task) {
       if ($task['status'] !== STATUS_RUNNING) {
         continue;
@@ -673,8 +677,6 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
     }
     unset($task);
 
-    // Refresh the registry before the next signal is dispatched, so the
-    // handler sees every process spawned in this pass.
     live_tasks($tasks);
 
     render_progress($tasks, $run);

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -38,6 +38,21 @@ define('COMMIT_MESSAGE_SNAPSHOTS', 'Updated snapshots.');
 define('SNAPSHOT_MARKER_BASELINE_UPDATED', '[SNAPSHOT] Baseline updated');
 define('SNAPSHOT_MARKER_DIFFS_UPDATED', '[SNAPSHOT] Diffs updated');
 
+// Dataset states. The first two are transient; the last four are outcomes and
+// double as the keys of the run statistics.
+define('STATUS_QUEUED', 'queued');
+define('STATUS_RUNNING', 'running');
+define('STATUS_SUCCESS', 'success');
+define('STATUS_UPDATED', 'updated');
+define('STATUS_FAILED', 'failed');
+define('STATUS_TIMEOUT', 'timeout');
+
+// Exit code reported by 'timeout' when a run exceeds its time limit.
+define('EXIT_CODE_TIMEOUT', 124);
+
+// Exit code reported for a process terminated by SIGINT.
+define('EXIT_CODE_INTERRUPTED', 130);
+
 // ----------------------------------------------------------------------------
 
 /**
@@ -45,10 +60,8 @@ define('SNAPSHOT_MARKER_DIFFS_UPDATED', '[SNAPSHOT] Diffs updated');
  *
  * @param array<string> $argv
  *   Array of arguments.
- * @param int $argc
- *   Number of arguments.
  */
-function main(array $argv, int $argc): void {
+function main(array $argv): void {
   $config = parse_arguments($argv);
 
   if ($config['help']) {
@@ -60,7 +73,7 @@ function main(array $argv, int $argc): void {
   validate_config($config);
   setup_signal_handlers();
 
-  chdir($config['root']);
+  chdir((string) $config['root']);
 
   if (!empty($config['datasets'])) {
     run_specified_datasets($config);
@@ -86,7 +99,7 @@ function validate_config(array $config): void {
     throw new \Exception('Missing required argument: <snapshots-path>');
   }
 
-  if (!is_dir($config['root'])) {
+  if (!is_dir((string) $config['root'])) {
     throw new \Exception(sprintf('Root directory does not exist: %s', $config['root']));
   }
 
@@ -104,7 +117,7 @@ function setup_signal_handlers(): void {
     $handler = function (): void {
       exit_tui();
       verbose("\nInterrupted by user\n");
-      exit(130);
+      exit(EXIT_CODE_INTERRUPTED);
     };
     pcntl_signal(SIGINT, $handler);
     pcntl_signal(SIGTERM, $handler);
@@ -118,41 +131,21 @@ function setup_signal_handlers(): void {
  *   Configuration array.
  */
 function run_specified_datasets(array $config): void {
-  $datasets = $config['datasets'];
+  $datasets = is_array($config['datasets']) ? array_map('strval', $config['datasets']) : [];
   $total = count($datasets);
-  $failed = [];
-  $updated = 0;
 
   verbose("Running %d specified dataset(s)\n", $total);
 
-  $current = 0;
-  foreach ($datasets as $dataset) {
-    $current++;
+  // A scenario is compared against the baseline that another dataset in the
+  // same list can rewrite, so datasets run one at a time.
+  $tasks = run_engine($datasets, $config, 1, 0, $total);
 
-    $result = run_with_timeout(
-      $config['test_name'] . '@' . $dataset,
-      $current,
-      $total,
-      $dataset,
-      $config['timeout'],
-      $config['retries'],
-      $config['debug'],
-      $config['root']
-    );
+  print_summary(tally_tasks($tasks), $total);
 
-    if ($result === 3) {
-      $updated++;
-      continue;
-    }
-
-    if ($result !== 0) {
-      $failed[] = $dataset;
-    }
-  }
-
-  if ($updated > 0) {
-    verbose("Updated %d dataset(s)\n", $updated);
-  }
+  $failed = array_map(
+    fn(array $task): string => (string) $task['dataset'],
+    array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_FAILED || $task['status'] === STATUS_TIMEOUT)
+  );
 
   if (!empty($failed)) {
     throw new \Exception(sprintf('Failed datasets: %s', implode(', ', $failed)));
@@ -168,34 +161,27 @@ function run_specified_datasets(array $config): void {
 function run_all_datasets(array $config): void {
   $start_time = time();
   $baseline_committed = FALSE;
-  $baseline_path = rtrim((string) $config['snapshots_path'], '/') . '/' . BASELINE_DIR;
 
   $datasets = discover_datasets($config);
   $total = count($datasets);
 
   verbose("Found %d unique datasets\n", $total);
 
-  $stats = ['current' => 0, 'succeeded' => 0, 'updated' => 0, 'failed' => 0, 'timedout' => 0];
-
+  $tasks = [];
+  $completed = 0;
   $scenario_datasets = $datasets;
+
   if ($datasets[0] === BASELINE_DATASET_NAME) {
-    $stats['current']++;
+    // Scenarios are diffed against the baseline, so the baseline must be
+    // rewritten before any of them runs.
+    $tasks = run_engine([BASELINE_DATASET_NAME], $config, 1, 0, $total);
+    $completed = 1;
 
-    $result = run_with_timeout(
-      $config['test_name'] . '@' . BASELINE_DATASET_NAME,
-      $stats['current'],
-      $total,
-      BASELINE_DATASET_NAME,
-      $config['timeout'],
-      $config['retries'],
-      $config['debug'],
-      $config['root']
-    );
+    $baseline_committed = handle_baseline_result($config);
 
-    $baseline_committed = handle_baseline_result($result, $config['root'], $baseline_path);
-    $stats = update_stats($stats, $result, $total);
+    if ($tasks[0]['status'] === STATUS_TIMEOUT) {
+      print_summary(tally_tasks($tasks), $total);
 
-    if ($result === 2) {
       throw new \Exception('Test timed out');
     }
 
@@ -203,12 +189,11 @@ function run_all_datasets(array $config): void {
   }
 
   if (!empty($scenario_datasets)) {
-    $parallel_stats = run_datasets_parallel($scenario_datasets, $stats['current'], $total, $config);
-    $stats['succeeded'] += $parallel_stats['succeeded'];
-    $stats['updated'] += $parallel_stats['updated'];
-    $stats['failed'] += $parallel_stats['failed'];
-    $stats['timedout'] += $parallel_stats['timedout'];
+    verbose("Running %d scenarios (parallel: %d)\n", count($scenario_datasets), (int) $config['jobs']);
+    $tasks = array_merge($tasks, run_engine($scenario_datasets, $config, (int) $config['jobs'], $completed, $total));
   }
+
+  $stats = tally_tasks($tasks);
 
   print_summary($stats, $total);
 
@@ -220,7 +205,7 @@ function run_all_datasets(array $config): void {
 
   // Successful updates are the expected outcome of this script and must not
   // produce a non-zero exit code. Only genuine failures or timeouts do.
-  if ($stats['failed'] > 0 || $stats['timedout'] > 0) {
+  if ($stats[STATUS_FAILED] > 0 || $stats[STATUS_TIMEOUT] > 0) {
     throw new \Exception('Some tests failed');
   }
 }
@@ -237,22 +222,18 @@ function run_all_datasets(array $config): void {
 function discover_datasets(array $config): array {
   verbose("Discovering datasets...\n");
 
-  $cmd = sprintf(
-    'XDEBUG_MODE=off %s/vendor/bin/phpunit --list-tests %s 2>/dev/null | grep "%s" || true',
-    $config['root'],
-    escapeshellarg((string) $config['test_dir']),
-    $config['test_name']
-  );
-  $test_list = (string) shell_exec($cmd);
-
-  if (empty(trim($test_list))) {
-    throw new \Exception('No datasets found');
-  }
+  $cmd = build_phpunit_command($config, ['--list-tests', escapeshellarg((string) $config['test_dir'])]);
+  $test_list = (string) shell_exec($cmd . ' 2>/dev/null');
 
   // Format: " - ClassName::testMethodName"dataset_name"".
   $pattern = '/' . preg_quote((string) $config['test_name'], '/') . '"([^"]+)"/';
   preg_match_all($pattern, $test_list, $matches);
   $datasets = array_unique($matches[1]);
+
+  if (empty($datasets)) {
+    throw new \Exception('No datasets found');
+  }
+
   sort($datasets);
 
   // Ensure baseline dataset runs first.
@@ -267,21 +248,18 @@ function discover_datasets(array $config): array {
 /**
  * Handle baseline test result and commit if needed.
  *
- * @param int $result
- *   Test result (0 = success, 1 = failed, 2 = timeout, 3 = updated).
- * @param string $root
- *   Git root directory.
- * @param string $baseline_path
- *   Path to baseline snapshots.
+ * @param array<string, mixed> $config
+ *   Configuration array.
  *
  * @return bool
  *   TRUE if baseline was committed.
  */
-function handle_baseline_result(int $result, string $root, string $baseline_path): bool {
+function handle_baseline_result(array $config): bool {
   $original_dir = (string) getcwd();
-  chdir($root);
+  chdir((string) $config['root']);
 
   $committed = FALSE;
+  $baseline_path = rtrim((string) $config['snapshots_path'], '/') . '/' . BASELINE_DIR;
 
   if (has_git_changes($baseline_path)) {
     verbose("Baseline snapshots updated - committing and continuing...\n");
@@ -346,16 +324,16 @@ function commit_changes(string $path, string $message, bool $amend = FALSE): boo
  */
 function commit_snapshot_changes(array $config, bool $baseline_committed): void {
   $original_dir = (string) getcwd();
-  chdir($config['root']);
+  chdir((string) $config['root']);
 
-  if (has_git_changes($config['snapshots_path'])) {
+  if (has_git_changes((string) $config['snapshots_path'])) {
     if ($baseline_committed) {
-      if (commit_changes($config['snapshots_path'], COMMIT_MESSAGE_SNAPSHOTS, TRUE)) {
+      if (commit_changes((string) $config['snapshots_path'], COMMIT_MESSAGE_SNAPSHOTS, TRUE)) {
         verbose("Note: Amended baseline commit to include all snapshot updates.\n");
       }
     }
     else {
-      if (commit_changes($config['snapshots_path'], COMMIT_MESSAGE_SNAPSHOTS)) {
+      if (commit_changes((string) $config['snapshots_path'], COMMIT_MESSAGE_SNAPSHOTS)) {
         verbose("Note: Created new commit for snapshot updates.\n");
       }
     }
@@ -365,31 +343,28 @@ function commit_snapshot_changes(array $config, bool $baseline_committed): void 
 }
 
 /**
- * Update statistics based on test result.
+ * Count completed tasks per outcome.
  *
- * @param array<string, int> $stats
- *   Current statistics.
- * @param int $result
- *   Test result (0 = success, 1 = failed, 2 = timeout, 3 = updated).
- * @param int $total
- *   Total number of datasets.
+ * @param array<int, array<string, mixed>> $tasks
+ *   Completed tasks.
  *
  * @return array<string, int>
- *   Updated statistics.
+ *   Statistics: success, failed and timeout counts.
  */
-function update_stats(array $stats, int $result, int $total): array {
-  if ($result === 0) {
-    $stats['succeeded']++;
-  }
-  elseif ($result === 3) {
-    $stats['updated']++;
-  }
-  elseif ($result === 2) {
-    $stats['timedout']++;
-    print_summary($stats, $total);
-  }
-  else {
-    $stats['failed']++;
+function tally_tasks(array $tasks): array {
+  $stats = [
+    STATUS_SUCCESS => 0,
+    STATUS_UPDATED => 0,
+    STATUS_FAILED => 0,
+    STATUS_TIMEOUT => 0,
+  ];
+
+  foreach ($tasks as $task) {
+    $status = (string) $task['status'];
+
+    if (isset($stats[$status])) {
+      $stats[$status]++;
+    }
   }
 
   return $stats;
@@ -407,10 +382,10 @@ function print_summary(array $stats, int $total): void {
   verbose(
     "Total: %d | Succeeded: %d | Updated: %d | Failed: %d | Timed out: %d\n",
     $total,
-    $stats['succeeded'],
-    $stats['updated'],
-    $stats['failed'],
-    $stats['timedout']
+    $stats[STATUS_SUCCESS],
+    $stats[STATUS_UPDATED],
+    $stats[STATUS_FAILED],
+    $stats[STATUS_TIMEOUT]
   );
 }
 
@@ -576,163 +551,94 @@ EOF;
 }
 
 /**
- * Run PHPUnit with timeout and retries.
+ * Run datasets, keeping up to a given number of PHPUnit processes alive.
  *
- * @param string $filter
- *   The PHPUnit filter.
- * @param int $current
- *   Current dataset number.
- * @param int $total
- *   Total number of datasets.
- * @param string $dataset
- *   Dataset name.
- * @param int $timeout
- *   Timeout in seconds.
- * @param int $retries
- *   Maximum number of retries.
- * @param bool $debug
- *   Whether to print debug output on failure.
- * @param string $root
- *   Project root directory.
- *
- * @return int
- *   0 = success, 1 = failed, 2 = timeout, 3 = updated.
- */
-function run_with_timeout(string $filter, int $current, int $total, string $dataset, int $timeout, int $retries, bool $debug, string $root): int {
-  $attempt = 1;
-
-  verbose('[%d/%d] %s ', $current, $total, $dataset);
-
-  while ($attempt <= $retries) {
-    dispatch_signals();
-
-    $result = run_phpunit($filter, $timeout, $root);
-
-    if ($result['exit_code'] === 130) {
-      verbose("\n");
-      exit(130);
-    }
-
-    if ($result['exit_code'] === 0) {
-      verbose(" ✓\n");
-
-      return 0;
-    }
-
-    // Timeout - retry if attempts remain.
-    if ($result['exit_code'] === 124) {
-      if ($attempt < $retries) {
-        verbose(" TIMEOUT, retry %d/%d ", $attempt + 1, $retries);
-        $attempt++;
-        continue;
-      }
-
-      verbose(" ✗ TIMEOUT\n");
-      print_debug_output($debug, $result['output']);
-
-      return 2;
-    }
-
-    // A successfully updated snapshot still exits non-zero in PHPUnit (the
-    // assertion failed before the update ran in tearDown), but the trait
-    // reports completion. Treat it as updated, not failed.
-    if (has_update_marker($result['output'])) {
-      verbose(" ✓ updated\n");
-      print_debug_output($debug, $result['output']);
-
-      return 3;
-    }
-
-    // Test failure - do not retry.
-    verbose(" ✗\n");
-    print_debug_output($debug, $result['output']);
-
-    return 1;
-  }
-
-  verbose(" ✗\n");
-
-  return 1;
-}
-
-/**
- * Run datasets in parallel with live progress display.
+ * A sequential run is the same engine with a concurrency of one.
  *
  * @param array<string> $datasets
  *   Dataset names to run.
- * @param int $start_number
- *   Starting dataset number (for display).
- * @param int $total
- *   Total number of datasets (for display).
  * @param array<string, mixed> $config
  *   Configuration array.
+ * @param int $jobs
+ *   Number of datasets to run at the same time.
+ * @param int $start_number
+ *   Number of datasets already completed, for display.
+ * @param int $total
+ *   Total number of datasets, for display.
  *
- * @return array<string, int>
- *   Statistics: succeeded, failed, timedout counts.
+ * @return array<int, array<string, mixed>>
+ *   Completed tasks, each carrying its outcome and captured output.
  */
-function run_datasets_parallel(array $datasets, int $start_number, int $total, array $config): array {
-  $jobs = (int) $config['jobs'];
-  $is_tty = function_exists('posix_isatty') && posix_isatty(STDOUT);
-
+function run_engine(array $datasets, array $config, int $jobs, int $start_number, int $total): array {
   $tasks = [];
   $number = $start_number;
+
   foreach ($datasets as $dataset) {
     $number++;
     $tasks[] = [
       'dataset' => $dataset,
       'number' => $number,
-      'status' => 'queued',
+      'status' => STATUS_QUEUED,
       'process' => NULL,
       'pipes' => [],
-      'output' => [],
+      'stdout' => [],
+      'stderr' => [],
       'start_time' => NULL,
-      'elapsed' => NULL,
+      'elapsed' => 0.0,
       'dots' => 0,
       'attempt' => 1,
       'last_dot_time' => 0.0,
     ];
   }
 
-  $scroll_offset = 0;
-  $start_time = microtime(TRUE);
+  $run = [
+    'jobs' => $jobs,
+    'total' => $total,
+    'is_tty' => function_exists('posix_isatty') && posix_isatty(STDOUT),
+    'scroll_offset' => 0,
+    'start_time' => microtime(TRUE),
+  ];
 
-  verbose("Running %d scenarios (parallel: %d)\n", count($datasets), $jobs);
-
-  if ($is_tty) {
+  if ($run['is_tty']) {
     enter_tui();
   }
 
   while (TRUE) {
     dispatch_signals();
 
-    if ($is_tty) {
-      $scroll_offset = read_keyboard_input($scroll_offset, count($tasks));
+    if ($run['is_tty']) {
+      $run['scroll_offset'] = read_keyboard_input($run['scroll_offset'], count($tasks));
     }
 
-    $running_count = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
+    $running = count(array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_RUNNING));
+
     foreach ($tasks as &$task) {
-      if ($running_count >= $jobs) {
+      if ($running >= $jobs) {
         break;
       }
-      if ($task['status'] !== 'queued') {
+
+      if ($task['status'] !== STATUS_QUEUED) {
         continue;
       }
+
       $task = start_task($task, $config);
-      $running_count++;
+      $running++;
     }
     unset($task);
 
     foreach ($tasks as &$task) {
-      if ($task['status'] !== 'running') {
+      if ($task['status'] !== STATUS_RUNNING) {
         continue;
       }
+
       $task = poll_task($task, $config);
     }
     unset($task);
 
-    render_progress($tasks, $total, $is_tty, $jobs, $scroll_offset, $start_time);
+    render_progress($tasks, $run);
 
-    $pending = array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued' || $t['status'] === 'running');
+    $pending = array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_QUEUED || $task['status'] === STATUS_RUNNING);
+
     if (empty($pending)) {
       break;
     }
@@ -740,31 +646,20 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total, a
     usleep(50000);
   }
 
-  if ($is_tty) {
-    // Hold final frame briefly so user can see results.
+  if ($run['is_tty']) {
+    // @codeCoverageIgnoreStart
+    // Hold the final frame so the results stay readable before the alternate
+    // screen is restored.
     sleep(2);
     exit_tui();
+    // @codeCoverageIgnoreEnd
   }
 
-  // Print final summary and debug output to normal scrollback.
-  $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
-  $updated = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'updated'));
-  $failed = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
-  $timedout = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
-
-  verbose("Parallel run: %d succeeded, %d updated, %d failed, %d timed out\n", $succeeded, $updated, $failed, $timedout);
-
-  if ($config['debug']) {
-    foreach ($tasks as $task) {
-      if ($task['status'] === 'failed' || $task['status'] === 'timeout') {
-        verbose("\n--- DEBUG: %s ---\n", $task['dataset']);
-        verbose("%s\n", implode("\n", $task['output']));
-        verbose("--- END DEBUG ---\n");
-      }
-    }
+  foreach ($tasks as $task) {
+    print_debug_output($task, $config);
   }
 
-  return ['succeeded' => $succeeded, 'updated' => $updated, 'failed' => $failed, 'timedout' => $timedout];
+  return $tasks;
 }
 
 /**
@@ -779,12 +674,11 @@ function run_datasets_parallel(array $datasets, int $start_number, int $total, a
  *   Updated task array with running process.
  */
 function start_task(array $task, array $config): array {
-  $filter = $config['test_name'] . '@' . $task['dataset'];
-  $cmd = sprintf(
-    'XDEBUG_MODE=off UPDATE_SNAPSHOTS=1 timeout --foreground %ds %s/vendor/bin/phpunit --no-coverage --filter=%s 2>&1',
-    $config['timeout'],
-    $config['root'],
-    escapeshellarg($filter)
+  $cmd = build_phpunit_command(
+    $config,
+    ['--no-coverage', '--filter=' . escapeshellarg(dataset_filter($config, (string) $task['dataset']))],
+    ['UPDATE_SNAPSHOTS' => '1'],
+    (int) $config['timeout']
   );
 
   $descriptors = [
@@ -796,7 +690,8 @@ function start_task(array $task, array $config): array {
   $process = proc_open($cmd, $descriptors, $pipes);
 
   if (!is_resource($process)) {
-    $task['status'] = 'failed';
+    $task['status'] = STATUS_FAILED;
+
     return $task;
   }
 
@@ -804,7 +699,7 @@ function start_task(array $task, array $config): array {
   stream_set_blocking($pipes[1], FALSE);
   stream_set_blocking($pipes[2], FALSE);
 
-  $task['status'] = 'running';
+  $task['status'] = STATUS_RUNNING;
   $task['process'] = $process;
   $task['pipes'] = $pipes;
   $task['start_time'] = microtime(TRUE);
@@ -826,7 +721,7 @@ function start_task(array $task, array $config): array {
  */
 function poll_task(array $task, array $config): array {
   $status = proc_get_status($task['process']);
-  $task['output'] = collect_output($task['pipes'], $task['output']);
+  $task = collect_task_output($task);
 
   if (microtime(TRUE) - $task['last_dot_time'] >= 0.25) {
     $task['dots']++;
@@ -842,49 +737,172 @@ function poll_task(array $task, array $config): array {
   // PHP < 8.3. proc_close() below only releases the handle.
   $exit_code = $status['exitcode'];
 
-  $task['output'] = collect_output($task['pipes'], $task['output']);
+  $task = collect_task_output($task);
   fclose($task['pipes'][1]);
   fclose($task['pipes'][2]);
   proc_close($task['process']);
+
   $task['elapsed'] = round(microtime(TRUE) - $task['start_time'], 1);
   $task['process'] = NULL;
   $task['pipes'] = [];
 
   if ($exit_code === 0) {
-    $task['status'] = 'success';
+    $task['status'] = STATUS_SUCCESS;
+
     return $task;
   }
 
-  // Timeout - retry if attempts remain.
-  if ($exit_code === 124) {
+  // An interrupted child means the whole run is being interrupted.
+  if ($exit_code === EXIT_CODE_INTERRUPTED) {
+    exit_tui();
+    exit(EXIT_CODE_INTERRUPTED);
+  }
+
+  if ($exit_code === EXIT_CODE_TIMEOUT) {
     if ($task['attempt'] < $config['retries']) {
       $task['attempt']++;
-      $task['status'] = 'queued';
+      $task['status'] = STATUS_QUEUED;
       $task['dots'] = 0;
       $task['start_time'] = NULL;
-      $task['elapsed'] = NULL;
+      $task['elapsed'] = 0.0;
+      $task['stdout'] = [];
+      $task['stderr'] = [];
+
       return $task;
     }
-    $task['status'] = 'timeout';
-    return $task;
-  }
 
-  // Interrupt.
-  if ($exit_code === 130) {
-    exit(130);
+    $task['status'] = STATUS_TIMEOUT;
+
+    return $task;
   }
 
   // A non-zero exit accompanied by the trait's completion marker means the
   // snapshot was updated rather than the test genuinely failing.
-  if (has_update_marker($task['output'])) {
-    $task['status'] = 'updated';
+  if (has_update_marker($task['stderr'])) {
+    $task['status'] = STATUS_UPDATED;
 
     return $task;
   }
 
-  $task['status'] = 'failed';
+  $task['status'] = STATUS_FAILED;
 
   return $task;
+}
+
+/**
+ * Build a PHPUnit command line.
+ *
+ * The command never merges stderr into stdout: at the shell level that turns
+ * SnapshotTrait's stderr writes into PHPUnit output, which PHPUnit then
+ * reports as an error.
+ *
+ * @param array<string, mixed> $config
+ *   Configuration array.
+ * @param array<string> $arguments
+ *   PHPUnit arguments, escaped by the caller where needed.
+ * @param array<string, string> $env
+ *   Environment variables to prefix the command with.
+ * @param int|null $timeout
+ *   Seconds to allow the run, or NULL to run without a time limit.
+ *
+ * @return string
+ *   Command line to pass to the shell.
+ */
+function build_phpunit_command(array $config, array $arguments, array $env = [], ?int $timeout = NULL): string {
+  $prefix = ['XDEBUG_MODE=off'];
+
+  foreach ($env as $name => $value) {
+    $prefix[] = $name . '=' . $value;
+  }
+
+  if ($timeout !== NULL) {
+    // '--foreground' keeps the child in the foreground process group, so an
+    // interactive interrupt reaches it.
+    $prefix[] = sprintf('timeout --foreground %ds', $timeout);
+  }
+
+  return sprintf('%s %s/vendor/bin/phpunit %s', implode(' ', $prefix), $config['root'], implode(' ', $arguments));
+}
+
+/**
+ * Build the PHPUnit filter selecting a single dataset.
+ *
+ * @param array<string, mixed> $config
+ *   Configuration array.
+ * @param string $dataset
+ *   Dataset name.
+ *
+ * @return string
+ *   Filter matching the test method and the named dataset.
+ */
+function dataset_filter(array $config, string $dataset): string {
+  return $config['test_name'] . '@' . $dataset;
+}
+
+/**
+ * Collect pending output from a task's pipes.
+ *
+ * @param array<string, mixed> $task
+ *   Task array with open pipes.
+ *
+ * @return array<string, mixed>
+ *   Task array with the collected output appended.
+ */
+function collect_task_output(array $task): array {
+  $stdout = stream_get_contents($task['pipes'][1]);
+  $stderr = stream_get_contents($task['pipes'][2]);
+
+  if ($stdout !== '' && $stdout !== FALSE) {
+    $task['stdout'][] = $stdout;
+  }
+
+  if ($stderr !== '' && $stderr !== FALSE) {
+    $task['stderr'][] = $stderr;
+  }
+
+  return $task;
+}
+
+/**
+ * Check whether captured output reports a completed snapshot update.
+ *
+ * SnapshotTrait emits a completion marker after it finishes rewriting baseline
+ * or diff files. When PHPUnit exits non-zero but this marker is present, the
+ * snapshot was updated successfully and the dataset must not be treated as a
+ * failure.
+ *
+ * @param array<string> $output
+ *   Captured PHPUnit error output chunks.
+ *
+ * @return bool
+ *   TRUE if a snapshot update completion marker is present.
+ */
+function has_update_marker(array $output): bool {
+  $text = implode('', $output);
+
+  return str_contains($text, SNAPSHOT_MARKER_BASELINE_UPDATED) || str_contains($text, SNAPSHOT_MARKER_DIFFS_UPDATED);
+}
+
+/**
+ * Print captured output of a dataset that did not pass cleanly.
+ *
+ * @param array<string, mixed> $task
+ *   Completed task.
+ * @param array<string, mixed> $config
+ *   Configuration array.
+ */
+function print_debug_output(array $task, array $config): void {
+  if (empty($config['debug']) || $task['status'] === STATUS_SUCCESS) {
+    return;
+  }
+
+  $output = implode('', $task['stdout']) . implode('', $task['stderr']);
+
+  if ($output === '') {
+    return;
+  }
+
+  verbose("\n--- DEBUG: %s ---\n%s\n--- END DEBUG ---\n", (string) $task['dataset'], $output);
 }
 
 /**
@@ -992,110 +1010,103 @@ function get_viewport_height(): int {
 /**
  * Render progress display for all tasks.
  *
- * In TTY mode, uses alternate screen with viewport scrolling.
- * In non-TTY mode, prints final results only.
- *
  * @param array<int, array<string, mixed>> $tasks
  *   All tasks.
- * @param int $total
- *   Total dataset count for numbering.
- * @param bool $is_tty
- *   Whether output is a TTY.
- * @param int $jobs
- *   Number of parallel jobs.
- * @param int $scroll_offset
- *   Current scroll offset for viewport.
- * @param float $start_time
- *   Start time of parallel run.
+ * @param array<string, mixed> $run
+ *   Display state of the current engine run.
  */
-function render_progress(array $tasks, int $total, bool $is_tty, int $jobs, int $scroll_offset, float $start_time): void {
-  $task_count = count($tasks);
-  $succeeded = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'success'));
-  $updated = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'updated'));
-  $failed = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'failed'));
-  $running = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'running'));
-  $queued = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'queued'));
-  $timedout = count(array_filter($tasks, fn(array $t): bool => $t['status'] === 'timeout'));
-  $pad = strlen((string) $total);
-
-  if (!$is_tty) {
-    if ($running === 0 && $queued === 0) {
-      foreach ($tasks as $task) {
-        $line = sprintf('  [%' . $pad . 'd/%d] %s ', $task['number'], $total, $task['dataset']);
-        if ($task['status'] === 'success') {
-          verbose("%s✓ %ss\n", $line, $task['elapsed']);
-        }
-        elseif ($task['status'] === 'updated') {
-          verbose("%s✓ updated %ss\n", $line, $task['elapsed']);
-        }
-        elseif ($task['status'] === 'timeout') {
-          verbose("%s⏱ %ss\n", $line, $task['elapsed']);
-        }
-        else {
-          verbose("%s✗ %ss\n", $line, $task['elapsed']);
-        }
-      }
-      verbose("\n");
-      verbose("  Done: %d  Updated: %d  Failed: %d  Timeout: %d\n", $succeeded, $updated, $failed, $timedout);
-    }
+function render_progress(array $tasks, array $run): void {
+  if (!$run['is_tty']) {
+    render_progress_plain($tasks, $run);
 
     return;
   }
 
   // @codeCoverageIgnoreStart
+  render_progress_tui($tasks, $run);
+  // @codeCoverageIgnoreEnd
+}
+
+/**
+ * Print one result line per task once every task has finished.
+ *
+ * @param array<int, array<string, mixed>> $tasks
+ *   All tasks.
+ * @param array<string, mixed> $run
+ *   Display state of the current engine run.
+ */
+function render_progress_plain(array $tasks, array $run): void {
+  $pending = array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_QUEUED || $task['status'] === STATUS_RUNNING);
+
+  if (!empty($pending)) {
+    return;
+  }
+
+  $pad = strlen((string) $run['total']);
+
+  foreach ($tasks as $task) {
+    $prefix = sprintf('  [%' . $pad . 'd/%d] %s ', $task['number'], $run['total'], $task['dataset']);
+    verbose("%s%s %ss\n", $prefix, status_label((string) $task['status']), $task['elapsed']);
+  }
+}
+
+/**
+ * Redraw the alternate screen with a viewport over the task list.
+ *
+ * @param array<int, array<string, mixed>> $tasks
+ *   All tasks.
+ * @param array<string, mixed> $run
+ *   Display state of the current engine run.
+ */
+function render_progress_tui(array $tasks, array $run): void {
+  // @codeCoverageIgnoreStart
+  $task_count = count($tasks);
+  $stats = tally_tasks($tasks);
+  $running = count(array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_RUNNING));
+  $queued = count(array_filter($tasks, fn(array $task): bool => $task['status'] === STATUS_QUEUED));
+  $pad = strlen((string) $run['total']);
+
   $viewport_height = get_viewport_height();
   $max_scroll = max(0, $task_count - $viewport_height);
-  $scroll_offset = min($scroll_offset, $max_scroll);
+  $scroll_offset = min($run['scroll_offset'], $max_scroll);
 
   // Cursor to home.
   print "\033[H";
 
-  printf("\033[K  Running %d scenarios (parallel: %d)\n", $task_count, $jobs);
+  printf("\033[K  Running %d dataset(s) (parallel: %d)\n", $task_count, $run['jobs']);
   print "\033[K\n";
 
   $visible_end = min($task_count, $scroll_offset + $viewport_height);
   for ($i = $scroll_offset; $i < $visible_end; $i++) {
     $task = $tasks[$i];
-    $prefix = sprintf('  [%' . $pad . 'd/%d] %-20s ', $task['number'], $total, $task['dataset']);
+    $prefix = sprintf('  [%' . $pad . 'd/%d] %-20s ', $task['number'], $run['total'], $task['dataset']);
 
     switch ($task['status']) {
-      case 'queued':
+      case STATUS_QUEUED:
         printf("\033[K%s\033[90m·\033[0m\n", $prefix);
         break;
 
-      case 'running':
+      case STATUS_RUNNING:
         printf("\033[K%s\033[33m%s\033[0m\n", $prefix, str_repeat('.', $task['dots']));
         break;
 
-      case 'success':
-        printf("\033[K%s\033[32m✓\033[0m %ss\n", $prefix, $task['elapsed']);
-        break;
-
-      case 'updated':
-        printf("\033[K%s\033[32m✓\033[0m updated %ss\n", $prefix, $task['elapsed']);
-        break;
-
-      case 'failed':
-        printf("\033[K%s\033[31m✗\033[0m %ss\n", $prefix, $task['elapsed']);
-        break;
-
-      case 'timeout':
-        printf("\033[K%s\033[33m⏱\033[0m %ss\n", $prefix, $task['elapsed']);
+      default:
+        printf("\033[K%s\033[%dm%s\033[0m %ss\n", $prefix, status_color((string) $task['status']), status_label((string) $task['status']), $task['elapsed']);
         break;
     }
   }
 
   print "\033[K\n";
   printf(
-    "\033[K  \033[32mDone: %d\033[0m  \033[36mUpdated: %d\033[0m  \033[31mFailed: %d\033[0m  \033[33mRunning: %d\033[0m  Queued: %d  Timeout: %d\n",
-    $succeeded,
-    $updated,
-    $failed,
+    "\033[K  \033[32mSucceeded: %d\033[0m  \033[36mUpdated: %d\033[0m  \033[31mFailed: %d\033[0m  \033[33mRunning: %d\033[0m  Queued: %d  Timed out: %d\n",
+    $stats[STATUS_SUCCESS],
+    $stats[STATUS_UPDATED],
+    $stats[STATUS_FAILED],
     $running,
     $queued,
-    $timedout
+    $stats[STATUS_TIMEOUT]
   );
-  printf("\033[K  Elapsed: %s\n", format_time((int) (microtime(TRUE) - $start_time)));
+  printf("\033[K  Elapsed: %s\n", format_time((int) (microtime(TRUE) - $run['start_time'])));
 
   if ($max_scroll > 0) {
     printf("\033[K\033[90m  ↑↓ Scroll (%d-%d of %d)\033[0m\n", $scroll_offset + 1, $visible_end, $task_count);
@@ -1107,128 +1118,38 @@ function render_progress(array $tasks, int $total, bool $is_tty, int $jobs, int 
 }
 
 /**
- * Execute PHPUnit command with progress dots.
+ * Get the display label of an outcome.
  *
- * @param string $filter
- *   The PHPUnit filter.
- * @param int $timeout
- *   Timeout in seconds.
- * @param string $root
- *   Project root directory.
+ * @param string $status
+ *   Task status.
  *
- * @return array{exit_code: int, output: array<string>}
- *   Array with exit code and output lines.
+ * @return string
+ *   Label shown next to the dataset name.
  */
-function run_phpunit(string $filter, int $timeout, string $root): array {
-  $cmd = sprintf(
-    // Do not use 2>&1 here: proc_open already captures stdout and stderr on
-    // separate pipes. Merging them at the shell level forces fwrite(STDERR,...)
-    // in SnapshotTrait::snapshotUpdateOnFailure() to write to stdout, which
-    // can cause false PHPUnit errors.
-    'XDEBUG_MODE=off UPDATE_SNAPSHOTS=1 timeout --foreground %ds %s/vendor/bin/phpunit --no-coverage --filter=%s',
-    $timeout,
-    $root,
-    escapeshellarg($filter)
-  );
-
-  $descriptors = [
-    0 => ['pipe', 'r'],
-    1 => ['pipe', 'w'],
-    2 => ['pipe', 'w'],
-  ];
-
-  $process = proc_open($cmd, $descriptors, $pipes);
-
-  if (!is_resource($process)) {
-    return ['exit_code' => 1, 'output' => []];
-  }
-
-  fclose($pipes[0]);
-  stream_set_blocking($pipes[1], FALSE);
-  stream_set_blocking($pipes[2], FALSE);
-
-  $output = [];
-  $last_dot_time = microtime(TRUE);
-  $exit_code = -1;
-
-  while (TRUE) {
-    $status = proc_get_status($process);
-
-    $output = collect_output($pipes, $output);
-
-    if (!$status['running']) {
-      // Capture the exit code here: proc_get_status() reaps the child on the
-      // first call that reports it stopped, so a later proc_close() returns -1
-      // on PHP < 8.3. proc_close() below only releases the handle.
-      $exit_code = $status['exitcode'];
-      break;
-    }
-
-    if (microtime(TRUE) - $last_dot_time >= 0.25) {
-      verbose('.');
-      $last_dot_time = microtime(TRUE);
-    }
-
-    usleep(100000);
-    dispatch_signals();
-  }
-
-  $output = collect_output($pipes, $output);
-
-  fclose($pipes[1]);
-  fclose($pipes[2]);
-
-  proc_close($process);
-
-  return [
-    'exit_code' => $exit_code,
-    'output' => explode("\n", implode('', $output)),
-  ];
+function status_label(string $status): string {
+  return match ($status) {
+    STATUS_SUCCESS => '✓',
+    STATUS_UPDATED => '✓ updated',
+    STATUS_TIMEOUT => '⏱',
+    default => '✗',
+  };
 }
 
 /**
- * Collect output from process pipes.
+ * Get the ANSI colour code of an outcome.
  *
- * @param array<int, resource> $pipes
- *   Process pipes.
- * @param array<string> $output
- *   Existing output.
+ * @param string $status
+ *   Task status.
  *
- * @return array<string>
- *   Updated output.
+ * @return int
+ *   ANSI colour code.
  */
-function collect_output(array $pipes, array $output): array {
-  $stdout = stream_get_contents($pipes[1]);
-  $stderr = stream_get_contents($pipes[2]);
-
-  if ($stdout !== '' && $stdout !== FALSE) {
-    $output[] = $stdout;
-  }
-  if ($stderr !== '' && $stderr !== FALSE) {
-    $output[] = $stderr;
-  }
-
-  return $output;
-}
-
-/**
- * Check whether captured output reports a completed snapshot update.
- *
- * SnapshotTrait emits a completion marker after it finishes rewriting baseline
- * or diff files. When PHPUnit exits non-zero but this marker is present, the
- * snapshot was updated successfully and the dataset must not be treated as a
- * failure.
- *
- * @param array<string> $output
- *   Captured PHPUnit output lines.
- *
- * @return bool
- *   TRUE if a snapshot update completion marker is present.
- */
-function has_update_marker(array $output): bool {
-  $text = implode("\n", $output);
-
-  return str_contains($text, SNAPSHOT_MARKER_BASELINE_UPDATED) || str_contains($text, SNAPSHOT_MARKER_DIFFS_UPDATED);
+function status_color(string $status): int {
+  return match ($status) {
+    STATUS_SUCCESS, STATUS_UPDATED => 32,
+    STATUS_TIMEOUT => 33,
+    default => 31,
+  };
 }
 
 /**
@@ -1237,20 +1158,6 @@ function has_update_marker(array $output): bool {
 function dispatch_signals(): void {
   if (function_exists('pcntl_signal_dispatch')) {
     pcntl_signal_dispatch();
-  }
-}
-
-/**
- * Print debug output if enabled.
- *
- * @param bool $debug
- *   Whether debug is enabled.
- * @param array<string> $output
- *   Output lines.
- */
-function print_debug_output(bool $debug, array $output): void {
-  if ($debug && !empty($output)) {
-    verbose("\n--- DEBUG OUTPUT ---\n%s\n--- END DEBUG ---\n\n", implode("\n", $output));
   }
 }
 
@@ -1346,9 +1253,8 @@ if (getenv('SCRIPT_RUN_SKIP') != 1) {
 
   try {
     $argv = is_array($_SERVER['argv'] ?? NULL) ? array_filter($_SERVER['argv'], is_string(...)) : [];
-    $argc = is_scalar($_SERVER['argc'] ?? NULL) ? (int) $_SERVER['argc'] : 0;
     // The function throws exceptions instead of providing an exit code.
-    main($argv, $argc);
+    main($argv);
   }
   catch (\ErrorException $exception) {
     if ($exception->getSeverity() <= E_USER_WARNING) {

--- a/bin/update-snapshots
+++ b/bin/update-snapshots
@@ -50,7 +50,9 @@ define('STATUS_TIMEOUT', 'timeout');
 // Exit code reported by 'timeout' when a run exceeds its time limit.
 define('EXIT_CODE_TIMEOUT', 124);
 
-// Exit codes reported for a process stopped by SIGINT and by SIGTERM.
+// Exit codes reported for a process stopped by SIGINT and by SIGTERM. Only the
+// script's own SIGTERM handler reports 143; a child that exits with it is
+// classified as failed like any other non-zero exit.
 define('EXIT_CODE_INTERRUPTED', 130);
 define('EXIT_CODE_TERMINATED', 143);
 
@@ -680,7 +682,7 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
     unset($task);
 
     // The poll loop can end the script when a child reports an interrupt, so
-    // processes are registered before it runs and again once it returns.
+    // processes are registered before it runs.
     live_tasks($tasks);
 
     foreach ($tasks as &$task) {
@@ -691,8 +693,6 @@ function run_engine(array $datasets, array $config, int $jobs, int $start_number
       $task = poll_task($task, $config);
     }
     unset($task);
-
-    live_tasks($tasks);
 
     render_progress($tasks, $run);
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "phpbench/phpbench": "^1.7.0",
         "phpstan/phpstan": "^2.2.13",
         "phpunit/phpunit": "^11.5.56",
-        "rector/rector": "^2.6.6"
+        "rector/rector": "^2.6.6",
+        "symfony/process": "^7.2"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/tests/phpunit/Fixtures/functional_update/README.md
+++ b/tests/phpunit/Fixtures/functional_update/README.md
@@ -69,30 +69,34 @@ functional_update/
 │       └── scenario1/
 │           └── scenario_file.txt # "new scenario content"
 │
-└── both_change/                  # Scenario: baseline AND scenario need update
-    ├── .gitignore
-    ├── phpunit.xml
-    ├── composer.json
-    ├── tests/
-    │   ├── SnapshotTest.php
-    │   └── snapshots/
-    │       ├── _baseline/
-    │       │   ├── file1.txt     # "original content"
-    │       │   └── file2.txt     # "content 2"
-    │       └── scenario1/
-    │           ├── .gitkeep
-    │           └── .ignorecontent
-    ├── actual/
-    │   ├── file1.txt             # "modified content for baseline" ← DIFFERS
-    │   ├── file2.txt             # "content 2"
-    │   └── scenario_file.txt     # "new scenario content" ← NEW FILE
-    └── expected/
-        ├── _baseline/
-        │   ├── file1.txt         # "modified content for baseline"
-        │   ├── file2.txt         # "content 2"
-        │   └── scenario_file.txt # "new scenario content" (merged into baseline)
-        └── scenario1/
-            └── .gitkeep          # Empty (no diffs after baseline update)
+├── both_change/                  # Scenario: baseline AND scenario need update
+│   ├── .gitignore
+│   ├── phpunit.xml
+│   ├── composer.json
+│   ├── tests/
+│   │   ├── SnapshotTest.php
+│   │   └── snapshots/
+│   │       ├── _baseline/
+│   │       │   ├── file1.txt     # "original content"
+│   │       │   └── file2.txt     # "content 2"
+│   │       └── scenario1/
+│   │           ├── .gitkeep
+│   │           └── .ignorecontent
+│   ├── actual/
+│   │   ├── file1.txt             # "modified content for baseline" ← DIFFERS
+│   │   ├── file2.txt             # "content 2"
+│   │   └── scenario_file.txt     # "new scenario content" ← NEW FILE
+│   └── expected/
+│       ├── _baseline/
+│       │   ├── file1.txt         # "modified content for baseline"
+│       │   ├── file2.txt         # "content 2"
+│       │   └── scenario_file.txt # "new scenario content" (merged into baseline)
+│       └── scenario1/
+│           └── .gitkeep          # Empty (no diffs after baseline update)
+│
+├── scenario_only_change/         # Scenario: only the scenario diff is stale
+├── genuine_failure/              # Scenario: a failure no update can fix
+└── slow/                         # Scenario: a dataset that outlives a signal
 ```
 
 ## Test Scenarios

--- a/tests/phpunit/Fixtures/functional_update/README.md
+++ b/tests/phpunit/Fixtures/functional_update/README.md
@@ -180,6 +180,19 @@ functional_update/
 4. The `failing` dataset fails for a non-snapshot reason → no `[SNAPSHOT]` completion marker is emitted
 5. Assert: script exits non-zero, no commit is created
 
+### slow
+
+**Test**: `testSignalStopsSpawnedProcesses`
+
+**Purpose**: Verify a signal stops the script and every PHPUnit process it spawned.
+
+**Flow**:
+1. Copy `slow/` to `$sut/test_project/`
+2. Run `update-snapshots testSnapshot tests/snapshots` (all datasets)
+3. The only dataset writes `running.marker` and then sleeps, so its PHPUnit process is still alive when the script is signalled
+4. Send `SIGINT` or `SIGTERM` to the script
+5. Assert: script reports the interruption and exits `130` (SIGINT) or `143` (SIGTERM), and no spawned PHPUnit process survives
+
 ## File Contents
 
 | File                                       | Content                         |

--- a/tests/phpunit/Fixtures/functional_update/README.md
+++ b/tests/phpunit/Fixtures/functional_update/README.md
@@ -186,16 +186,22 @@ functional_update/
 
 ### slow
 
-**Test**: `testSignalStopsSpawnedProcesses`
+**Test**: `testSignalStopsSpawnedProcesses`, `testTimeoutRetriesReportAttemptCount`
 
-**Purpose**: Verify a signal stops the script and every PHPUnit process it spawned.
+**Purpose**: Verify a signal stops the script and every PHPUnit process it spawned, and that a dataset retried after a timeout reports the attempt it ended on.
 
-**Flow**:
+**Flow** (`testSignalStopsSpawnedProcesses`):
 1. Copy `slow/` to `$sut/test_project/`
 2. Run `update-snapshots testSnapshot tests/snapshots` (all datasets)
 3. The only dataset writes `running.marker` and then sleeps, so its PHPUnit process is still alive when the script is signalled
 4. Send `SIGINT` or `SIGTERM` to the script
 5. Assert: script reports the interruption and exits `130` (SIGINT) or `143` (SIGTERM), and no spawned PHPUnit process survives
+
+**Flow** (`testTimeoutRetriesReportAttemptCount`):
+1. Copy `slow/` to `$sut/test_project/`
+2. Run `update-snapshots --timeout=1 --retries=2 testSnapshot tests/snapshots slow` (specified dataset)
+3. The dataset sleeps past the timeout on every attempt, so each run is killed and the dataset is retried until the retry budget is spent
+4. Assert: the result line reports `(attempt 2/2)`, the dataset appears in `Failed datasets: slow`, and the script exits non-zero
 
 ## File Contents
 

--- a/tests/phpunit/Fixtures/functional_update/slow/composer.json
+++ b/tests/phpunit/Fixtures/functional_update/slow/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "test/project",
+  "autoload-dev": {
+    "psr-4": {
+      "Test\\": "tests/"
+    }
+  }
+}

--- a/tests/phpunit/Fixtures/functional_update/slow/phpunit.xml
+++ b/tests/phpunit/Fixtures/functional_update/slow/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/phpunit/Fixtures/functional_update/slow/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/slow/tests/SnapshotTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class whose only dataset outlives the signal sent to the script.
+ *
+ * The update-snapshots script must terminate this run when it is signalled,
+ * so the test sleeps long enough to still be alive at that point. It writes a
+ * marker file first: the file name is shared with the functional test, which
+ * waits for it before signalling.
+ */
+final class SnapshotTest extends TestCase {
+
+  /**
+   * Test snapshot matching.
+   */
+  #[DataProvider('dataProviderSnapshot')]
+  public function testSnapshot(string $dataset): void {
+    file_put_contents(dirname(__DIR__) . '/running.marker', $dataset);
+
+    sleep(60);
+
+    $this->assertSame('slow', $dataset);
+  }
+
+  /**
+   * Data provider for snapshot tests.
+   *
+   * @return \Iterator<string, array{string}>
+   *   Array of dataset names.
+   */
+  public static function dataProviderSnapshot(): \Iterator {
+    yield 'slow' => ['slow'];
+  }
+
+}

--- a/tests/phpunit/Fixtures/functional_update/slow/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/slow/tests/SnapshotTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test class whose only dataset outlives the signal sent to the script.
+ * Test class whose only dataset runs longer than the script lets it.
  *
- * The update-snapshots script must terminate this run when it is signalled,
- * so the test sleeps long enough to still be alive at that point. It writes a
- * marker file first: the file name is shared with the functional test, which
- * waits for it before signalling.
+ * The sleep outlasts both the signal sent by the interruption test and the
+ * short timeout used by the retry test, so the run is always ended from the
+ * outside. It writes a marker file first: the file name is shared with the
+ * functional test, which waits for it before signalling.
  */
 final class SnapshotTest extends TestCase {
 

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -552,6 +552,36 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   }
 
   /**
+   * Test that a dataset retried after a timeout reports its attempt count.
+   *
+   * Scenario: slow
+   * - The dataset sleeps far longer than the timeout, so every attempt is
+   *   killed and the dataset is retried until the retry budget is spent.
+   * - Expected: the result line names the attempt the dataset ended on, and
+   *   the exhausted dataset is reported as failed.
+   */
+  public function testTimeoutRetriesReportAttemptCount(): void {
+    $this->setupTestProject('slow');
+
+    $this->processRun('php', [
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=1',
+      '--retries=2',
+      'testSnapshot',
+      'tests/snapshots',
+      'slow',
+    ]);
+
+    $this->assertProcessFailed();
+    $this->assertProcessOutputContains('Running 1 specified dataset(s)');
+    $this->assertProcessOutputContains('(attempt 2/2)');
+    $this->assertProcessOutputContains('Timed out: 1');
+    $this->assertProcessOutputContains('Failed datasets: slow');
+  }
+
+  /**
    * Test that a signal stops the script and every process it spawned.
    *
    * Scenario: slow

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -323,10 +323,10 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   /**
    * Test that stderr from snapshotUpdateOnFailure() is captured separately.
    *
-   * The run_phpunit() function uses proc_open with separate pipes for
-   * stdout and stderr. The [SNAPSHOT] messages written to stderr by
-   * snapshotUpdateOnFailure() must not be merged into stdout (no 2>&1),
-   * as this can cause false PHPUnit errors.
+   * The script spawns PHPUnit with separate pipes for stdout and stderr. The
+   * [SNAPSHOT] messages written to stderr by snapshotUpdateOnFailure() must
+   * not be merged into stdout (no 2>&1), as this can cause false PHPUnit
+   * errors.
    *
    * Scenario: scenario_change with --debug
    * - Run scenario1 dataset (triggers snapshot update with stderr output)

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -28,12 +28,12 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   /**
    * Seconds to wait for a file written by a spawned dataset to appear.
    */
-  protected const WAIT_FOR_FILE = 30;
+  protected const int WAIT_FOR_FILE = 30;
 
   /**
    * Seconds to wait for the signalled script to exit.
    */
-  protected const WAIT_FOR_EXIT = 30;
+  protected const int WAIT_FOR_EXIT = 30;
 
   /**
    * Seconds to wait for spawned processes to disappear.
@@ -41,7 +41,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
    * Far shorter than the fixture's sleep, so a process that only ends when its
    * own test finishes still counts as a survivor.
    */
-  protected const WAIT_FOR_PROCESSES_GONE = 10;
+  protected const int WAIT_FOR_PROCESSES_GONE = 10;
 
   protected string $scriptPath;
 
@@ -642,7 +642,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
       $process->signal($signal);
 
-      $deadline = microtime(TRUE) + static::WAIT_FOR_EXIT;
+      $deadline = microtime(TRUE) + self::WAIT_FOR_EXIT;
       while ($process->isRunning() && microtime(TRUE) < $deadline) {
         usleep(50000);
       }
@@ -679,7 +679,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
    *   TRUE if the file appeared before the wait ended.
    */
   protected function waitForFile(string $path): bool {
-    $deadline = microtime(TRUE) + static::WAIT_FOR_FILE;
+    $deadline = microtime(TRUE) + self::WAIT_FOR_FILE;
 
     do {
       clearstatcache(TRUE, $path);
@@ -704,7 +704,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
    *   Process IDs matching the fragment when the wait ended.
    */
   protected function waitForProcessesGone(string $marker): array {
-    $deadline = microtime(TRUE) + static::WAIT_FOR_PROCESSES_GONE;
+    $deadline = microtime(TRUE) + self::WAIT_FOR_PROCESSES_GONE;
 
     do {
       $pids = $this->findProcesses($marker);

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -25,6 +25,24 @@ use Symfony\Component\Process\Process;
 #[CoversNothing]
 final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
+  /**
+   * Seconds to wait for a file written by a spawned dataset to appear.
+   */
+  protected const WAIT_FOR_FILE = 30;
+
+  /**
+   * Seconds to wait for the signalled script to exit.
+   */
+  protected const WAIT_FOR_EXIT = 30;
+
+  /**
+   * Seconds to wait for spawned processes to disappear.
+   *
+   * Far shorter than the fixture's sleep, so a process that only ends when its
+   * own test finishes still counts as a survivor.
+   */
+  protected const WAIT_FOR_PROCESSES_GONE = 10;
+
   protected string $scriptPath;
 
   protected string $projectDir;
@@ -595,9 +613,10 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
     $this->setupTestProject('slow');
 
     // The project directory is unique per test, so a command line containing
-    // it belongs to this run and to no other. Only dataset runs are passed
-    // '--no-coverage', which keeps dataset discovery out of the match.
-    $marker = $this->projectDir . '/vendor/bin/phpunit --no-coverage';
+    // it belongs to this run and to no other, and only dataset runs are passed
+    // '--no-coverage', which keeps dataset discovery out of the match. The
+    // bracket stops the pattern from matching the shell that runs pgrep.
+    $marker = $this->projectDir . '/vendor/bin/[p]hpunit --no-coverage';
 
     $process = new Process([
       PHP_BINARY,
@@ -623,7 +642,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
       $process->signal($signal);
 
-      $deadline = microtime(TRUE) + 30;
+      $deadline = microtime(TRUE) + static::WAIT_FOR_EXIT;
       while ($process->isRunning() && microtime(TRUE) < $deadline) {
         usleep(50000);
       }
@@ -660,7 +679,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
    *   TRUE if the file appeared before the wait ended.
    */
   protected function waitForFile(string $path): bool {
-    $deadline = microtime(TRUE) + 30;
+    $deadline = microtime(TRUE) + static::WAIT_FOR_FILE;
 
     do {
       clearstatcache(TRUE, $path);
@@ -678,9 +697,6 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
   /**
    * Wait until no process matches a command line fragment.
    *
-   * The wait is far shorter than the fixture's sleep, so a process that only
-   * ends when its own test finishes still counts as a survivor.
-   *
    * @param string $marker
    *   Command line fragment identifying the processes.
    *
@@ -688,7 +704,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
    *   Process IDs matching the fragment when the wait ended.
    */
   protected function waitForProcessesGone(string $marker): array {
-    $deadline = microtime(TRUE) + 10;
+    $deadline = microtime(TRUE) + static::WAIT_FOR_PROCESSES_GONE;
 
     do {
       $pids = $this->findProcesses($marker);

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Process\Process;
  * 4. both_change - Baseline fails, scenario fails → 1 commit (amended).
  * 5. genuine_failure - Non-snapshot failure → non-zero exit, no commit.
  * 6. scenario_only_change - Stale scenario diff updates in parallel run.
+ * 7. slow - Long-running dataset ended by a signal or by the run timeout.
  */
 #[CoversNothing]
 final class SnapshotUpdateScriptTest extends FunctionalTestCase {

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -684,8 +684,7 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
    */
   protected function findProcesses(string $marker): array {
     $output = [];
-    $code = 0;
-    exec(sprintf('pgrep -f %s 2>/dev/null', escapeshellarg($marker)), $output, $code);
+    exec(sprintf('pgrep -f %s 2>/dev/null', escapeshellarg($marker)), $output);
 
     return array_values(array_filter(array_map(trim(...), $output), fn(string $pid): bool => $pid !== ''));
   }

--- a/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
+++ b/tests/phpunit/Functional/SnapshotUpdateScriptTest.php
@@ -7,7 +7,9 @@ namespace AlexSkrypnyk\Snapshot\Tests\Functional;
 use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Snapshot;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Exception;
+use Symfony\Component\Process\Process;
 
 /**
  * Functional tests for the update-snapshots CLI script.
@@ -547,6 +549,145 @@ final class SnapshotUpdateScriptTest extends FunctionalTestCase {
 
     $last_commit_message = $this->getLastCommitMessage();
     $this->assertStringContainsString('Updated', $last_commit_message);
+  }
+
+  /**
+   * Test that a signal stops the script and every process it spawned.
+   *
+   * Scenario: slow
+   * - The only dataset sleeps, so its PHPUnit process is still running when
+   *   the script is signalled.
+   * - Expected: the script reports the interruption, exits with the code for
+   *   the signal, and leaves no spawned PHPUnit process behind.
+   */
+  #[DataProvider('dataProviderSignalStopsSpawnedProcesses')]
+  public function testSignalStopsSpawnedProcesses(int $signal, int $expected_code): void {
+    $this->setupTestProject('slow');
+
+    // The project directory is unique per test, so a command line containing
+    // it belongs to this run and to no other. Only dataset runs are passed
+    // '--no-coverage', which keeps dataset discovery out of the match.
+    $marker = $this->projectDir . '/vendor/bin/phpunit --no-coverage';
+
+    $process = new Process([
+      PHP_BINARY,
+      $this->scriptPath,
+      '--root=' . $this->projectDir,
+      '--test-dir=tests',
+      '--timeout=120',
+      'testSnapshot',
+      'tests/snapshots',
+    ]);
+    $process->setTimeout(120);
+    $process->start();
+
+    try {
+      // The dataset writes this file just before it sleeps. Waiting for it
+      // puts the signal after PHPUnit has written its startup output, so the
+      // pipes the script closes on exit cannot be what ends the spawned run.
+      $this->assertTrue(
+        $this->waitForFile($this->projectDir . '/running.marker'),
+        'Dataset did not start running before the signal was sent'
+      );
+      $this->assertNotEmpty($this->findProcesses($marker), 'No PHPUnit process was running when the signal was sent');
+
+      $process->signal($signal);
+
+      $deadline = microtime(TRUE) + 30;
+      while ($process->isRunning() && microtime(TRUE) < $deadline) {
+        usleep(50000);
+      }
+
+      $this->assertFalse($process->isRunning(), 'Script did not exit after the signal');
+      $this->assertSame($expected_code, $process->getExitCode(), 'Script did not report the exit code of the signal');
+      $this->assertStringContainsString('Interrupted', $process->getOutput(), 'Script did not report the interruption');
+      $this->assertSame([], $this->waitForProcessesGone($marker), 'Spawned PHPUnit processes outlived the script');
+    }
+    finally {
+      $process->stop(0);
+      exec(sprintf('pkill -f %s 2>/dev/null', escapeshellarg($marker)));
+    }
+  }
+
+  /**
+   * Data provider for signal handling.
+   *
+   * @return \Iterator<string, array{int, int}>
+   *   Signal number and the exit code the script must report for it.
+   */
+  public static function dataProviderSignalStopsSpawnedProcesses(): \Iterator {
+    yield 'SIGINT' => [2, 130];
+    yield 'SIGTERM' => [15, 143];
+  }
+
+  /**
+   * Wait for a file to appear.
+   *
+   * @param string $path
+   *   Path to the file.
+   *
+   * @return bool
+   *   TRUE if the file appeared before the wait ended.
+   */
+  protected function waitForFile(string $path): bool {
+    $deadline = microtime(TRUE) + 30;
+
+    do {
+      clearstatcache(TRUE, $path);
+
+      if (file_exists($path)) {
+        return TRUE;
+      }
+
+      usleep(50000);
+    } while (microtime(TRUE) < $deadline);
+
+    return FALSE;
+  }
+
+  /**
+   * Wait until no process matches a command line fragment.
+   *
+   * The wait is far shorter than the fixture's sleep, so a process that only
+   * ends when its own test finishes still counts as a survivor.
+   *
+   * @param string $marker
+   *   Command line fragment identifying the processes.
+   *
+   * @return array<string>
+   *   Process IDs matching the fragment when the wait ended.
+   */
+  protected function waitForProcessesGone(string $marker): array {
+    $deadline = microtime(TRUE) + 10;
+
+    do {
+      $pids = $this->findProcesses($marker);
+
+      if ($pids === []) {
+        return $pids;
+      }
+
+      usleep(50000);
+    } while (microtime(TRUE) < $deadline);
+
+    return $pids;
+  }
+
+  /**
+   * Find processes whose command line contains a fragment.
+   *
+   * @param string $marker
+   *   Command line fragment identifying the processes.
+   *
+   * @return array<string>
+   *   Process IDs matching the fragment.
+   */
+  protected function findProcesses(string $marker): array {
+    $output = [];
+    $code = 0;
+    exec(sprintf('pgrep -f %s 2>/dev/null', escapeshellarg($marker)), $output, $code);
+
+    return array_values(array_filter(array_map(trim(...), $output), fn(string $pid): bool => $pid !== ''));
   }
 
   /**


### PR DESCRIPTION
Closes #54, closes #59, closes #62

## Summary

`bin/update-snapshots` previously implemented its sequential and parallel execution paths twice over, with separate spawners that disagreed on stderr handling, three copies of the PHPUnit command template, two retry loops and two outcome encodings - and its signal handler exited without touching the PHPUnit processes it had spawned. This PR collapses the two paths into one engine, makes the sequential mode the same engine at a concurrency of one, and guarantees that no spawned PHPUnit process outlives the script on any exit path. The guarantee is pinned by new functional tests that were verified to fail against the pre-fix script, including on the Linux process topology where an intermediary `sh` previously swallowed the termination signal.

## Changes

### Engine unification (#59)

- One execution path: `run_engine()` with one spawner, one poll loop, one retry/requeue mechanism and one command-template builder (`build_phpunit_command()`, also feeding `--list-tests` discovery); the sequential mode is the engine at concurrency 1.
- stdout and stderr are captured separately everywhere (no `2>&1` remains); `[SNAPSHOT]` completion markers are detected on stderr.
- One outcome encoding end-to-end: the strings `success`, `updated`, `failed`, `timeout` double as the statistics keys; the parallel display labels are the only vocabulary (`Succeeded:`, `Timed out:`).
- Retried datasets are visible: completion lines carry an `(attempt N/M)` suffix, pinned by a deterministic timeout-retry test.
- One TUI session per run via a shared `with_tui()` bracket used by both run modes; plain (non-TTY) mode prints each task's result once as it settles instead of holding everything until the batch completes.
- The spawned command is prefixed `exec env`, so the shell replaces itself and the script's immediate child is `timeout`, which forwards signals to PHPUnit on every platform; the interpolated root path is shell-escaped, so a root containing spaces works.

### Signal handling (#62)

- SIGINT and SIGTERM now terminate every live PHPUnit child (SIGTERM, a bounded 2-second grace, then SIGKILL for stragglers) via a module-level task registry, exiting `130` and `143` respectively.
- The reaper also sweeps each child's descendant PIDs (recursive `pgrep -P` walk) and is registered as a shutdown function, so uncaught internal errors cannot orphan children either.
- Pinned by `testSignalStopsSpawnedProcesses` (SIGINT/SIGTERM data provider against a new minimal `slow` fixture with a marker-file handshake and named wait bounds) - verified to fail against the pre-fix script on both macOS and the reproduced Linux topology.
- `symfony/process` is declared in `require-dev` (the tests now use it directly).

### Documentation (#54 and supporting)

- The run-statistics `@return` documents all four keys, including `updated` - the script's central outcome.
- README states the signal guarantee precisely (scoped to running datasets, `pcntl` requirement named) and the fixtures README documents all seven scenario fixtures, including both consumers of `slow`.

## Merge order

This PR is independent of the other PRs in this series and can be merged at any time, in any order.

## Before / After

```
Before                                        After
──────────────────────────────────────       ──────────────────────────────────────
run_phpunit()        start_task()             run_engine()  (jobs=1 == sequential)
 ├ own proc_open      ├ own proc_open          ├ build_phpunit_command()  (exec env)
 ├ own retry loop     ├ own requeue            ├ one spawner + poll + requeue
 ├ stderr separate    ├ stderr merged          ├ stderr captured separately
 └ int outcomes 0-3   └ string outcomes        └ outcomes: success/updated/failed/timeout

SIGTERM ──> script exits alone                SIGTERM/SIGINT/shutdown ──> kill_all_tasks()
            │                                             │
            └─ timeout ── php phpunit                     ├─ SIGTERM children + descendants
               (orphaned, still writing                   ├─ 2s grace, then SIGKILL
                snapshots with                            └─ exit 143 / 130, zero survivors
                UPDATE_SNAPSHOTS=1)
```
