### PR TITLE
[#47] [#49] [#52] Fixed 'isBaseline()' matching and passed 'Rules' through 'patch()' and 'sync()'.

### DIFF
--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -57,7 +57,9 @@ class Comparer implements ComparerInterface {
       // getFiles() allows a transform callback to return non-file values;
       // skip anything that is not a file since none is passed here.
       if (!$left_file instanceof IndexedFileInterface) {
+        // @codeCoverageIgnoreStart
         continue;
+        // @codeCoverageIgnoreEnd
       }
 
       ($this->diffs[$path] ??= new Diff())->setLeft($left_file);
@@ -70,7 +72,9 @@ class Comparer implements ComparerInterface {
 
     foreach ($right_files as $path => $right_file) {
       if (!$right_file instanceof IndexedFileInterface) {
+        // @codeCoverageIgnoreStart
         continue;
+        // @codeCoverageIgnoreEnd
       }
 
       ($this->diffs[$path] ??= new Diff())->setRight($right_file);

--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -54,14 +54,25 @@ class Comparer implements ComparerInterface {
     // that addLeftFile()/addRightFile() would recompute, so they are reused
     // as the diff keys.
     foreach ($left_files as $path => $left_file) {
+      // getFiles() allows a transform callback to return non-file values;
+      // skip anything that is not a file since none is passed here.
+      if (!$left_file instanceof IndexedFileInterface) {
+        continue;
+      }
+
       ($this->diffs[$path] ??= new Diff())->setLeft($left_file);
-      if (isset($right_files[$path])) {
+
+      if (isset($right_files[$path]) && $right_files[$path] instanceof IndexedFileInterface) {
         $this->diffs[$path]->setRight($right_files[$path]);
         unset($right_files[$path]);
       }
     }
 
     foreach ($right_files as $path => $right_file) {
+      if (!$right_file instanceof IndexedFileInterface) {
+        continue;
+      }
+
       ($this->diffs[$path] ??= new Diff())->setRight($right_file);
     }
 

--- a/src/Index/IndexInterface.php
+++ b/src/Index/IndexInterface.php
@@ -17,7 +17,7 @@ interface IndexInterface {
    * @param callable|null $cb
    *   Optional callback to transform each file.
    *
-   * @return array<string, \AlexSkrypnyk\Snapshot\Index\IndexedFileInterface>
+   * @return array<string, \AlexSkrypnyk\Snapshot\Index\IndexedFileInterface|mixed>
    *   Array of files indexed by path relative to base directory.
    */
   public function getFiles(?callable $cb = NULL): array;

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -8,6 +8,7 @@ use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Compare\Comparer;
 use AlexSkrypnyk\Snapshot\Compare\Diff;
 use AlexSkrypnyk\Snapshot\Index\Index;
+use AlexSkrypnyk\Snapshot\Index\IndexedFileInterface;
 use AlexSkrypnyk\Snapshot\Patch\Patcher;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
 use AlexSkrypnyk\Snapshot\Sync\Syncer;
@@ -161,6 +162,12 @@ class Snapshot {
 
     $patch_index = self::scan($patches, $rules);
     foreach ($patch_index->getFiles() as $file) {
+      // getFiles() allows a transform callback to return non-file values;
+      // skip anything that is not a file since none is passed here.
+      if (!$file instanceof IndexedFileInterface) {
+        continue;
+      }
+
       $basename = $file->getBasename();
       $relative_path = $file->getPathnameFromBasepath();
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -147,17 +147,19 @@ class Snapshot {
    *   Directory containing patch/diff files.
    * @param string $destination
    *   Destination directory for patched output.
+   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   *   Optional rules applied to the baseline sync and the patches scan.
    * @param callable|null $content_processor
    *   Optional callback to process content after patching.
    */
-  public static function patch(string $baseline, string $patches, string $destination, ?callable $content_processor = NULL): void {
+  public static function patch(string $baseline, string $patches, string $destination, ?Rules $rules = NULL, ?callable $content_processor = NULL): void {
     File::mkdir($destination);
 
-    self::sync($baseline, $destination);
+    self::sync($baseline, $destination, 0755, FALSE, $rules);
 
     $patcher = new Patcher($baseline, $destination);
 
-    $patch_index = self::scan($patches);
+    $patch_index = self::scan($patches, $rules);
     foreach ($patch_index->getFiles() as $file) {
       $basename = $file->getBasename();
       $relative_path = $file->getPathnameFromBasepath();
@@ -205,9 +207,13 @@ class Snapshot {
    *   Directory permissions.
    * @param bool $copy_empty_dirs
    *   Whether to copy empty directories.
+   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   *   Optional comparison rules.
+   * @param callable|null $content_processor
+   *   Optional callback to process file content.
    */
-  public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE): void {
-    $index = self::scan($source);
+  public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, ?Rules $rules = NULL, ?callable $content_processor = NULL): void {
+    $index = self::scan($source, $rules, $content_processor);
     (new Syncer($index))->sync($destination, $permissions, $copy_empty_dirs);
   }
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -165,7 +165,9 @@ class Snapshot {
       // getFiles() allows a transform callback to return non-file values;
       // skip anything that is not a file since none is passed here.
       if (!$file instanceof IndexedFileInterface) {
+        // @codeCoverageIgnoreStart
         continue;
+        // @codeCoverageIgnoreEnd
       }
 
       $basename = $file->getBasename();

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -234,7 +234,7 @@ class Snapshot {
    *   TRUE if path is a baseline directory.
    */
   public static function isBaseline(string $path): bool {
-    return str_contains($path, DIRECTORY_SEPARATOR . self::BASELINE_DIR);
+    return basename($path) === self::BASELINE_DIR;
   }
 
 }

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -7,7 +7,6 @@ namespace AlexSkrypnyk\Snapshot;
 use AlexSkrypnyk\Snapshot\Compare\Comparer;
 use AlexSkrypnyk\Snapshot\Index\Index;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
-use AlexSkrypnyk\Snapshot\Sync\Syncer;
 
 /**
  * Configurable snapshot builder for repeated operations.
@@ -208,7 +207,7 @@ class SnapshotBuilder {
    *   Return self for chaining.
    */
   public function patch(string $baseline, string $patches, string $destination): static {
-    Snapshot::patch($baseline, $patches, $destination, $this->contentProcessor);
+    Snapshot::patch($baseline, $patches, $destination, $this->rules, $this->contentProcessor);
     return $this;
   }
 
@@ -228,8 +227,7 @@ class SnapshotBuilder {
    *   Return self for chaining.
    */
   public function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE): static {
-    $index = new Index($source, $this->rules, $this->contentProcessor);
-    (new Syncer($index))->sync($destination, $permissions, $copy_empty_dirs);
+    Snapshot::sync($source, $destination, $permissions, $copy_empty_dirs, $this->rules, $this->contentProcessor);
     return $this;
   }
 

--- a/src/Sync/Syncer.php
+++ b/src/Sync/Syncer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\Snapshot\Sync;
 
 use AlexSkrypnyk\File\File;
+use AlexSkrypnyk\Snapshot\Index\IndexedFileInterface;
 use AlexSkrypnyk\Snapshot\Index\IndexInterface;
 
 /**
@@ -30,6 +31,12 @@ class Syncer implements SyncerInterface {
     File::mkdir($dst, $permissions);
 
     foreach ($this->srcIndex->getFiles() as $file) {
+      // getFiles() allows a transform callback to return non-file values;
+      // skip anything that is not a file since none is passed here.
+      if (!$file instanceof IndexedFileInterface) {
+        continue;
+      }
+
       $absolute_src_path = $file->getPathname();
       $absolute_dst_path = $dst . DIRECTORY_SEPARATOR . $file->getPathnameFromBasepath();
       if ($file->isIgnoreContent()) {

--- a/src/Sync/Syncer.php
+++ b/src/Sync/Syncer.php
@@ -34,7 +34,9 @@ class Syncer implements SyncerInterface {
       // getFiles() allows a transform callback to return non-file values;
       // skip anything that is not a file since none is passed here.
       if (!$file instanceof IndexedFileInterface) {
+        // @codeCoverageIgnoreStart
         continue;
+        // @codeCoverageIgnoreEnd
       }
 
       $absolute_src_path = $file->getPathname();

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -6,6 +6,7 @@ namespace AlexSkrypnyk\Snapshot\Testing;
 
 use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Exception\PatchException;
+use AlexSkrypnyk\Snapshot\Rules\Rules;
 use AlexSkrypnyk\Snapshot\Snapshot;
 use PHPUnit\Framework\TestStatus\Error;
 use PHPUnit\Framework\TestStatus\Failure;
@@ -48,9 +49,11 @@ trait SnapshotTrait {
    *   Optional callback to process file content before comparison.
    * @param bool $show_diff
    *   Whether to include diff output in failure messages.
+   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   *   Optional comparison rules.
    */
-  public function assertDirectoriesIdentical(string $dir1, string $dir2, ?string $message = NULL, ?callable $match_content = NULL, bool $show_diff = TRUE): void {
-    $text = Snapshot::compare($dir1, $dir2, NULL, $match_content)->render(['show_diff' => $show_diff]);
+  public function assertDirectoriesIdentical(string $dir1, string $dir2, ?string $message = NULL, ?callable $match_content = NULL, bool $show_diff = TRUE, ?Rules $rules = NULL): void {
+    $text = Snapshot::compare($dir1, $dir2, $rules, $match_content)->render(['show_diff' => $show_diff]);
     if (!empty($text)) {
       $this->fail($message ? $message . PHP_EOL . $text : $text);
     }

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -290,27 +290,15 @@ final class IndexTest extends UnitTestCase {
 
       $files = $index->getFiles();
 
-      $this->assertArrayHasKey('symlink_file.txt', $files);
-      $symlink_file_entry = $files['symlink_file.txt'];
-      if (!$symlink_file_entry instanceof IndexedFileInterface) {
-        $this->fail('Expected symlink_file.txt to be indexed as a file.');
-      }
+      $symlink_file_entry = $this->assertIndexedFile($files, 'symlink_file.txt');
 
-      $this->assertArrayHasKey('symlink_dir', $files);
-      $symlink_dir_entry = $files['symlink_dir'];
-      if (!$symlink_dir_entry instanceof IndexedFileInterface) {
-        $this->fail('Expected symlink_dir to be indexed as a file.');
-      }
+      $symlink_dir_entry = $this->assertIndexedFile($files, 'symlink_dir');
 
       // Whether a broken symlink is included depends on implementation
       // details, so neither its presence nor its absence is asserted here.
       // The original file is indexed through both the direct path and the
       // symlink.
-      $this->assertArrayHasKey('dir1/file1.txt', $files);
-      $dir1_file1_entry = $files['dir1/file1.txt'];
-      if (!$dir1_file1_entry instanceof IndexedFileInterface) {
-        $this->fail('Expected dir1/file1.txt to be indexed as a file.');
-      }
+      $dir1_file1_entry = $this->assertIndexedFile($files, 'dir1/file1.txt');
 
       $this->assertSame('Original file content', $dir1_file1_entry->getContent());
 
@@ -403,6 +391,17 @@ final class IndexTest extends UnitTestCase {
     finally {
       File::rmdir($test_dir);
     }
+  }
+
+  protected function assertIndexedFile(array $files, string $key): IndexedFileInterface {
+    $this->assertArrayHasKey($key, $files);
+
+    $file = $files[$key];
+    if (!$file instanceof IndexedFileInterface) {
+      $this->fail(sprintf('Expected %s to be indexed as a file.', $key));
+    }
+
+    return $file;
   }
 
   public static function locationsTmp(): string {

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -7,6 +7,7 @@ namespace AlexSkrypnyk\Snapshot\Tests\Unit;
 use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Index\Index;
 use AlexSkrypnyk\Snapshot\Index\IndexedFile;
+use AlexSkrypnyk\Snapshot\Index\IndexedFileInterface;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
 use AlexSkrypnyk\Snapshot\Snapshot;
 use AlexSkrypnyk\Snapshot\Tests\UnitTestCase;
@@ -290,19 +291,31 @@ final class IndexTest extends UnitTestCase {
       $files = $index->getFiles();
 
       $this->assertArrayHasKey('symlink_file.txt', $files);
+      $symlink_file_entry = $files['symlink_file.txt'];
+      if (!$symlink_file_entry instanceof IndexedFileInterface) {
+        $this->fail('Expected symlink_file.txt to be indexed as a file.');
+      }
 
       $this->assertArrayHasKey('symlink_dir', $files);
+      $symlink_dir_entry = $files['symlink_dir'];
+      if (!$symlink_dir_entry instanceof IndexedFileInterface) {
+        $this->fail('Expected symlink_dir to be indexed as a file.');
+      }
 
       // Whether a broken symlink is included depends on implementation
       // details, so neither its presence nor its absence is asserted here.
       // The original file is indexed through both the direct path and the
       // symlink.
       $this->assertArrayHasKey('dir1/file1.txt', $files);
+      $dir1_file1_entry = $files['dir1/file1.txt'];
+      if (!$dir1_file1_entry instanceof IndexedFileInterface) {
+        $this->fail('Expected dir1/file1.txt to be indexed as a file.');
+      }
 
-      $this->assertSame('Original file content', $files['dir1/file1.txt']->getContent());
+      $this->assertSame('Original file content', $dir1_file1_entry->getContent());
 
-      $this->assertTrue($files['symlink_file.txt']->isLink());
-      $this->assertTrue($files['symlink_dir']->isLink());
+      $this->assertTrue($symlink_file_entry->isLink());
+      $this->assertTrue($symlink_dir_entry->isLink());
     }
     finally {
       if (file_exists($symlink_file)) {

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -185,6 +185,40 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $this->assertTrue($processor_called, 'Content processor should be called');
   }
 
+  public function testPatchWithRulesHonoursSkip(): void {
+    $baseline = self::$sut . DIRECTORY_SEPARATOR . 'baseline';
+    $patches = self::$sut . DIRECTORY_SEPARATOR . 'patches';
+    $destination = self::$sut . DIRECTORY_SEPARATOR . 'destination';
+    mkdir($baseline, 0777, TRUE);
+    mkdir($patches, 0777, TRUE);
+
+    file_put_contents($baseline . DIRECTORY_SEPARATOR . 'keep.txt', 'keep content');
+    file_put_contents($baseline . DIRECTORY_SEPARATOR . 'skip.txt', 'secret content');
+
+    $builder = SnapshotBuilder::create()->withRules(Rules::create()->skip('skip.txt'));
+    $result = $builder->patch($baseline, $patches, $destination);
+
+    $this->assertSame($builder, $result);
+    $this->assertFileExists($destination . DIRECTORY_SEPARATOR . 'keep.txt');
+    $this->assertFileDoesNotExist($destination . DIRECTORY_SEPARATOR . 'skip.txt');
+  }
+
+  public function testSyncWithRulesHonoursSkip(): void {
+    $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
+    $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
+    mkdir($src, 0777, TRUE);
+
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'keep.txt', 'keep content');
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'skip.txt', 'secret content');
+
+    $builder = SnapshotBuilder::create()->withRules(Rules::create()->skip('skip.txt'));
+    $result = $builder->sync($src, $dst);
+
+    $this->assertSame($builder, $result);
+    $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'keep.txt');
+    $this->assertFileDoesNotExist($dst . DIRECTORY_SEPARATOR . 'skip.txt');
+  }
+
   public function testFluentOperationChaining(): void {
     $src = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . 'directory2');
     $expected = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal' . DIRECTORY_SEPARATOR . 'directory1');

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -321,11 +321,19 @@ ABSENT,
     $this->assertSame($baseline_dir, $result);
   }
 
-  public function testIsBaseline(): void {
-    $this->assertTrue(Snapshot::isBaseline('/path/to/' . Snapshot::BASELINE_DIR . '/file.txt'));
-    $this->assertTrue(Snapshot::isBaseline('/path/' . Snapshot::BASELINE_DIR));
-    $this->assertFalse(Snapshot::isBaseline('/path/to/regular/directory'));
-    $this->assertFalse(Snapshot::isBaseline('/path/to/snapshot'));
+  #[DataProvider('dataProviderIsBaseline')]
+  public function testIsBaseline(string $path, bool $expected): void {
+    $this->assertSame($expected, Snapshot::isBaseline($path));
+  }
+
+  public static function dataProviderIsBaseline(): \Iterator {
+    yield 'baseline directory' => ['snapshots' . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR, TRUE];
+    yield 'baseline directory with trailing separator' => ['snapshots' . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR . DIRECTORY_SEPARATOR, TRUE];
+    yield 'bare baseline directory' => [Snapshot::BASELINE_DIR, TRUE];
+    yield 'file inside baseline directory' => ['snapshots' . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'App.php', FALSE];
+    yield 'sibling directory with baseline prefix' => ['snapshots' . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR . '_backup', FALSE];
+    yield 'file inside sibling directory with baseline prefix' => ['snapshots' . DIRECTORY_SEPARATOR . Snapshot::BASELINE_DIR . '_old' . DIRECTORY_SEPARATOR . 'x', FALSE];
+    yield 'regular scenario directory' => ['snapshots' . DIRECTORY_SEPARATOR . 'scenario_one', FALSE];
   }
 
   public function testCompareWithRules(): void {

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -285,7 +285,7 @@ ABSENT,
       return $content;
     };
 
-    Snapshot::patch($baseline, $diff, self::$sut, $processor);
+    Snapshot::patch($baseline, $diff, self::$sut, NULL, $processor);
 
     $this->assertTrue($processor_called, 'Content processor should be called');
   }
@@ -296,7 +296,7 @@ ABSENT,
 
     $processor = fn(string $content): string => str_replace('f1l1', 'REPLACED', $content);
 
-    Snapshot::patch($baseline, $diff, self::$sut, $processor);
+    Snapshot::patch($baseline, $diff, self::$sut, NULL, $processor);
 
     $files = File::scandir(self::$sut);
     $modified = FALSE;
@@ -452,6 +452,46 @@ ABSENT,
     $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'subdir' . DIRECTORY_SEPARATOR . 'nested.txt');
     $this->assertSame('nested content', file_get_contents($dst . DIRECTORY_SEPARATOR . 'subdir' . DIRECTORY_SEPARATOR . 'nested.txt'));
     $this->assertTrue(is_link($dst . DIRECTORY_SEPARATOR . 'link.txt'));
+  }
+
+  public function testPatchWithRules(): void {
+    $baseline = self::$sut . DIRECTORY_SEPARATOR . 'baseline';
+    $patches = self::$sut . DIRECTORY_SEPARATOR . 'patches';
+    $destination = self::$sut . DIRECTORY_SEPARATOR . 'destination';
+    mkdir($baseline, 0777, TRUE);
+    mkdir($patches, 0777, TRUE);
+
+    file_put_contents($baseline . DIRECTORY_SEPARATOR . 'keep.txt', 'keep content');
+    file_put_contents($baseline . DIRECTORY_SEPARATOR . 'skip.txt', 'secret baseline content');
+    file_put_contents($patches . DIRECTORY_SEPARATOR . 'newfile.txt', 'new content');
+    file_put_contents($patches . DIRECTORY_SEPARATOR . 'skip.txt', 'secret patch content');
+
+    $rules = Rules::create()->skip('skip.txt');
+
+    Snapshot::patch($baseline, $patches, $destination, $rules);
+
+    $this->assertFileExists($destination . DIRECTORY_SEPARATOR . 'keep.txt');
+    $this->assertFileExists($destination . DIRECTORY_SEPARATOR . 'newfile.txt');
+    $this->assertFileDoesNotExist($destination . DIRECTORY_SEPARATOR . 'skip.txt');
+  }
+
+  public function testSyncWithRulesAndProcessor(): void {
+    $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
+    $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
+    mkdir($src, 0777, TRUE);
+
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'keep.txt', 'keep content');
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'skip.txt', 'secret content');
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'excluded.txt', 'exclude-me content');
+
+    $rules = Rules::create()->skip('skip.txt');
+    $processor = fn(IndexedFile $file): bool => !str_contains($file->getContent(), 'exclude-me');
+
+    Snapshot::sync($src, $dst, 0755, FALSE, $rules, $processor);
+
+    $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'keep.txt');
+    $this->assertFileDoesNotExist($dst . DIRECTORY_SEPARATOR . 'skip.txt');
+    $this->assertFileDoesNotExist($dst . DIRECTORY_SEPARATOR . 'excluded.txt');
   }
 
 }

--- a/tests/phpunit/Unit/SnapshotTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotTraitTest.php
@@ -113,17 +113,8 @@ final class SnapshotTraitTest extends TestCase {
     file_put_contents($dir1 . DIRECTORY_SEPARATOR . 'file1.txt', 'Content 1');
     file_put_contents($dir2 . DIRECTORY_SEPARATOR . 'file1.txt', 'Different content');
 
-    try {
-      $this->assertDirectoriesIdentical($dir1, $dir2);
-      $this->fail('Assertion should have failed for different file content');
-    }
-    catch (AssertionFailedError $assertion_failed_error) {
-      $this->assertStringContainsString('file1.txt', $assertion_failed_error->getMessage());
-    }
-
     $rules = Rules::create()->skip('file1.txt');
     $this->assertDirectoriesIdentical($dir1, $dir2, NULL, NULL, TRUE, $rules);
-    $this->addToAssertionCount(1);
   }
 
   public function testAssertSnapshotMatchesBaselinePositive(): void {

--- a/tests/phpunit/Unit/SnapshotTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotTraitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\Snapshot\Tests\Unit;
 
 use AlexSkrypnyk\File\File;
+use AlexSkrypnyk\Snapshot\Rules\Rules;
 use AlexSkrypnyk\Snapshot\Snapshot;
 use AlexSkrypnyk\Snapshot\Testing\SnapshotTrait;
 use PHPUnit\Framework\AssertionFailedError;
@@ -100,6 +101,29 @@ final class SnapshotTraitTest extends TestCase {
       $this->assertStringContainsString('file2.txt', $assertion_failed_error->getMessage());
       $this->assertStringContainsString('file3.txt', $assertion_failed_error->getMessage());
     }
+  }
+
+  public function testAssertDirectoriesIdenticalWithRulesIgnoresSkippedDifference(): void {
+    $dir1 = $this->tmpDir . DIRECTORY_SEPARATOR . 'dir1';
+    $dir2 = $this->tmpDir . DIRECTORY_SEPARATOR . 'dir2';
+
+    mkdir($dir1, 0777, TRUE);
+    mkdir($dir2, 0777, TRUE);
+
+    file_put_contents($dir1 . DIRECTORY_SEPARATOR . 'file1.txt', 'Content 1');
+    file_put_contents($dir2 . DIRECTORY_SEPARATOR . 'file1.txt', 'Different content');
+
+    try {
+      $this->assertDirectoriesIdentical($dir1, $dir2);
+      $this->fail('Assertion should have failed for different file content');
+    }
+    catch (AssertionFailedError $assertion_failed_error) {
+      $this->assertStringContainsString('file1.txt', $assertion_failed_error->getMessage());
+    }
+
+    $rules = Rules::create()->skip('file1.txt');
+    $this->assertDirectoriesIdentical($dir1, $dir2, NULL, NULL, TRUE, $rules);
+    $this->addToAssertionCount(1);
   }
 
   public function testAssertSnapshotMatchesBaselinePositive(): void {


### PR DESCRIPTION
Closes #47, closes #49, closes #52

## Summary

Fixed `Snapshot::isBaseline()` matching sibling directories that merely share the baseline directory name as a prefix, such as `_baseline_backup`, by comparing the final path segment instead of a substring. Added an optional `Rules` parameter to `Snapshot::patch()` and `Snapshot::sync()` so that skip, include, and ignore-content rules configured on a `SnapshotBuilder` are honoured during patch and sync operations instead of being silently dropped. Updated `SnapshotBuilder::patch()` and `SnapshotBuilder::sync()` to forward their configured rules and content processor to the facade rather than constructing an `Index` independently. Widened the `@return` type of `IndexInterface::getFiles()` to `IndexedFileInterface|mixed`, matching the existing `Comparer` precedent, and added runtime `instanceof` guards at the internal call sites that consume the result.

## Breaking change

`Snapshot::patch()` now takes `?Rules $rules` as its fourth parameter, before the content processor, matching `scan()`/`compare()`/`diff()`. A positional call passing the processor fourth must move it to fifth. The next release containing this change should be tagged as a major version; the release drafter defaults to minor and has no label-based override.

## Changes

### #47 - `isBaseline()` false positives on sibling directories

- Compared the final path segment in `isBaseline()` instead of a substring, so a sibling directory that merely shares the baseline name as a prefix (for example `_baseline_backup`) is no longer treated as a baseline.
- Pinned the fix with a 7-case data provider covering the baseline directory itself, a trailing separator, a bare baseline name, a file inside the baseline directory, a sibling directory with the baseline name as a prefix, a file inside that sibling directory, and a regular scenario directory.

### #49 - `Rules` silently dropped on `patch()` and `sync()`

- Added `?Rules $rules` as the fourth parameter of `Snapshot::patch()`, before `$content_processor`, forwarded to the baseline sync and to the patches scan.
- Appended `?Rules $rules` and `?callable $content_processor` to `Snapshot::sync()`.
- Updated `SnapshotBuilder::patch()` and `SnapshotBuilder::sync()` to forward the builder's configured rules and content processor to the facade; `sync()` now delegates to `Snapshot::sync()` instead of building its own `Index`.
- Appended a trailing `?Rules $rules` parameter to `SnapshotTrait::assertDirectoriesIdentical()`.
- Added five tests pinning the previously-silent rules drop across `patch()`, `sync()`, and `assertDirectoriesIdentical()`.

### #52 - `getFiles()` return type too narrow for transform callbacks

- Widened the `@return` type of `IndexInterface::getFiles()` to `IndexedFileInterface|mixed`, matching the existing `Diff|mixed` precedent on `Comparer`.
- Added runtime `instanceof` guards at the internal call sites in `Comparer`, `Snapshot::patch()`, and `Syncer::sync()` so PHPStan level 9 holds against the widened type.
- Extracted an `assertIndexedFile()` helper in `IndexTest` to narrow the widened type in tests.

## Merge order

This PR is independent of the other PRs in this series and can be merged at any time, in any order. A follow-up API-settlement PR normalises parameter placement across the facade (`sync()` and `assertDirectoriesIdentical()` deliberately append their new parameters here to stay non-breaking until then).

## Before / After

```
BEFORE
+----------------------------------------------------------+
| isBaseline(".../_baseline_backup")                       |
|   str_contains(path, "/" . BASELINE_DIR)                 |
|   => TRUE   (sibling dir treated as baseline)            |
|                                                          |
| SnapshotBuilder::patch($baseline, $patches, $d)          |
|   Snapshot::patch(..., $this->contentProcessor)          |
|   => $this->rules is never forwarded                     |
+----------------------------------------------------------+

AFTER
+----------------------------------------------------------+
| isBaseline(".../_baseline_backup")                       |
|   basename(path) === BASELINE_DIR                        |
|   => FALSE  (only the baseline dir itself)               |
|                                                          |
| SnapshotBuilder::patch($baseline, $patches, $d)          |
|   Snapshot::patch(..., $this->rules,                     |
|     $this->contentProcessor)                             |
|   => rules reach the Index via scan()/sync()             |
+----------------------------------------------------------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes `Snapshot::isBaseline()` to match only the baseline directory itself.
- Propagates `Rules` and content processors through patch, sync, builder, and directory-comparison operations.
- Widens `IndexInterface::getFiles()` documentation and adds runtime type guards for transformed values.
- Adds coverage for baseline matching, rules propagation, content processing, and indexed-file type narrowing.
- `Snapshot::patch()` now accepts `?Rules $rules` before the content processor. This is a breaking API change requiring a major release.

## Possibly related

- `#47` — `'isBaseline()' returns TRUE for paths inside and beside the baseline directory`
- `#49` — `Let 'Rules' reach 'Snapshot::patch()' and 'Snapshot::sync()'`
- `#52` — `Reconcile 'getFiles()' return type with its transform callback`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->