### PR TITLE
[#45] [#63] [#64] Made include rules override globals and split include-content rules from includes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ A pattern is matched in one of two ways, depending on whether it contains a `/`:
 
 A `!` rule overrides either kind: it is matched against both the file name and the relative path, so `!important.log` keeps that file even though `*.log` would otherwise skip it.
 
-A `!^` rule overrides content ignoring instead: `!^composer.lock` keeps comparing that file's content even though `^composer.lock` would otherwise leave it unchecked.
+A `!^` rule overrides content ignoring instead: `!^composer.lock` keeps comparing that file's content even though `^composer.lock` would otherwise leave it unchecked. Unlike `!`, a `!^` rule is matched only against the relative path, the same way a `^` rule is.
 
 #### Why Ignore Content?
 
@@ -313,6 +313,7 @@ $builder = SnapshotBuilder::create()
     ->addSkip('custom/')
     ->addIgnoreContent('custom.lock')
     ->addInclude('custom/keep.txt')
+    ->addIncludeContent('custom/keep.log')
     ->withContentProcessor(fn($content) => trim($content));
 
 // Use the builder for multiple operations
@@ -339,7 +340,8 @@ $rules = Rules::nodeProject(); // Skips node_modules/, ignores lock files
 $rules = Rules::create()
     ->skip('vendor/', 'node_modules/', '.git/')
     ->ignoreContent('composer.lock', 'package-lock.json')
-    ->include('vendor/autoload.php');
+    ->include('vendor/autoload.php')
+    ->includeContent('build-manifest.json');
 
 // Or load them from an existing .ignorecontent file
 $rules = Rules::fromFile($baseline . '/.ignorecontent');

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ A pattern is matched in one of two ways, depending on whether it contains a `/`:
 
 A `!` rule overrides either kind: it is matched against both the file name and the relative path, so `!important.log` keeps that file even though `*.log` would otherwise skip it.
 
+A `!^` rule overrides content ignoring instead: `!^composer.lock` keeps comparing that file's content even though `^composer.lock` would otherwise leave it unchecked.
+
 #### Why Ignore Content?
 
 Some files should exist but have unpredictable or environment-specific content:
@@ -271,6 +273,7 @@ Using `^filename` ensures the file exists without failing on content differences
 | `!cache/keep.txt` | Include this file even though another rule would otherwise skip it |
 | `^composer.lock` | Check that the file exists, but do not compare its content |
 | `^cache/` | Check that files under the directory exist, but do not compare their content |
+| `!^composer.lock` | Compare this file's content even though a `^` rule would otherwise ignore it |
 
 ### Programmatic API
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,10 @@ build/cache/
 
 A pattern is matched in one of two ways, depending on whether it contains a `/`:
 
-- **Without a `/`** the pattern is matched against the file name alone, so `*.log` skips every `.log` file at any depth. Name patterns are applied before everything else, and a `!` rule does not override them.
-- **With a `/`** the pattern is matched against the path relative to the directory being indexed, so `build/cache/` only skips that one directory. A `!` rule does override a path rule.
+- **Without a `/`** the pattern is matched against the file name alone, so `*.log` skips every `.log` file at any depth.
+- **With a `/`** the pattern is matched against the path relative to the directory being indexed, so `build/cache/` only skips that one directory.
+
+A `!` rule overrides either kind: it is matched against both the file name and the relative path, so `!important.log` keeps that file even though `*.log` would otherwise skip it.
 
 #### Why Ignore Content?
 
@@ -266,7 +268,7 @@ Using `^filename` ensures the file exists without failing on content differences
 | `*.log` | Skip every file whose name matches the glob, at any depth |
 | `cache/` | Skip the directory and everything under it |
 | `cache/*` | Skip the files directly in the directory, but not its subdirectories |
-| `!cache/keep.txt` | Include this file even though a path rule would skip it |
+| `!cache/keep.txt` | Include this file even though another rule would otherwise skip it |
 | `^composer.lock` | Check that the file exists, but do not compare its content |
 | `^cache/` | Check that files under the directory exist, but do not compare their content |
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ A `!` rule overrides either kind: it is matched against both the file name and t
 
 A `!^` rule overrides content ignoring instead: `!^composer.lock` keeps comparing that file's content even though `^composer.lock` would otherwise leave it unchecked. Unlike `!`, a `!^` rule is matched only against the relative path, the same way a `^` rule is.
 
+The `.ignorecontent` file itself and the `.git/` directory are always skipped and cannot be re-included by any `!` rule.
+
 #### Why Ignore Content?
 
 Some files should exist but have unpredictable or environment-specific content:

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -91,6 +91,7 @@ class Index implements IndexInterface {
     $include_patterns = array_unique($this->rules->getInclude());
     $skip_patterns = array_unique($this->rules->getSkip());
     $ignore_content_patterns = array_unique($this->rules->getIgnoreContent());
+    $include_content_patterns = array_unique($this->rules->getIncludeContent());
 
     foreach ($this->iterator($this->directory) as $resource) {
       if (!$resource instanceof \SplFileInfo) {
@@ -128,9 +129,9 @@ class Index implements IndexInterface {
         continue;
       }
 
-      $is_ignore_content = FALSE;
-      if (!$is_included && $this->matchesAnyPattern($relative_path, $ignore_content_patterns)) {
-        $is_ignore_content = TRUE;
+      $is_ignore_content = $this->matchesAnyPattern($relative_path, $ignore_content_patterns);
+      if ($is_ignore_content && !empty($include_content_patterns)) {
+        $is_ignore_content = !$this->matchesAnyPattern($relative_path, $include_content_patterns);
       }
 
       if ($is_ignore_content) {

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -111,17 +111,17 @@ class Index implements IndexInterface {
 
       $file = new IndexedFile($resource->getPathname(), $this->directory);
 
-      // Fast path: check basename against global patterns first.
       $basename = $file->getBasename();
-      if ($this->matchesAnyPattern($basename, $global_patterns)) {
-        continue;
-      }
-
       $relative_path = $file->getPathnameFromBasepath();
 
+      // $is_included must be known before the global check, so an include pattern can override it too.
       $is_included = FALSE;
       if (!empty($include_patterns)) {
-        $is_included = $this->matchesAnyPattern($relative_path, $include_patterns);
+        $is_included = $this->matchesAnyPattern($relative_path, $include_patterns) || $this->matchesAnyPattern($basename, $include_patterns);
+      }
+
+      if (!$is_included && $this->matchesAnyPattern($basename, $global_patterns)) {
+        continue;
       }
 
       if (!$is_included && $this->matchesAnyPattern($relative_path, $skip_patterns)) {

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -115,8 +115,14 @@ class Index implements IndexInterface {
       $basename = $file->getBasename();
       $relative_path = $file->getPathnameFromBasepath();
 
+      // Neither the rules file nor the VCS tree is user-overridable, so both
+      // are hard-skipped before include patterns are checked.
+      if ($relative_path === Snapshot::IGNORECONTENT || str_starts_with($relative_path, '.git/')) {
+        continue;
+      }
+
       // $is_included must be known before the global check, so an include
-      // pattern can override it too.
+      // pattern can override the global check as well as the skip check.
       $is_included = FALSE;
       if (!empty($include_patterns)) {
         $is_included = $this->matchesAnyPattern($relative_path, $include_patterns) || $this->matchesAnyPattern($basename, $include_patterns);

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -115,7 +115,8 @@ class Index implements IndexInterface {
       $basename = $file->getBasename();
       $relative_path = $file->getPathnameFromBasepath();
 
-      // $is_included must be known before the global check, so an include pattern can override it too.
+      // $is_included must be known before the global check, so an include
+      // pattern can override it too.
       $is_included = FALSE;
       if (!empty($include_patterns)) {
         $is_included = $this->matchesAnyPattern($relative_path, $include_patterns) || $this->matchesAnyPattern($basename, $include_patterns);

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -246,10 +246,10 @@ class Rules implements RulesInterface {
    *  dir/    Ignore directory and all subdirectories.
    *  dir/*   Ignore all files in directory, but not subdirectories.
    *  ^file   Ignore content changes in file, but not the file itself.
-   *  ^dir/   Ignore content changes in all files and subdirectories, but check
-   *          that the directory itself exists.
-   *  ^dir/*  Ignore content changes in all files, but not subdirectories and
-   *          check that the directory itself exists.
+   *  ^dir/   Ignore content changes in all files under the directory, at any
+   *          depth.
+   *  ^dir/*  Ignore content changes in all files in directory, but not
+   *          subdirectories.
    *  !file   Do not ignore file.
    *  !dir/   Do not ignore directory, including all subdirectories.
    *  !dir/*  Do not ignore all files in directory, but not subdirectories.

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -42,6 +42,13 @@ class Rules implements RulesInterface {
   protected array $includePatterns = [];
 
   /**
+   * Patterns for files where content should be explicitly compared.
+   *
+   * @var array<int, string>
+   */
+  protected array $includeContentPatterns = [];
+
+  /**
    * Creates a new Rules instance.
    *
    * @return self
@@ -145,6 +152,13 @@ class Rules implements RulesInterface {
   /**
    * {@inheritdoc}
    */
+  public function getIncludeContent(): array {
+    return $this->includeContentPatterns;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function addIgnoreContent(string $pattern): static {
     $this->ignoreContentPatterns[] = $pattern;
     return $this;
@@ -177,6 +191,14 @@ class Rules implements RulesInterface {
   /**
    * {@inheritdoc}
    */
+  public function addIncludeContent(string $pattern): static {
+    $this->includeContentPatterns[] = $pattern;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function skip(string ...$patterns): static {
     foreach ($patterns as $pattern) {
       $this->addSkip($pattern);
@@ -200,6 +222,16 @@ class Rules implements RulesInterface {
   public function include(string ...$patterns): static {
     foreach ($patterns as $pattern) {
       $this->addInclude($pattern);
+    }
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function includeContent(string ...$patterns): static {
+    foreach ($patterns as $pattern) {
+      $this->addIncludeContent($pattern);
     }
     return $this;
   }
@@ -237,9 +269,17 @@ class Rules implements RulesInterface {
         continue;
       }
       if ($line[0] === '!') {
-        $pattern = ($line[1] ?? '') === '^' ? substr($line, 2) : substr($line, 1);
-        if ($pattern !== '') {
-          $this->includePatterns[] = $pattern;
+        if (($line[1] ?? '') === '^') {
+          $pattern = substr($line, 2);
+          if ($pattern !== '') {
+            $this->includeContentPatterns[] = $pattern;
+          }
+        }
+        else {
+          $pattern = substr($line, 1);
+          if ($pattern !== '') {
+            $this->includePatterns[] = $pattern;
+          }
         }
       }
       elseif ($line[0] === '^') {

--- a/src/Rules/RulesInterface.php
+++ b/src/Rules/RulesInterface.php
@@ -42,6 +42,14 @@ interface RulesInterface {
   public function getInclude(): array;
 
   /**
+   * Gets patterns for files where content should be explicitly compared.
+   *
+   * @return array<int, string>
+   *   Array of patterns.
+   */
+  public function getIncludeContent(): array;
+
+  /**
    * Adds a pattern for files where only content should be ignored.
    *
    * @param string $pattern
@@ -86,6 +94,17 @@ interface RulesInterface {
   public function addInclude(string $pattern): static;
 
   /**
+   * Adds a pattern for files where content should be explicitly compared.
+   *
+   * @param string $pattern
+   *   The pattern to add.
+   *
+   * @return $this
+   *   Return self for chaining.
+   */
+  public function addIncludeContent(string $pattern): static;
+
+  /**
    * Fluent method to skip multiple patterns.
    *
    * @param string ...$patterns
@@ -117,6 +136,17 @@ interface RulesInterface {
    *   Return self for chaining.
    */
   public function include(string ...$patterns): static;
+
+  /**
+   * Fluent method to explicitly compare content for multiple patterns.
+   *
+   * @param string ...$patterns
+   *   Patterns to compare content for.
+   *
+   * @return $this
+   *   Return self for chaining.
+   */
+  public function includeContent(string ...$patterns): static;
 
   /**
    * Parse the rules content.

--- a/src/Rules/RulesInterface.php
+++ b/src/Rules/RulesInterface.php
@@ -138,7 +138,7 @@ interface RulesInterface {
   public function include(string ...$patterns): static;
 
   /**
-   * Fluent method to explicitly compare content for multiple patterns.
+   * Fluent method to include content of multiple patterns.
    *
    * @param string ...$patterns
    *   Patterns to compare content for.

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -128,7 +128,7 @@ class SnapshotBuilder {
   }
 
   /**
-   * Add include-content patterns to the rules.
+   * Add include content patterns to the rules.
    *
    * Creates rules if not set.
    *

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -128,6 +128,23 @@ class SnapshotBuilder {
   }
 
   /**
+   * Add include-content patterns to the rules.
+   *
+   * Creates rules if not set.
+   *
+   * @param string ...$patterns
+   *   Patterns to compare content for.
+   *
+   * @return $this
+   *   Return self for chaining.
+   */
+  public function addIncludeContent(string ...$patterns): static {
+    $this->rules ??= new Rules();
+    $this->rules->includeContent(...$patterns);
+    return $this;
+  }
+
+  /**
    * Get the configured rules.
    *
    * @return \AlexSkrypnyk\Snapshot\Rules\Rules|null

--- a/tests/phpunit/Fixtures/compare/files_equal_advanced/directory1/.ignorecontent
+++ b/tests/phpunit/Fixtures/compare/files_equal_advanced/directory1/.ignorecontent
@@ -5,8 +5,8 @@
 # dir/ - ignore directory and all subdirectories
 # dir/* - ignore all files in directory, but not subdirectories
 # ^file - ignore content changes in file, but not the file itself
-# ^dir/ - ignore content changes in all files and subdirectories, but check that the directory itself exists
-# ^dir/* - ignore content changes in all files, but not subdirectories and check that the directory itself exists
+# ^dir/ - ignore content changes in files under the directory, at any depth
+# ^dir/* - ignore content changes in files in directory, not subdirectories
 # !file - do not ignore file
 # !dir/ - do not ignore directory, including all subdirectories
 # !dir/* - do not ignore all files in directory, but not subdirectories

--- a/tests/phpunit/Fixtures/compare/files_equal_advanced/directory1/dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log
+++ b/tests/phpunit/Fixtures/compare/files_equal_advanced/directory1/dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log
@@ -1,0 +1,1 @@
+d32f2l1.log only dst

--- a/tests/phpunit/Fixtures/compare/files_equal_advanced/directory2/dir3_subdirs/dir32-unignored/d32f2-only-src.log
+++ b/tests/phpunit/Fixtures/compare/files_equal_advanced/directory2/dir3_subdirs/dir32-unignored/d32f2-only-src.log
@@ -1,0 +1,1 @@
+d32f2l1.log only src

--- a/tests/phpunit/Fixtures/compare/files_not_equal_advanced/directory1/.ignorecontent
+++ b/tests/phpunit/Fixtures/compare/files_not_equal_advanced/directory1/.ignorecontent
@@ -5,8 +5,8 @@
 # dir/ - ignore directory and all subdirectories
 # dir/* - ignore all files in directory, but not subdirectories
 # ^file - ignore content changes in file, but not the file itself
-# ^dir/ - ignore content changes in all files and subdirectories, but check that the directory itself exists
-# ^dir/* - ignore content changes in all files, but not subdirectories and check that the directory itself exists
+# ^dir/ - ignore content changes in files under the directory, at any depth
+# ^dir/* - ignore content changes in files in directory, not subdirectories
 # !file - do not ignore file
 # !dir/ - do not ignore directory, including all subdirectories
 # !dir/* - do not ignore all files in directory, but not subdirectories

--- a/tests/phpunit/Fixtures/diff/baseline/.ignorecontent
+++ b/tests/phpunit/Fixtures/diff/baseline/.ignorecontent
@@ -5,8 +5,8 @@
 # dir/ - ignore directory and all subdirectories
 # dir/* - ignore all files in directory, but not subdirectories
 # ^file - ignore content changes in file, but not the file itself
-# ^dir/ - ignore content changes in all files and subdirectories, but check that the directory itself exists
-# ^dir/* - ignore content changes in all files, but not subdirectories and check that the directory itself exists
+# ^dir/ - ignore content changes in files under the directory, at any depth
+# ^dir/* - ignore content changes in files in directory, not subdirectories
 # !file - do not ignore file
 # !dir/ - do not ignore directory, including all subdirectories
 # !dir/* - do not ignore all files in directory, but not subdirectories

--- a/tests/phpunit/Fixtures/diff/files_equal/result/.ignorecontent
+++ b/tests/phpunit/Fixtures/diff/files_equal/result/.ignorecontent
@@ -5,8 +5,8 @@
 # dir/ - ignore directory and all subdirectories
 # dir/* - ignore all files in directory, but not subdirectories
 # ^file - ignore content changes in file, but not the file itself
-# ^dir/ - ignore content changes in all files and subdirectories, but check that the directory itself exists
-# ^dir/* - ignore content changes in all files, but not subdirectories and check that the directory itself exists
+# ^dir/ - ignore content changes in files under the directory, at any depth
+# ^dir/* - ignore content changes in files in directory, not subdirectories
 # !file - do not ignore file
 # !dir/ - do not ignore directory, including all subdirectories
 # !dir/* - do not ignore all files in directory, but not subdirectories

--- a/tests/phpunit/Fixtures/diff/files_not_equal/result/.ignorecontent
+++ b/tests/phpunit/Fixtures/diff/files_not_equal/result/.ignorecontent
@@ -5,8 +5,8 @@
 # dir/ - ignore directory and all subdirectories
 # dir/* - ignore all files in directory, but not subdirectories
 # ^file - ignore content changes in file, but not the file itself
-# ^dir/ - ignore content changes in all files and subdirectories, but check that the directory itself exists
-# ^dir/* - ignore content changes in all files, but not subdirectories and check that the directory itself exists
+# ^dir/ - ignore content changes in files under the directory, at any depth
+# ^dir/* - ignore content changes in files in directory, not subdirectories
 # !file - do not ignore file
 # !dir/ - do not ignore directory, including all subdirectories
 # !dir/* - do not ignore all files in directory, but not subdirectories

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -103,6 +103,7 @@ final class IndexTest extends UnitTestCase {
         'dir3_subdirs/dir31/d31f2-ignored.txt',
         'dir3_subdirs/dir32-unignored/d32f1.txt',
         'dir3_subdirs/dir32-unignored/d32f1_symlink.txt',
+        'dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log',
         'dir3_subdirs/dir32-unignored/d32f2.txt',
         'dir3_subdirs_symlink',
         'dir5_content_ignore/d5f1-ignored-changed-content.txt',
@@ -387,6 +388,43 @@ final class IndexTest extends UnitTestCase {
       $this->assertArrayHasKey('test_file.txt', $files);
 
       $this->assertArrayNotHasKey('sub_directory', $files);
+    }
+    finally {
+      File::rmdir($test_dir);
+    }
+  }
+
+  public function testIncludePatternsOverrideGlobalAndSkipPatterns(): void {
+    $test_dir = $this->locationsTmp() . DIRECTORY_SEPARATOR . 'test_include_overrides';
+    File::mkdir($test_dir);
+    File::mkdir($test_dir . DIRECTORY_SEPARATOR . 'sub');
+    File::mkdir($test_dir . DIRECTORY_SEPARATOR . 'cache');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'important.txt', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'important.log', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'other.log', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'sub' . DIRECTORY_SEPARATOR . 'important.log', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'sub' . DIRECTORY_SEPARATOR . 'other.log', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'keep.txt', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'other.txt', 'content');
+
+    try {
+      $rules = (new Rules())
+        ->addGlobal('important.txt')
+        ->addGlobal('*.log')
+        ->addSkip('cache/')
+        ->addInclude('important.txt')
+        ->addInclude('important.log')
+        ->addInclude('cache/keep.txt');
+
+      $files = (new Index($test_dir, $rules))->getFiles();
+
+      $this->assertArrayHasKey('important.txt', $files);
+      $this->assertArrayHasKey('important.log', $files);
+      $this->assertArrayHasKey('sub/important.log', $files);
+      $this->assertArrayNotHasKey('other.log', $files);
+      $this->assertArrayNotHasKey('sub/other.log', $files);
+      $this->assertArrayHasKey('cache/keep.txt', $files);
+      $this->assertArrayNotHasKey('cache/other.txt', $files);
     }
     finally {
       File::rmdir($test_dir);

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -421,11 +421,18 @@ final class IndexTest extends UnitTestCase {
 
       $files = (new Index($test_dir, $rules))->getFiles();
 
+      // 'important.txt' + '!important.txt': the file is indexed.
       $this->assertArrayHasKey('important.txt', $files);
+
+      // '*.log' + '!important.log': the file is indexed at any depth,
+      // 'other.log' stays excluded.
       $this->assertArrayHasKey('important.log', $files);
       $this->assertArrayHasKey('sub/important.log', $files);
       $this->assertArrayNotHasKey('other.log', $files);
       $this->assertArrayNotHasKey('sub/other.log', $files);
+
+      // 'cache/' + '!cache/keep.txt': the named file is indexed, its
+      // sibling stays excluded.
       $this->assertArrayHasKey('cache/keep.txt', $files);
       $this->assertArrayNotHasKey('cache/other.txt', $files);
     }

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -463,20 +463,16 @@ final class IndexTest extends UnitTestCase {
       $files = (new Index($test_dir, $rules))->getFiles();
 
       // '^file.txt' + '!^file.txt': content is compared, not ignored.
-      $this->assertArrayHasKey('file.txt', $files);
-      $this->assertFalse($files['file.txt']->isIgnoreContent());
+      $this->assertFalse($this->assertIndexedFile($files, 'file.txt')->isIgnoreContent());
 
       // '^dir/' + '!^dir/keep.txt': the named file's content is compared,
       // the sibling's is not.
-      $this->assertArrayHasKey('dir/keep.txt', $files);
-      $this->assertFalse($files['dir/keep.txt']->isIgnoreContent());
-      $this->assertArrayHasKey('dir/sibling.txt', $files);
-      $this->assertTrue($files['dir/sibling.txt']->isIgnoreContent());
+      $this->assertFalse($this->assertIndexedFile($files, 'dir/keep.txt')->isIgnoreContent());
+      $this->assertTrue($this->assertIndexedFile($files, 'dir/sibling.txt')->isIgnoreContent());
 
       // Skip + plain '!skipped.txt': the file is indexed, but its content
       // is still ignored.
-      $this->assertArrayHasKey('skipped.txt', $files);
-      $this->assertTrue($files['skipped.txt']->isIgnoreContent());
+      $this->assertTrue($this->assertIndexedFile($files, 'skipped.txt')->isIgnoreContent());
     }
     finally {
       File::rmdir($test_dir);

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -46,6 +46,7 @@ final class IndexTest extends UnitTestCase {
       'dir3_subdirs/dir32-unignored/d32f1.txt',
       'dir3_subdirs/dir32-unignored/d32f1_symlink.txt',
       'dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log',
+      'dir3_subdirs/dir32-unignored/d32f2-only-src.log',
       'dir3_subdirs/dir32-unignored/d32f2.txt',
       'dir3_subdirs/f3-new-file-ignore-everywhere.txt',
       'dir3_subdirs_symlink',
@@ -76,6 +77,7 @@ final class IndexTest extends UnitTestCase {
         'dir3_subdirs/d3f2-ignored.txt',
         'dir3_subdirs/dir31/d31f2-ignored.txt',
         'dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log',
+        'dir3_subdirs/dir32-unignored/d32f2-only-src.log',
         'dir3_subdirs/dir32-unignored/d32f2.txt',
         'dir5_content_ignore/d5f2-unignored-content.txt',
         'f2.txt',
@@ -104,6 +106,7 @@ final class IndexTest extends UnitTestCase {
         'dir3_subdirs/dir32-unignored/d32f1.txt',
         'dir3_subdirs/dir32-unignored/d32f1_symlink.txt',
         'dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log',
+        'dir3_subdirs/dir32-unignored/d32f2-only-src.log',
         'dir3_subdirs/dir32-unignored/d32f2.txt',
         'dir3_subdirs_symlink',
         'dir5_content_ignore/d5f1-ignored-changed-content.txt',
@@ -467,6 +470,37 @@ final class IndexTest extends UnitTestCase {
       // is still ignored.
       $this->assertArrayHasKey('skipped.txt', $files);
       $this->assertTrue($files['skipped.txt']->isIgnoreContent());
+    }
+    finally {
+      File::rmdir($test_dir);
+    }
+  }
+
+  public function testBuiltInSkipsAreNotOverridableByIncludePatterns(): void {
+    $test_dir = $this->locationsTmp() . DIRECTORY_SEPARATOR . 'test_builtin_skips';
+    File::mkdir($test_dir);
+    File::mkdir($test_dir . DIRECTORY_SEPARATOR . '.git');
+    File::mkdir($test_dir . DIRECTORY_SEPARATOR . 'sub');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT, 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . '.git' . DIRECTORY_SEPARATOR . 'config', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'sub' . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT, 'content');
+
+    try {
+      $rules = (new Rules())
+        ->addInclude('config')
+        ->addInclude('.git/config')
+        ->addInclude(Snapshot::IGNORECONTENT);
+
+      $files = (new Index($test_dir, $rules))->getFiles();
+
+      // A bare or path-formed include cannot expose the VCS tree.
+      $this->assertArrayNotHasKey('.git/config', $files);
+
+      // Nor can it expose the root rules file.
+      $this->assertArrayNotHasKey(Snapshot::IGNORECONTENT, $files);
+
+      // A nested rules file is not a built-in and stays indexed as before.
+      $this->assertArrayHasKey('sub/' . Snapshot::IGNORECONTENT, $files);
     }
     finally {
       File::rmdir($test_dir);

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -456,13 +456,15 @@ final class IndexTest extends UnitTestCase {
       $this->assertArrayHasKey('file.txt', $files);
       $this->assertFalse($files['file.txt']->isIgnoreContent());
 
-      // '^dir/' + '!^dir/keep.txt': the named file's content is compared, the sibling's is not.
+      // '^dir/' + '!^dir/keep.txt': the named file's content is compared,
+      // the sibling's is not.
       $this->assertArrayHasKey('dir/keep.txt', $files);
       $this->assertFalse($files['dir/keep.txt']->isIgnoreContent());
       $this->assertArrayHasKey('dir/sibling.txt', $files);
       $this->assertTrue($files['dir/sibling.txt']->isIgnoreContent());
 
-      // Skip + plain '!skipped.txt': the file is indexed, but its content is still ignored.
+      // Skip + plain '!skipped.txt': the file is indexed, but its content
+      // is still ignored.
       $this->assertArrayHasKey('skipped.txt', $files);
       $this->assertTrue($files['skipped.txt']->isIgnoreContent());
     }

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -431,6 +431,46 @@ final class IndexTest extends UnitTestCase {
     }
   }
 
+  public function testIncludeContentPatternsOverrideIgnoreContentPatterns(): void {
+    $test_dir = $this->locationsTmp() . DIRECTORY_SEPARATOR . 'test_include_content_overrides';
+    File::mkdir($test_dir);
+    File::mkdir($test_dir . DIRECTORY_SEPARATOR . 'dir');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'file.txt', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'skipped.txt', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'dir' . DIRECTORY_SEPARATOR . 'keep.txt', 'content');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'dir' . DIRECTORY_SEPARATOR . 'sibling.txt', 'content');
+
+    try {
+      $rules = (new Rules())
+        ->addIgnoreContent('file.txt')
+        ->addIgnoreContent('dir/')
+        ->addIgnoreContent('skipped.txt')
+        ->addSkip('skipped.txt')
+        ->addIncludeContent('file.txt')
+        ->addIncludeContent('dir/keep.txt')
+        ->addInclude('skipped.txt');
+
+      $files = (new Index($test_dir, $rules))->getFiles();
+
+      // '^file.txt' + '!^file.txt': content is compared, not ignored.
+      $this->assertArrayHasKey('file.txt', $files);
+      $this->assertFalse($files['file.txt']->isIgnoreContent());
+
+      // '^dir/' + '!^dir/keep.txt': the named file's content is compared, the sibling's is not.
+      $this->assertArrayHasKey('dir/keep.txt', $files);
+      $this->assertFalse($files['dir/keep.txt']->isIgnoreContent());
+      $this->assertArrayHasKey('dir/sibling.txt', $files);
+      $this->assertTrue($files['dir/sibling.txt']->isIgnoreContent());
+
+      // Skip + plain '!skipped.txt': the file is indexed, but its content is still ignored.
+      $this->assertArrayHasKey('skipped.txt', $files);
+      $this->assertTrue($files['skipped.txt']->isIgnoreContent());
+    }
+    finally {
+      File::rmdir($test_dir);
+    }
+  }
+
   protected function assertIndexedFile(array $files, string $key): IndexedFileInterface {
     $this->assertArrayHasKey($key, $files);
 

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -28,6 +28,7 @@ final class RulesTest extends UnitTestCase {
 
     $rules = Rules::fromFile($file);
     $this->assertSame($expected['include'], $rules->getInclude());
+    $this->assertSame($expected['include_content'], $rules->getIncludeContent());
     $this->assertSame($expected['content'], $rules->getIgnoreContent());
     $this->assertSame($expected['global'], $rules->getGlobal());
     $this->assertSame($expected['skip'], $rules->getSkip());
@@ -38,6 +39,7 @@ final class RulesTest extends UnitTestCase {
   public static function dataProviderRulesFromFile(): \Iterator {
     $default = [
       'include' => [],
+      'include_content' => [],
       'content' => [],
       'global' => [],
       'skip' => [],
@@ -57,7 +59,8 @@ final class RulesTest extends UnitTestCase {
     yield 'include rules' => [
       "!include-this\n!^content-only",
       [
-        'include' => ['include-this', 'content-only'],
+        'include' => ['include-this'],
+        'include_content' => ['content-only'],
       ] + $default,
     ];
     yield 'ignore content rules' => [
@@ -81,7 +84,8 @@ final class RulesTest extends UnitTestCase {
     yield 'mixed rules' => [
       "!include-this\n!^content-only\n^ignore-content\nsome/path/file.txt\nglobal-pattern",
       [
-        'include' => ['include-this', 'content-only'],
+        'include' => ['include-this'],
+        'include_content' => ['content-only'],
         'content' => ['ignore-content'],
         'global' => ['global-pattern'],
         'skip' => ['some/path/file.txt'],
@@ -91,6 +95,7 @@ final class RulesTest extends UnitTestCase {
       "  !include-with-spaces  \n  ^ignore-content-with-spaces  \n  global-with-spaces  \n  some/path/with spaces/  ",
       [
         'include' => ['include-with-spaces'],
+        'include_content' => [],
         'content' => ['ignore-content-with-spaces'],
         'global' => ['global-with-spaces'],
         'skip' => ['some/path/with spaces/'],
@@ -100,6 +105,7 @@ final class RulesTest extends UnitTestCase {
       "!include-this\r\n^ignore-content\r\rglobal-pattern\nsome/path/file.txt",
       [
         'include' => ['include-this'],
+        'include_content' => [],
         'content' => ['ignore-content'],
         'global' => ['global-pattern'],
         'skip' => ['some/path/file.txt'],
@@ -108,34 +114,39 @@ final class RulesTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderParseEdgeCases')]
-  public function testParseEdgeCases(string $input, array $expected_include, array $expected_content, array $expected_global, array $expected_skip): void {
+  public function testParseEdgeCases(string $input, array $expected_include, array $expected_include_content, array $expected_content, array $expected_global, array $expected_skip): void {
     $rules = new Rules();
     $rules->parse($input);
 
     $this->assertSame($expected_include, $rules->getInclude());
+    $this->assertSame($expected_include_content, $rules->getIncludeContent());
     $this->assertSame($expected_content, $rules->getIgnoreContent());
     $this->assertSame($expected_global, $rules->getGlobal());
     $this->assertSame($expected_skip, $rules->getSkip());
   }
 
   public static function dataProviderParseEdgeCases(): \Iterator {
-    yield 'empty lines and whitespace' => ["\n  \n\t\n", [], [], [], []];
-    yield 'special characters in include rule' => ['!special@chars', ['special@chars'], [], [], []];
-    yield 'regex special characters as global rule' => ['[regex].special+chars?{test}', [], [], ['[regex].special+chars?{test}'], []];
-    yield 'very long pattern' => [str_repeat('a', 1000), [], [], [str_repeat('a', 1000)], []];
-    yield 'lone negation prefix is ignored' => ['!', [], [], [], []];
-    yield 'negation of content marker only is ignored' => ['!^', [], [], [], []];
+    yield 'empty lines and whitespace' => ["\n  \n\t\n", [], [], [], [], []];
+    yield 'special characters in include rule' => ['!special@chars', ['special@chars'], [], [], [], []];
+    yield 'regex special characters as global rule' => ['[regex].special+chars?{test}', [], [], [], ['[regex].special+chars?{test}'], []];
+    yield 'very long pattern' => [str_repeat('a', 1000), [], [], [], [str_repeat('a', 1000)], []];
+    yield 'lone negation prefix is ignored' => ['!', [], [], [], [], []];
+    yield 'negation of content marker only is ignored' => ['!^', [], [], [], [], []];
+    yield 'content-only include is routed to include-content' => ['!^keep-content.txt', [], ['keep-content.txt'], [], [], []];
+    yield 'plain include is routed to include, not include-content' => ['!keep.txt', ['keep.txt'], [], [], [], []];
   }
 
   public function testParseMethodChaining(): void {
     $rules = new Rules();
     $result = $rules->parse('!include-rule')
+      ->parse('!^include-content-rule')
       ->parse('^ignore-content-rule')
       ->parse('global-rule')
       ->parse('some/path/');
 
     $this->assertSame($rules, $result);
     $this->assertSame(['include-rule'], $rules->getInclude());
+    $this->assertSame(['include-content-rule'], $rules->getIncludeContent());
     $this->assertSame(['ignore-content-rule'], $rules->getIgnoreContent());
     $this->assertSame(['global-rule'], $rules->getGlobal());
     $this->assertSame(['some/path/'], $rules->getSkip());
@@ -153,6 +164,7 @@ final class RulesTest extends UnitTestCase {
     yield 'addSkip' => ['addSkip', 'getSkip', 'skip-pattern'];
     yield 'addGlobal' => ['addGlobal', 'getGlobal', 'global-pattern'];
     yield 'addInclude' => ['addInclude', 'getInclude', 'include-pattern'];
+    yield 'addIncludeContent' => ['addIncludeContent', 'getIncludeContent', 'include-content-pattern'];
   }
 
   public function testAddMethodChaining(): void {
@@ -160,13 +172,15 @@ final class RulesTest extends UnitTestCase {
     $result = $rules->addIgnoreContent('pattern1')
       ->addSkip('pattern2')
       ->addGlobal('pattern3')
-      ->addInclude('pattern4');
+      ->addInclude('pattern4')
+      ->addIncludeContent('pattern5');
 
     $this->assertSame($rules, $result, 'Method chaining should return the same instance');
     $this->assertSame(['pattern1'], $rules->getIgnoreContent());
     $this->assertSame(['pattern2'], $rules->getSkip());
     $this->assertSame(['pattern3'], $rules->getGlobal());
     $this->assertSame(['pattern4'], $rules->getInclude());
+    $this->assertSame(['pattern5'], $rules->getIncludeContent());
   }
 
   public function testFromFileReadException(): void {
@@ -200,7 +214,8 @@ EOT;
     try {
       $rules = Rules::fromFile($rules_file);
 
-      $this->assertSame(['include-pattern', 'include-ignore-content-pattern'], $rules->getInclude());
+      $this->assertSame(['include-pattern'], $rules->getInclude());
+      $this->assertSame(['include-ignore-content-pattern'], $rules->getIncludeContent());
       $this->assertSame(['ignore-content-pattern'], $rules->getIgnoreContent());
       $this->assertSame(['global-pattern'], $rules->getGlobal());
       $this->assertSame(['path/to/file.txt'], $rules->getSkip());
@@ -218,6 +233,7 @@ EOT;
     $this->assertSame([], $rules->getSkip());
     $this->assertSame([], $rules->getIgnoreContent());
     $this->assertSame([], $rules->getInclude());
+    $this->assertSame([], $rules->getIncludeContent());
     $this->assertSame([], $rules->getGlobal());
   }
 
@@ -242,15 +258,24 @@ EOT;
     $this->assertSame(['important.log', 'keep-this.txt'], $rules->getInclude());
   }
 
+  public function testFluentIncludeContentMethod(): void {
+    $rules = Rules::create()
+      ->includeContent('composer.lock', 'keep-this-content.txt');
+
+    $this->assertSame(['composer.lock', 'keep-this-content.txt'], $rules->getIncludeContent());
+  }
+
   public function testFluentMethodChaining(): void {
     $rules = Rules::create()
       ->skip('vendor/', 'node_modules/')
       ->ignoreContent('composer.lock')
-      ->include('!important.txt');
+      ->include('!important.txt')
+      ->includeContent('important.log');
 
     $this->assertSame(['vendor/', 'node_modules/'], $rules->getSkip());
     $this->assertSame(['composer.lock'], $rules->getIgnoreContent());
     $this->assertSame(['!important.txt'], $rules->getInclude());
+    $this->assertSame(['important.log'], $rules->getIncludeContent());
   }
 
   public function testPhpProject(): void {

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -61,6 +61,14 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $this->assertSame(['important.log'], $rules->getInclude());
   }
 
+  public function testAddIncludeContent(): void {
+    $builder = SnapshotBuilder::create()->addIncludeContent('important.log');
+
+    $rules = $builder->getRules();
+    $this->assertInstanceOf(Rules::class, $rules);
+    $this->assertSame(['important.log'], $rules->getIncludeContent());
+  }
+
   public function testFluentMethodChaining(): void {
     $builder = SnapshotBuilder::create()
       ->withRules(Rules::phpProject())

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -79,16 +79,7 @@ final class SnapshotTest extends UnitTestCase {
         ],
       ],
     ];
-    yield 'files_equal_advanced' => [
-      [
-        'absent_dir1' => [
-          'dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log',
-        ],
-        'absent_dir2' => [
-          'dir3_subdirs/dir32-unignored/d32f2-only-src.log',
-        ],
-      ],
-    ];
+    yield 'files_equal_advanced' => [];
     yield 'files_not_equal_advanced' => [
       [
         'absent_dir1' => [
@@ -189,17 +180,7 @@ ABSENT,
       ],
     ];
     yield 'files_equal_advanced' => [
-      [
-        'Differences between directories',
-          <<<ABSENT
-Files absent in [left]:
-  dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log
-ABSENT,
-          <<<ABSENT
-Files absent in [right]:
-  dir3_subdirs/dir32-unignored/d32f2-only-src.log
-ABSENT,
-      ],
+      [],
     ];
     yield 'files_not_equal_advanced' => [
       [

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -79,13 +79,23 @@ final class SnapshotTest extends UnitTestCase {
         ],
       ],
     ];
-    yield 'files_equal_advanced' => [];
+    yield 'files_equal_advanced' => [
+      [
+        'absent_dir1' => [
+          'dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log',
+        ],
+        'absent_dir2' => [
+          'dir3_subdirs/dir32-unignored/d32f2-only-src.log',
+        ],
+      ],
+    ];
     yield 'files_not_equal_advanced' => [
       [
         'absent_dir1' => [
           'dir2_flat-present-dst/d2f1.txt',
           'dir2_flat-present-dst/d2f2.txt',
           'dir3_subdirs/dir31/f4-new-file-notignore-everywhere.txt',
+          'dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log',
           'dir5_content_ignore/dir51/d51f2-new-file.txt',
           'f4-new-file-notignore-everywhere.txt',
         ],
@@ -94,6 +104,7 @@ final class SnapshotTest extends UnitTestCase {
           'dir1_flat/d1f1_symlink.txt',
           'dir1_flat/d1f3-only-src.txt',
           'dir3_subdirs/dir32-unignored/d32f1_symlink.txt',
+          'dir3_subdirs/dir32-unignored/d32f2-only-src.log',
           'dir3_subdirs_symlink',
           'f2_symlink.txt',
         ],
@@ -178,7 +189,17 @@ ABSENT,
       ],
     ];
     yield 'files_equal_advanced' => [
-      [],
+      [
+        'Differences between directories',
+          <<<ABSENT
+Files absent in [left]:
+  dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log
+ABSENT,
+          <<<ABSENT
+Files absent in [right]:
+  dir3_subdirs/dir32-unignored/d32f2-only-src.log
+ABSENT,
+      ],
     ];
     yield 'files_not_equal_advanced' => [
       [
@@ -188,6 +209,7 @@ ABSENT,
   dir2_flat-present-dst/d2f1.txt
   dir2_flat-present-dst/d2f2.txt
   dir3_subdirs/dir31/f4-new-file-notignore-everywhere.txt
+  dir3_subdirs/dir32-unignored/d32f2-ignore-ext-only-dst.log
   dir5_content_ignore/dir51/d51f2-new-file.txt
   f4-new-file-notignore-everywhere.txt
 ABSENT,
@@ -197,6 +219,7 @@ ABSENT,
   dir1_flat/d1f1_symlink.txt
   dir1_flat/d1f3-only-src.txt
   dir3_subdirs/dir32-unignored/d32f1_symlink.txt
+  dir3_subdirs/dir32-unignored/d32f2-only-src.log
   dir3_subdirs_symlink
   f2_symlink.txt
 ABSENT,


### PR DESCRIPTION
Closes #45, closes #63, closes #64

## Summary

Include patterns (`!x`) were only ever checked against path-style skip rules, so a bare-name global pattern like `*.log` could never be overridden and the README's own `!important.log` example did not work as documented.
Indexing now resolves include patterns first, matching either the relative path or the basename, before either the global or the path-based skip check runs.
A `!^x` pattern is split into its own include-content set so it can re-enable content comparison for a file matched by a `^` rule without also acting as a full `!x` override, restoring the distinction the documentation already claimed.
The `.ignorecontent` rules file and the `.git/` directory are now hard skips that no `!` rule can undo.
Fixture headers and the `parse()` docblock also drop a `^dir/` directory-existence claim that was never implemented.

## Behaviour changes

- An include pattern (`!x`) now overrides bare-name/global patterns (`*.log`), not only path rules; files previously hidden by a global inside a re-included directory will appear in comparisons.
- `!x` no longer re-enables content comparison for a file matched by a `^` rule; only `!^x` does. Consumers using plain `!` for both effects need a matching `!^` line.
- `RulesInterface` gained `getIncludeContent()`, `addIncludeContent()` and `includeContent()` - breaking for direct implementors of the interface.
- The `.ignorecontent` file and `.git/` remain skipped regardless of any `!` rule.

The next release containing this change should be tagged as a major version; the release drafter defaults to minor.

## Changes

### #45 - Include patterns override globals

- Checked include patterns against both the relative path and the basename before either the global (bare-name) or path-based skip check runs, so `!important.log` now overrides `*.log`.
- Exempted the `.ignorecontent` rules file and the `.git/` directory from the include override, since neither should ever be re-included.
- Re-equalised the `files_equal_advanced` fixture and labelled the new test cases for the include-override behaviour.

### #63 - Split include-content rules from includes

- Routed `!^x` lines to a new include-content pattern set instead of merging them into `includePatterns`, so `!^x` only re-enables content comparison and no longer also acts as a full `!x` override.
- Added `getIncludeContent()`, `addIncludeContent()` and `includeContent()` to `Rules` and `RulesInterface`, plus an `addIncludeContent()` passthrough on `SnapshotBuilder`.
- Documented the `!x` vs `!^x` distinction in the README and completed the method lists for both classes.

### #64 - Removed the false `^dir/` directory-existence claim

- Dropped the sentence claiming `^dir/` checks that a directory exists from the `parse()` docblock and from five fixture `.ignorecontent` headers; no code ever implemented that check.

### Other

- Wrapped overlong inline comments to the project's line-length convention.

## Merge order

This PR is independent of the other open PRs in this series and can be merged at any time, in any order.

## Before / After

```
BEFORE - global short-circuits; include (path-only) reaches skip and content together
┌────────────────┐
│ Global (*.log) │  basename only - include is never read here
└────────────────┘
  │  no match
  ▼
┌─────────────┐
│ Skip (path) │  overridden by !x (path-only match)
└─────────────┘
  │  no match, or !x matched here
  ▼
┌─────────────────────┐
│ Ignore-content (^x) │  also suppressed by the same !x match
└─────────────────────┘

  *.log + !important.log  ->  SKIPPED - the global check already
  short-circuited before !important.log's path-only include is read.


AFTER - built-ins first, then include, then global/skip, then content
┌───────────┐
│ Built-ins │  .ignorecontent, .git/ - never overridable
└───────────┘
  │  no match
  ▼
┌──────────────┐
│ Include (!x) │  checked against path AND basename
└──────────────┘
  │  no match
  ▼
┌────────────────┐
│ Global (*.log) │
└────────────────┘
  │  no match
  ▼
┌─────────────┐
│ Skip (path) │
└─────────────┘
  │  no match
  ▼
┌────────────────────┐
│ Content (^x / !^x) │  ^x ignores; !^x re-includes - its own pattern set
└────────────────────┘

  *.log + !important.log            ->  INDEXED (include now overrides global)
  ^composer.lock + !^composer.lock  ->  content compared (independent of !x)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Make `!` include rules override global and path-based skip patterns.
- Add separate `!^` include-content rules.
- Keep `.ignorecontent` and `.git/` unconditionally skipped.
- Add include-content APIs to `RulesInterface`, `Rules`, and `SnapshotBuilder`.
- Remove inaccurate directory-existence claims for `^dir/` rules.
- Update documentation and tests.
- Plan a major version release.

## Possibly related

- Possibly related to `#45`.
- Possibly related to `#63`.
- Possibly related to `#64`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->