### PR TITLE
[#57] [#58] [#66] Settled the public API for the next major release.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ class MyTest extends TestCase {
 
     // Compare actual against baseline + diffs
     public function testScenario(): void {
-        $this->assertSnapshotMatchesBaseline($actual, $baseline, $diffs);
+        $this->assertSnapshotMatchesBaseline($baseline, $diffs, $actual);
     }
 
     // Enable auto-update on failure (call in tearDown)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ composer install
 - All files must end with a newline character
 - Local variables/method arguments: `snake_case`
 - Method names/class properties: `camelCase`
+- Promoted constructor properties declare properties, so they follow the property convention: `camelCase`
 
 
 ## Testing Patterns

--- a/README.md
+++ b/README.md
@@ -493,8 +493,8 @@ Every renamed or reshaped public symbol:
 | `Index::__construct(..., $beforeMatchContent)` | `Index::__construct(..., $fileFilter)` |
 | `Index::getFiles($cb)` | `Index::getFiles($transformer)` |
 | `Comparer::getAbsentLeftDiffs/getAbsentRightDiffs/getContentDiffs($cb)` | the same methods taking `$transformer` |
-| `Comparer::addLeftFile/addRightFile(): void` | the same methods returning `static` |
-| `IndexedFile::setBasepath/setContent/setIgnoreContent(): void` | the same methods returning `static` |
+| `Comparer::addLeftFile/addRightFile(): void` | the same methods returning `static`, on `ComparerInterface` too |
+| `IndexedFile::setBasepath/setContent/setIgnoreContent(): void` | the same methods returning `static`, on `IndexedFileInterface` too |
 | `RuleSetInterface::getSkipPatterns()` | `RuleSetInterface::getSkip()` |
 | `RuleSetInterface::getIgnoreContentPatterns()` | `RuleSetInterface::getIgnoreContent()` |
 | `RuleSetInterface::toRules()` | removed; use `Rules::fromRuleSet($set)` or `$set->applyTo()` |
@@ -503,7 +503,7 @@ Every renamed or reshaped public symbol:
 | `?Rules` parameters and returns across the facade, builder, trait and `Index` | `?RulesInterface` |
 | `PatchException::$file_path/$line_number/$line_content` | `$filePath/$lineNumber/$lineContent`; the getters are unchanged |
 
-Additions that break nothing: `Rules::global()`, `SnapshotBuilder::addGlobal()`, `SnapshotBuilder::withFileFilter()`/`getFileFilter()`, and `RuleSetInterface::getGlobal()`/`getInclude()`/`getIncludeContent()` with their `GLOBAL_PATTERNS`, `INCLUDE_PATTERNS` and `INCLUDE_CONTENT_PATTERNS` constants.
+Additive for callers, breaking for direct implementers: `Rules::global()` (also on `RulesInterface`) and `RuleSetInterface::getGlobal()`/`getInclude()`/`getIncludeContent()` with their `GLOBAL_PATTERNS`, `INCLUDE_PATTERNS` and `INCLUDE_CONTENT_PATTERNS` constants. Classes extending `Rules` or `AbstractRuleSet` inherit them and need no change; classes implementing `RulesInterface` or `RuleSetInterface` directly must add the new methods. Purely additive: `SnapshotBuilder::addGlobal()` and `SnapshotBuilder::withFileFilter()`/`getFileFilter()`.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ echo $comparer->render();
 // Create diff files
 Snapshot::diff($baseline, $actual, $output_dir);
 
-// Apply patches
-Snapshot::patch($baseline, $patches, $destination);
+// Apply diffs to the baseline
+Snapshot::patch($baseline, $diffs, $destination);
 
 // Sync directories
 Snapshot::sync($source, $destination);
@@ -303,9 +303,11 @@ Snapshot::sync($source, $destination);
 
 ### Fluent Builder API
 
-For configured operations with rules and content processors, use `SnapshotBuilder`:
+For configured operations with rules, a file filter or a content processor, use
+`SnapshotBuilder`:
 
 ```php
+use AlexSkrypnyk\Snapshot\Index\IndexedFile;
 use AlexSkrypnyk\Snapshot\SnapshotBuilder;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
 
@@ -316,15 +318,25 @@ $builder = SnapshotBuilder::create()
     ->addIgnoreContent('custom.lock')
     ->addInclude('custom/keep.txt')
     ->addIncludeContent('custom/keep.log')
-    ->withContentProcessor(fn($content) => trim($content));
+    // Drop every generated file from the index
+    ->withFileFilter(fn(IndexedFile $file) => !str_contains($file->getPathnameFromBasepath(), 'generated/'))
+    // Normalise the content of every file written by patch()
+    ->withContentProcessor(fn(string $content) => trim($content));
 
 // Use the builder for multiple operations
 $index = $builder->scan($directory);
 $comparer = $builder->compare($dir1, $dir2);
 $builder->sync($source, $destination);
 $builder->diff($baseline, $actual, $output);
-$builder->patch($baseline, $patches, $destination);
+$builder->patch($baseline, $diffs, $destination);
 ```
+
+The two callbacks serve different operations and receive different values:
+
+| Callback | Used by | Receives | Effect |
+|----------|---------|----------|--------|
+| `withFileFilter()` | `scan()`, `compare()`, `diff()`, `sync()` | An `IndexedFile` | Returning `FALSE` excludes the file from the index |
+| `withContentProcessor()` | `patch()` | The patched file content as a string | The returned string is written back to the file |
 
 ### Programmatic Rules
 

--- a/README.md
+++ b/README.md
@@ -308,8 +308,8 @@ For configured operations with rules, a file filter or a content processor, use
 
 ```php
 use AlexSkrypnyk\Snapshot\Index\IndexedFile;
-use AlexSkrypnyk\Snapshot\SnapshotBuilder;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
+use AlexSkrypnyk\Snapshot\SnapshotBuilder;
 
 // Create a reusable builder with configuration
 $builder = SnapshotBuilder::create()
@@ -375,13 +375,13 @@ class MyProjectRuleSet extends AbstractRuleSet {
 
     protected const SKIP_PATTERNS = ['dist/', '.cache/'];
 
-    protected const IGNORE_CONTENT_PATTERNS = ['build-manifest.json'];
+    protected const IGNORE_CONTENT_PATTERNS = ['reports/'];
 
     protected const GLOBAL_PATTERNS = ['*.log'];
 
     protected const INCLUDE_PATTERNS = ['dist/keep.txt'];
 
-    protected const INCLUDE_CONTENT_PATTERNS = ['build-manifest.json'];
+    protected const INCLUDE_CONTENT_PATTERNS = ['reports/summary.json'];
 
 }
 

--- a/README.md
+++ b/README.md
@@ -377,10 +377,19 @@ class MyProjectRuleSet extends AbstractRuleSet {
 
     protected const IGNORE_CONTENT_PATTERNS = ['build-manifest.json'];
 
+    protected const GLOBAL_PATTERNS = ['*.log'];
+
+    protected const INCLUDE_PATTERNS = ['dist/keep.txt'];
+
+    protected const INCLUDE_CONTENT_PATTERNS = ['build-manifest.json'];
+
 }
 
 $rules = Rules::fromRuleSet(new MyProjectRuleSet());
 ```
+
+Each constant maps to the matching `Rules` pattern list, and a set can define
+only the constants it needs - the rest default to empty.
 
 ### Version Normalization
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ public function testScenarioA(): void {
     $generator->generate($output_dir, ['option' => 'A']);
 
     $this->assertSnapshotMatchesBaseline(
-        $output_dir,            // Actual output
         $baseline_dir,          // Common baseline
-        $scenario_a_diffs_dir   // Diffs specific to scenario A
+        $scenario_a_diffs_dir,  // Diffs specific to scenario A
+        $output_dir             // Actual output
     );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ The two callbacks serve different operations and receive different values:
 | `withFileFilter()` | `scan()`, `compare()`, `diff()`, `sync()` | An `IndexedFile` | Returning `FALSE` excludes the file from the index |
 | `withContentProcessor()` | `patch()` | The patched file content as a string | The returned string is written back to the file |
 
+`patch()` takes no file filter: its baseline sync and its scan of the diffs directory are driven by the configured rules alone.
+
 ### Programmatic Rules
 
 Configure comparison rules programmatically using the `Rules` class:
@@ -469,6 +471,39 @@ $replacer->replace($content);  // $content is now 'Version: __VERSION__'
 // Apply to directory
 $replacer->replaceInDir($directory);
 ```
+
+## ⬆️ Upgrading
+
+This release settles the public API and contains breaking changes.
+
+- **Read this first - one break is silent.** `assertSnapshotMatchesBaseline()` reordered its three leading string parameters from `($actual, $baseline, $diffs)` to `($baseline, $diffs, $actual)`. Every parameter is a string path, so an un-updated call still type-checks and runs against the wrong directories instead of failing at the call site. Update every call site before upgrading.
+- **The companion break is loud.** `assertDirectoriesIdentical()` moved `$message` to last and promoted `$rules` to third, so an un-updated call that passed a message third now throws a `TypeError` rather than misbehaving quietly.
+
+Every renamed or reshaped public symbol:
+
+| Old | New |
+|-----|-----|
+| `assertSnapshotMatchesBaseline($actual, $baseline, $diffs, $expected, $message)` | `assertSnapshotMatchesBaseline($baseline, $diffs, $actual, $expected, $message)` |
+| `assertDirectoriesIdentical($dir1, $dir2, $message, $match_content, $show_diff, $rules)` | `assertDirectoriesIdentical($expected, $actual, $rules, $file_filter, $show_diff, $message)` |
+| `Snapshot::scan/compare/diff/sync(..., $content_processor)` | `Snapshot::scan/compare/diff/sync(..., $file_filter)` |
+| `Snapshot::patch($baseline, $patches, ...)` | `Snapshot::patch($baseline, $diffs, ...)` |
+| `SnapshotBuilder::patch($baseline, $patches, ...)` | `SnapshotBuilder::patch($baseline, $diffs, ...)` |
+| `SnapshotBuilder::withContentProcessor()` fed every operation | `withContentProcessor()` feeds `patch()` only; new `withFileFilter()` feeds `scan()`, `compare()`, `diff()`, `sync()` |
+| `SnapshotBuilder::withContentProcessor(callable $processor)` | `SnapshotBuilder::withContentProcessor(callable $content_processor)` |
+| `Index::__construct(..., $beforeMatchContent)` | `Index::__construct(..., $fileFilter)` |
+| `Index::getFiles($cb)` | `Index::getFiles($transformer)` |
+| `Comparer::getAbsentLeftDiffs/getAbsentRightDiffs/getContentDiffs($cb)` | the same methods taking `$transformer` |
+| `Comparer::addLeftFile/addRightFile(): void` | the same methods returning `static` |
+| `IndexedFile::setBasepath/setContent/setIgnoreContent(): void` | the same methods returning `static` |
+| `RuleSetInterface::getSkipPatterns()` | `RuleSetInterface::getSkip()` |
+| `RuleSetInterface::getIgnoreContentPatterns()` | `RuleSetInterface::getIgnoreContent()` |
+| `RuleSetInterface::toRules()` | removed; use `Rules::fromRuleSet($set)` or `$set->applyTo()` |
+| `RuleSetInterface::applyTo(?Rules $rules): Rules` | `applyTo(?RulesInterface $rules): RulesInterface` |
+| `Rules::create/fromRuleSet/phpProject/nodeProject/fromFile(): self` | the same factories returning `static` |
+| `?Rules` parameters and returns across the facade, builder, trait and `Index` | `?RulesInterface` |
+| `PatchException::$file_path/$line_number/$line_content` | `$filePath/$lineNumber/$lineContent`; the getters are unchanged |
+
+Additions that break nothing: `Rules::global()`, `SnapshotBuilder::addGlobal()`, `SnapshotBuilder::withFileFilter()`/`getFileFilter()`, and `RuleSetInterface::getGlobal()`/`getInclude()`/`getIncludeContent()` with their `GLOBAL_PATTERNS`, `INCLUDE_PATTERNS` and `INCLUDE_CONTENT_PATTERNS` constants.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -353,9 +353,11 @@ $rules = Rules::nodeProject(); // Skips node_modules/, ignores lock files
 // Or create custom rules with fluent API
 $rules = Rules::create()
     ->skip('vendor/', 'node_modules/', '.git/')
-    ->ignoreContent('composer.lock', 'package-lock.json')
+    ->ignoreContent('composer.lock', 'package-lock.json', 'reports/')
+    // Keeps this one file even though vendor/ is skipped
     ->include('vendor/autoload.php')
-    ->includeContent('build-manifest.json');
+    // Compares this one file's content even though reports/ is content-ignored
+    ->includeContent('reports/summary.json');
 
 // Or load them from an existing .ignorecontent file
 $rules = Rules::fromFile($baseline . '/.ignorecontent');

--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -110,22 +110,22 @@ class Comparer implements ComparerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getAbsentLeftDiffs(?callable $cb = NULL): array {
-    return $this->filterCached('absent_left', fn(Diff $diff): bool => !$diff->existsLeft(), $cb);
+  public function getAbsentLeftDiffs(?callable $transformer = NULL): array {
+    return $this->filterCached('absent_left', fn(Diff $diff): bool => !$diff->existsLeft(), $transformer);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getAbsentRightDiffs(?callable $cb = NULL): array {
-    return $this->filterCached('absent_right', fn(Diff $diff): bool => !$diff->existsRight(), $cb);
+  public function getAbsentRightDiffs(?callable $transformer = NULL): array {
+    return $this->filterCached('absent_right', fn(Diff $diff): bool => !$diff->existsRight(), $transformer);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getContentDiffs(?callable $cb = NULL): array {
-    return $this->filterCached('content', fn(Diff $diff): bool => $diff->existsLeft() && $diff->existsRight() && !$diff->isSameContent(), $cb);
+  public function getContentDiffs(?callable $transformer = NULL): array {
+    return $this->filterCached('content', fn(Diff $diff): bool => $diff->existsLeft() && $diff->existsRight() && !$diff->isSameContent(), $transformer);
   }
 
   /**
@@ -135,20 +135,20 @@ class Comparer implements ComparerInterface {
    *   Cache key for this filter type.
    * @param callable $filter
    *   The filter callback. Should return TRUE to include an item.
-   * @param callable|null $cb
+   * @param callable|null $transformer
    *   Optional transformation callback applied to each filtered diff.
    *
    * @return array<string, Diff|mixed>
    *   Filtered (and optionally transformed) array of diffs.
    */
-  protected function filterCached(string $cache_key, callable $filter, ?callable $cb = NULL): array {
+  protected function filterCached(string $cache_key, callable $filter, ?callable $transformer = NULL): array {
     $this->cache[$cache_key] ??= array_filter($this->diffs, $filter);
 
     $diffs = $this->cache[$cache_key];
 
-    if (is_callable($cb)) {
+    if (is_callable($transformer)) {
       foreach ($diffs as $path => $diff) {
-        $diffs[$path] = $cb($diff);
+        $diffs[$path] = $transformer($diff);
       }
     }
 

--- a/src/Compare/Comparer.php
+++ b/src/Compare/Comparer.php
@@ -90,21 +90,25 @@ class Comparer implements ComparerInterface {
   /**
    * {@inheritdoc}
    */
-  public function addLeftFile(IndexedFileInterface $file): void {
+  public function addLeftFile(IndexedFileInterface $file): static {
     $path = $file->getPathnameFromBasepath();
     $this->diffs[$path] ??= new Diff();
     $this->diffs[$path]->setLeft($file);
     $this->cache = [];
+
+    return $this;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addRightFile(IndexedFileInterface $file): void {
+  public function addRightFile(IndexedFileInterface $file): static {
     $path = $file->getPathnameFromBasepath();
     $this->diffs[$path] ??= new Diff();
     $this->diffs[$path]->setRight($file);
     $this->cache = [];
+
+    return $this;
   }
 
   /**

--- a/src/Compare/ComparerInterface.php
+++ b/src/Compare/ComparerInterface.php
@@ -24,16 +24,22 @@ interface ComparerInterface extends RenderableInterface {
    *
    * @param \AlexSkrypnyk\Snapshot\Index\IndexedFileInterface $file
    *   The file to add.
+   *
+   * @return $this
+   *   Return self for chaining.
    */
-  public function addLeftFile(IndexedFileInterface $file): void;
+  public function addLeftFile(IndexedFileInterface $file): static;
 
   /**
    * Adds a file from the right (destination) directory to the diff collection.
    *
    * @param \AlexSkrypnyk\Snapshot\Index\IndexedFileInterface $file
    *   The file to add.
+   *
+   * @return $this
+   *   Return self for chaining.
    */
-  public function addRightFile(IndexedFileInterface $file): void;
+  public function addRightFile(IndexedFileInterface $file): static;
 
   /**
    * Get an array of absent left diffs.

--- a/src/Compare/ComparerInterface.php
+++ b/src/Compare/ComparerInterface.php
@@ -38,37 +38,37 @@ interface ComparerInterface extends RenderableInterface {
   /**
    * Get an array of absent left diffs.
    *
-   * @param callable|null $cb
+   * @param callable|null $transformer
    *   Optional transformation callback.
    *
    * @return array<string, \AlexSkrypnyk\Snapshot\Compare\Diff|mixed>
    *   An array of diffs that are present in the right directory but not in
    *   the left.
    */
-  public function getAbsentLeftDiffs(?callable $cb = NULL): array;
+  public function getAbsentLeftDiffs(?callable $transformer = NULL): array;
 
   /**
    * Get an array of absent right diffs.
    *
-   * @param callable|null $cb
+   * @param callable|null $transformer
    *   Optional transformation callback.
    *
    * @return array<string, \AlexSkrypnyk\Snapshot\Compare\Diff|mixed>
    *   An array of diffs that are present in the left directory but not in
    *   the right.
    */
-  public function getAbsentRightDiffs(?callable $cb = NULL): array;
+  public function getAbsentRightDiffs(?callable $transformer = NULL): array;
 
   /**
    * Get an array of content diffs.
    *
-   * @param callable|null $cb
+   * @param callable|null $transformer
    *   Optional transformation callback.
    *
    * @return array<string, \AlexSkrypnyk\Snapshot\Compare\Diff|mixed>
    *   An array of diffs that are present in both directories but have different
    *   content.
    */
-  public function getContentDiffs(?callable $cb = NULL): array;
+  public function getContentDiffs(?callable $transformer = NULL): array;
 
 }

--- a/src/Exception/PatchException.php
+++ b/src/Exception/PatchException.php
@@ -12,9 +12,6 @@ class PatchException extends SnapshotException {
   /**
    * Constructs a PatchException.
    *
-   * The promoted parameters declare properties, so they carry the camelCase
-   * property names rather than the snake_case argument names.
-   *
    * @param string $message
    *   The exception message.
    * @param string|null $filePath

--- a/src/Exception/PatchException.php
+++ b/src/Exception/PatchException.php
@@ -12,13 +12,16 @@ class PatchException extends SnapshotException {
   /**
    * Constructs a PatchException.
    *
+   * The promoted parameters declare properties, so they carry the camelCase
+   * property names rather than the snake_case argument names.
+   *
    * @param string $message
    *   The exception message.
-   * @param string|null $file_path
+   * @param string|null $filePath
    *   The file path, if applicable.
-   * @param int|string|null $line_number
+   * @param int|string|null $lineNumber
    *   The line number, if applicable.
-   * @param string|null $line_content
+   * @param string|null $lineContent
    *   The line content, if applicable.
    * @param int $code
    *   The exception code.
@@ -27,9 +30,9 @@ class PatchException extends SnapshotException {
    */
   public function __construct(
     string $message,
-    protected ?string $file_path = NULL,
-    protected int|string|null $line_number = NULL,
-    protected ?string $line_content = NULL,
+    protected ?string $filePath = NULL,
+    protected int|string|null $lineNumber = NULL,
+    protected ?string $lineContent = NULL,
     int $code = 0,
     ?\Throwable $previous = NULL,
   ) {
@@ -37,20 +40,20 @@ class PatchException extends SnapshotException {
       $message = 'An error occurred';
     }
 
-    if (($this->file_path || $this->line_number || $this->line_content) && str_ends_with($message, '.')) {
+    if (($this->filePath || $this->lineNumber || $this->lineContent) && str_ends_with($message, '.')) {
       $message = rtrim($message, '.');
     }
 
-    if ($this->file_path !== NULL) {
-      $message .= sprintf(' in file "%s"', $this->file_path);
+    if ($this->filePath !== NULL) {
+      $message .= sprintf(' in file "%s"', $this->filePath);
     }
 
-    if ($this->line_number !== NULL) {
-      $message .= ' on line ' . $this->line_number;
+    if ($this->lineNumber !== NULL) {
+      $message .= ' on line ' . $this->lineNumber;
     }
 
-    if ($this->line_content !== NULL) {
-      $message .= sprintf(': "%s"', $this->line_content);
+    if ($this->lineContent !== NULL) {
+      $message .= sprintf(': "%s"', $this->lineContent);
     }
 
     if (!str_ends_with($message, '.')) {
@@ -67,7 +70,7 @@ class PatchException extends SnapshotException {
    *   The file path.
    */
   public function getFilePath(): ?string {
-    return $this->file_path;
+    return $this->filePath;
   }
 
   /**
@@ -77,7 +80,7 @@ class PatchException extends SnapshotException {
    *   The line number.
    */
   public function getLineNumber(): int|string|null {
-    return $this->line_number;
+    return $this->lineNumber;
   }
 
   /**
@@ -87,7 +90,7 @@ class PatchException extends SnapshotException {
    *   The line content.
    */
   public function getLineContent(): ?string {
-    return $this->line_content;
+    return $this->lineContent;
   }
 
 }

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -6,6 +6,7 @@ namespace AlexSkrypnyk\Snapshot\Index;
 
 use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
+use AlexSkrypnyk\Snapshot\Rules\RulesInterface;
 use AlexSkrypnyk\Snapshot\Snapshot;
 
 /**
@@ -25,14 +26,14 @@ class Index implements IndexInterface {
   /**
    * The rules to apply when indexing files.
    */
-  protected Rules $rules;
+  protected RulesInterface $rules;
 
   /**
    * Constructs an Index instance.
    *
    * @param string $directory
    *   The directory to index.
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional rules to apply when indexing. Falls back to the directory's
    *   rules file, then to empty rules.
    * @param mixed $fileFilter
@@ -44,7 +45,7 @@ class Index implements IndexInterface {
    */
   public function __construct(
     protected string $directory,
-    ?Rules $rules = NULL,
+    ?RulesInterface $rules = NULL,
     protected mixed $fileFilter = NULL,
   ) {
     $this->rules = $rules ??
@@ -89,7 +90,7 @@ class Index implements IndexInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRules(): Rules {
+  public function getRules(): RulesInterface {
     return $this->rules;
   }
 

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -37,9 +37,9 @@ class Index implements IndexInterface {
    *   Optional rules to apply when indexing. Falls back to the directory's
    *   rules file, then to empty rules.
    * @param mixed $fileFilter
-   *   Optional callback receiving the IndexedFile of each candidate file. Real
-   *   directories and files matched by an ignore-content rule never reach it,
-   *   but a symlink to a directory does. Returning FALSE excludes the file
+   *   Optional callback receiving the IndexedFile of each file that survives
+   *   the skip, global and ignore-content rules. A symlink to a directory
+   *   reaches it; a broken symlink does not. Returning FALSE excludes the file
    *   from the index; any other return value is discarded, and any change the
    *   callback made to the file is kept.
    */

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -37,11 +37,11 @@ class Index implements IndexInterface {
    *   Optional rules to apply when indexing. Falls back to the directory's
    *   rules file, then to empty rules.
    * @param mixed $fileFilter
-   *   Optional callback receiving the IndexedFile of each file whose content
-   *   is compared; directories and files with ignored content never reach it.
-   *   Returning FALSE excludes the file from the index; any other return value
-   *   is discarded, leaving the file indexed along with any change the
-   *   callback made to it.
+   *   Optional callback receiving the IndexedFile of each candidate file. Real
+   *   directories and files matched by an ignore-content rule never reach it,
+   *   but a symlink to a directory does. Returning FALSE excludes the file
+   *   from the index; any other return value is discarded, and any change the
+   *   callback made to the file is kept.
    */
   public function __construct(
     protected string $directory,

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -27,10 +27,25 @@ class Index implements IndexInterface {
    */
   protected Rules $rules;
 
+  /**
+   * Constructs an Index instance.
+   *
+   * @param string $directory
+   *   The directory to index.
+   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   *   Optional rules to apply when indexing. Falls back to the directory's
+   *   rules file, then to empty rules.
+   * @param mixed $fileFilter
+   *   Optional callback receiving the IndexedFile of each file whose content
+   *   is compared; directories and files with ignored content never reach it.
+   *   Returning FALSE excludes the file from the index; any other return value
+   *   is discarded, leaving the file indexed along with any change the
+   *   callback made to it.
+   */
   public function __construct(
     protected string $directory,
     ?Rules $rules = NULL,
-    protected mixed $beforeMatchContent = NULL,
+    protected mixed $fileFilter = NULL,
   ) {
     $this->rules = $rules ??
       (
@@ -44,21 +59,21 @@ class Index implements IndexInterface {
   /**
    * {@inheritdoc}
    */
-  public function getFiles(?callable $cb = NULL): array {
+  public function getFiles(?callable $transformer = NULL): array {
     if ($this->files === NULL) {
       $this->scan();
     }
 
     $this->files ??= [];
 
-    if (!is_callable($cb)) {
+    if (!is_callable($transformer)) {
       return $this->files;
     }
 
     // Transform a copy so the callback never mutates the cached index.
     $files = [];
     foreach ($this->files as $path => $file) {
-      $files[$path] = $cb($file);
+      $files[$path] = $transformer($file);
     }
 
     return $files;
@@ -79,7 +94,7 @@ class Index implements IndexInterface {
   }
 
   /**
-   * Scan files in directory respecting rules and optionally using a callback.
+   * Scans files in the directory, applying the rules and the file filter.
    */
   protected function scan(): static {
     $this->files = [];
@@ -149,9 +164,8 @@ class Index implements IndexInterface {
         $file->setIgnoreContent();
         // @codeCoverageIgnoreEnd
       }
-      elseif (is_callable($this->beforeMatchContent)) {
-        $ret = call_user_func($this->beforeMatchContent, $file);
-        if ($ret === FALSE) {
+      elseif (is_callable($this->fileFilter)) {
+        if (call_user_func($this->fileFilter, $file) === FALSE) {
           continue;
         }
       }

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -38,10 +38,10 @@ class Index implements IndexInterface {
    *   rules file, then to empty rules.
    * @param mixed $fileFilter
    *   Optional callback receiving the IndexedFile of each file that survives
-   *   the skip, global and ignore-content rules. A symlink to a directory
-   *   reaches it; a broken symlink does not. Returning FALSE excludes the file
-   *   from the index; any other return value is discarded, and any change the
-   *   callback made to the file is kept.
+   *   the skip and global rules, including files marked by an ignore-content
+   *   rule. A symlink to a directory reaches it; a broken symlink does not.
+   *   Returning FALSE excludes the file from the index; any other return value
+   *   is discarded, and any change the callback made to the file is kept.
    */
   public function __construct(
     protected string $directory,
@@ -165,10 +165,11 @@ class Index implements IndexInterface {
         $file->setIgnoreContent();
         // @codeCoverageIgnoreEnd
       }
-      elseif (is_callable($this->fileFilter)) {
-        if (call_user_func($this->fileFilter, $file) === FALSE) {
-          continue;
-        }
+
+      // The filter runs after the content marking so that it can exclude a
+      // file whose content is ignored.
+      if (is_callable($this->fileFilter) && call_user_func($this->fileFilter, $file) === FALSE) {
+        continue;
       }
 
       $this->files[$relative_path] = $file;

--- a/src/Index/IndexInterface.php
+++ b/src/Index/IndexInterface.php
@@ -14,13 +14,13 @@ interface IndexInterface {
   /**
    * Gets the indexed files.
    *
-   * @param callable|null $cb
+   * @param callable|null $transformer
    *   Optional callback to transform each file.
    *
    * @return array<string, \AlexSkrypnyk\Snapshot\Index\IndexedFileInterface|mixed>
    *   Array of files indexed by path relative to base directory.
    */
-  public function getFiles(?callable $cb = NULL): array;
+  public function getFiles(?callable $transformer = NULL): array;
 
   /**
    * Gets the directory being indexed.

--- a/src/Index/IndexedFile.php
+++ b/src/Index/IndexedFile.php
@@ -69,9 +69,11 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
   /**
    * {@inheritdoc}
    */
-  public function setBasepath(string $basepath): void {
+  public function setBasepath(string $basepath): static {
     $this->basepath = rtrim($basepath, DIRECTORY_SEPARATOR);
     $this->relativePathname = NULL;
+
+    return $this;
   }
 
   /**
@@ -133,14 +135,14 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
   /**
    * {@inheritdoc}
    */
-  public function setIgnoreContent(bool $ignore = TRUE): void {
-    $this->setContent($ignore ? static::CONTENT_IGNORED_MARKER : NULL);
+  public function setIgnoreContent(bool $ignore = TRUE): static {
+    return $this->setContent($ignore ? static::CONTENT_IGNORED_MARKER : NULL);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setContent(?string $content): void {
+  public function setContent(?string $content): static {
     if ($content !== NULL) {
       $this->content = $content;
       $this->hash = $this->hash($this->content);
@@ -152,6 +154,8 @@ class IndexedFile extends \SplFileInfo implements IndexedFileInterface {
       $this->content = NULL;
       $this->hash = NULL;
     }
+
+    return $this;
   }
 
   /**

--- a/src/Index/IndexedFileInterface.php
+++ b/src/Index/IndexedFileInterface.php
@@ -14,8 +14,11 @@ interface IndexedFileInterface {
    *
    * @param string $basepath
    *   The base path to set.
+   *
+   * @return $this
+   *   Return self for chaining.
    */
-  public function setBasepath(string $basepath): void;
+  public function setBasepath(string $basepath): static;
 
   /**
    * Gets the base path.
@@ -70,16 +73,22 @@ interface IndexedFileInterface {
    *
    * @param bool $ignore
    *   Whether to ignore the content.
+   *
+   * @return $this
+   *   Return self for chaining.
    */
-  public function setIgnoreContent(bool $ignore = TRUE): void;
+  public function setIgnoreContent(bool $ignore = TRUE): static;
 
   /**
    * Sets the file content.
    *
    * @param string|null $content
    *   The content to set, or NULL to load lazily.
+   *
+   * @return $this
+   *   Return self for chaining.
    */
-  public function setContent(?string $content): void;
+  public function setContent(?string $content): static;
 
   /**
    * Gets the full pathname.

--- a/src/Rules/AbstractRuleSet.php
+++ b/src/Rules/AbstractRuleSet.php
@@ -13,18 +13,18 @@ namespace AlexSkrypnyk\Snapshot\Rules;
 abstract class AbstractRuleSet implements RuleSetInterface {
 
   /**
-   * Patterns for files to skip.
-   *
-   * @var array<int, string>
-   */
-  protected const SKIP_PATTERNS = [];
-
-  /**
    * Patterns for files where only content should be ignored.
    *
    * @var array<int, string>
    */
   protected const IGNORE_CONTENT_PATTERNS = [];
+
+  /**
+   * Patterns for files to skip.
+   *
+   * @var array<int, string>
+   */
+  protected const SKIP_PATTERNS = [];
 
   /**
    * Global patterns that apply everywhere.
@@ -50,15 +50,15 @@ abstract class AbstractRuleSet implements RuleSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function getSkip(): array {
-    return static::SKIP_PATTERNS;
+  public function getIgnoreContent(): array {
+    return static::IGNORE_CONTENT_PATTERNS;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getIgnoreContent(): array {
-    return static::IGNORE_CONTENT_PATTERNS;
+  public function getSkip(): array {
+    return static::SKIP_PATTERNS;
   }
 
   /**
@@ -88,12 +88,12 @@ abstract class AbstractRuleSet implements RuleSetInterface {
   public function applyTo(?RulesInterface $rules = NULL): RulesInterface {
     $rules ??= new Rules();
 
-    foreach ($this->getSkip() as $pattern) {
-      $rules->addSkip($pattern);
-    }
-
     foreach ($this->getIgnoreContent() as $pattern) {
       $rules->addIgnoreContent($pattern);
+    }
+
+    foreach ($this->getSkip() as $pattern) {
+      $rules->addSkip($pattern);
     }
 
     foreach ($this->getGlobal() as $pattern) {

--- a/src/Rules/AbstractRuleSet.php
+++ b/src/Rules/AbstractRuleSet.php
@@ -7,60 +7,108 @@ namespace AlexSkrypnyk\Snapshot\Rules;
 /**
  * Abstract base class for rule sets.
  *
- * Subclasses should define SKIP_PATTERNS and IGNORE_CONTENT_PATTERNS constants.
+ * Subclasses define the pattern constants for the rule kinds they cover and
+ * inherit the empty defaults for the rest.
  */
 abstract class AbstractRuleSet implements RuleSetInterface {
 
   /**
-   * Patterns to skip during comparison.
+   * Patterns for files to skip.
    *
    * @var array<int, string>
    */
   protected const SKIP_PATTERNS = [];
 
   /**
-   * Patterns where content differences should be ignored.
+   * Patterns for files where only content should be ignored.
    *
    * @var array<int, string>
    */
   protected const IGNORE_CONTENT_PATTERNS = [];
 
   /**
+   * Global patterns that apply everywhere.
+   *
+   * @var array<int, string>
+   */
+  protected const GLOBAL_PATTERNS = [];
+
+  /**
+   * Patterns for files to explicitly include.
+   *
+   * @var array<int, string>
+   */
+  protected const INCLUDE_PATTERNS = [];
+
+  /**
+   * Patterns for files where content should be explicitly compared.
+   *
+   * @var array<int, string>
+   */
+  protected const INCLUDE_CONTENT_PATTERNS = [];
+
+  /**
    * {@inheritdoc}
    */
-  public function getSkipPatterns(): array {
+  public function getSkip(): array {
     return static::SKIP_PATTERNS;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getIgnoreContentPatterns(): array {
+  public function getIgnoreContent(): array {
     return static::IGNORE_CONTENT_PATTERNS;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function applyTo(?Rules $rules = NULL): Rules {
-    $rules ??= new Rules();
-
-    foreach ($this->getSkipPatterns() as $pattern) {
-      $rules->addSkip($pattern);
-    }
-
-    foreach ($this->getIgnoreContentPatterns() as $pattern) {
-      $rules->addIgnoreContent($pattern);
-    }
-
-    return $rules;
+  public function getGlobal(): array {
+    return static::GLOBAL_PATTERNS;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function toRules(): Rules {
-    return $this->applyTo();
+  public function getInclude(): array {
+    return static::INCLUDE_PATTERNS;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIncludeContent(): array {
+    return static::INCLUDE_CONTENT_PATTERNS;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applyTo(?RulesInterface $rules = NULL): RulesInterface {
+    $rules ??= new Rules();
+
+    foreach ($this->getSkip() as $pattern) {
+      $rules->addSkip($pattern);
+    }
+
+    foreach ($this->getIgnoreContent() as $pattern) {
+      $rules->addIgnoreContent($pattern);
+    }
+
+    foreach ($this->getGlobal() as $pattern) {
+      $rules->addGlobal($pattern);
+    }
+
+    foreach ($this->getInclude() as $pattern) {
+      $rules->addInclude($pattern);
+    }
+
+    foreach ($this->getIncludeContent() as $pattern) {
+      $rules->addIncludeContent($pattern);
+    }
+
+    return $rules;
   }
 
 }

--- a/src/Rules/NodeProjectRuleSet.php
+++ b/src/Rules/NodeProjectRuleSet.php
@@ -10,7 +10,7 @@ namespace AlexSkrypnyk\Snapshot\Rules;
  * Skips common Node.js project directories and ignores content of lock files.
  *
  * @code
- * $rules = (new NodeProjectRuleSet())->toRules();
+ * $rules = Rules::fromRuleSet(new NodeProjectRuleSet());
  * Snapshot::compare($baseline, $actual, $rules);
  * @endcode
  */

--- a/src/Rules/PhpProjectRuleSet.php
+++ b/src/Rules/PhpProjectRuleSet.php
@@ -10,7 +10,7 @@ namespace AlexSkrypnyk\Snapshot\Rules;
  * Skips common PHP project directories and ignores content of lock files.
  *
  * @code
- * $rules = (new PhpProjectRuleSet())->toRules();
+ * $rules = Rules::fromRuleSet(new PhpProjectRuleSet());
  * Snapshot::compare($baseline, $actual, $rules);
  * @endcode
  */

--- a/src/Rules/RuleSetInterface.php
+++ b/src/Rules/RuleSetInterface.php
@@ -58,7 +58,9 @@ interface RuleSetInterface {
    *   Optional existing rules to extend. Creates new rules if NULL.
    *
    * @return \AlexSkrypnyk\Snapshot\Rules\RulesInterface
-   *   Rules instance with this rule set applied.
+   *   The same rules instance the patterns were applied to: the given one, or
+   *   the one created when NULL was passed. Implementations must not return a
+   *   different instance, so callers may keep using the one they passed in.
    */
   public function applyTo(?RulesInterface $rules = NULL): RulesInterface;
 

--- a/src/Rules/RuleSetInterface.php
+++ b/src/Rules/RuleSetInterface.php
@@ -12,38 +12,54 @@ namespace AlexSkrypnyk\Snapshot\Rules;
 interface RuleSetInterface {
 
   /**
-   * Get patterns to skip during comparison.
+   * Get patterns for files to skip.
    *
    * @return array<int, string>
-   *   Array of patterns to skip.
+   *   Array of patterns.
    */
-  public function getSkipPatterns(): array;
+  public function getSkip(): array;
 
   /**
-   * Get patterns where content differences should be ignored.
+   * Get patterns for files where only content should be ignored.
    *
    * @return array<int, string>
-   *   Array of patterns to ignore content.
+   *   Array of patterns.
    */
-  public function getIgnoreContentPatterns(): array;
+  public function getIgnoreContent(): array;
+
+  /**
+   * Get global patterns that apply everywhere.
+   *
+   * @return array<int, string>
+   *   Array of patterns.
+   */
+  public function getGlobal(): array;
+
+  /**
+   * Get patterns for files to explicitly include.
+   *
+   * @return array<int, string>
+   *   Array of patterns.
+   */
+  public function getInclude(): array;
+
+  /**
+   * Get patterns for files where content should be explicitly compared.
+   *
+   * @return array<int, string>
+   *   Array of patterns.
+   */
+  public function getIncludeContent(): array;
 
   /**
    * Apply this rule set to a Rules instance.
    *
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional existing rules to extend. Creates new Rules if NULL.
    *
-   * @return \AlexSkrypnyk\Snapshot\Rules\Rules
+   * @return \AlexSkrypnyk\Snapshot\Rules\RulesInterface
    *   Rules instance with this rule set applied.
    */
-  public function applyTo(?Rules $rules = NULL): Rules;
-
-  /**
-   * Create a new Rules instance with this rule set applied.
-   *
-   * @return \AlexSkrypnyk\Snapshot\Rules\Rules
-   *   New Rules instance configured with this rule set.
-   */
-  public function toRules(): Rules;
+  public function applyTo(?RulesInterface $rules = NULL): RulesInterface;
 
 }

--- a/src/Rules/RuleSetInterface.php
+++ b/src/Rules/RuleSetInterface.php
@@ -12,15 +12,7 @@ namespace AlexSkrypnyk\Snapshot\Rules;
 interface RuleSetInterface {
 
   /**
-   * Get patterns for files to skip.
-   *
-   * @return array<int, string>
-   *   Array of patterns.
-   */
-  public function getSkip(): array;
-
-  /**
-   * Get patterns for files where only content should be ignored.
+   * Gets patterns for files where only content should be ignored.
    *
    * @return array<int, string>
    *   Array of patterns.
@@ -28,7 +20,15 @@ interface RuleSetInterface {
   public function getIgnoreContent(): array;
 
   /**
-   * Get global patterns that apply everywhere.
+   * Gets patterns for files to skip.
+   *
+   * @return array<int, string>
+   *   Array of patterns.
+   */
+  public function getSkip(): array;
+
+  /**
+   * Gets global patterns that apply everywhere.
    *
    * @return array<int, string>
    *   Array of patterns.
@@ -36,7 +36,7 @@ interface RuleSetInterface {
   public function getGlobal(): array;
 
   /**
-   * Get patterns for files to explicitly include.
+   * Gets patterns for files to explicitly include.
    *
    * @return array<int, string>
    *   Array of patterns.
@@ -44,7 +44,7 @@ interface RuleSetInterface {
   public function getInclude(): array;
 
   /**
-   * Get patterns for files where content should be explicitly compared.
+   * Gets patterns for files where content should be explicitly compared.
    *
    * @return array<int, string>
    *   Array of patterns.
@@ -52,10 +52,10 @@ interface RuleSetInterface {
   public function getIncludeContent(): array;
 
   /**
-   * Apply this rule set to a Rules instance.
+   * Apply this rule set to a rules instance.
    *
    * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
-   *   Optional existing rules to extend. Creates new Rules if NULL.
+   *   Optional existing rules to extend. Creates new rules if NULL.
    *
    * @return \AlexSkrypnyk\Snapshot\Rules\RulesInterface
    *   Rules instance with this rule set applied.

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -225,6 +225,16 @@ class Rules implements RulesInterface {
   /**
    * {@inheritdoc}
    */
+  public function global(string ...$patterns): static {
+    foreach ($patterns as $pattern) {
+      $this->addGlobal($pattern);
+    }
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function include(string ...$patterns): static {
     foreach ($patterns as $pattern) {
       $this->addInclude($pattern);

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -10,6 +10,8 @@ use AlexSkrypnyk\Snapshot\Exception\SnapshotException;
 
 /**
  * Handles file matching rules and patterns.
+ *
+ * @phpstan-consistent-constructor
  */
 class Rules implements RulesInterface {
 
@@ -51,11 +53,11 @@ class Rules implements RulesInterface {
   /**
    * Creates a new Rules instance.
    *
-   * @return self
+   * @return static
    *   A new Rules instance.
    */
-  public static function create(): self {
-    return new self();
+  public static function create(): static {
+    return new static();
   }
 
   /**
@@ -64,11 +66,11 @@ class Rules implements RulesInterface {
    * @param \AlexSkrypnyk\Snapshot\Rules\RuleSetInterface $rule_set
    *   The rule set to apply.
    *
-   * @return self
+   * @return static
    *   A new Rules instance with the rule set applied.
    */
-  public static function fromRuleSet(RuleSetInterface $rule_set): self {
-    $rules = new self();
+  public static function fromRuleSet(RuleSetInterface $rule_set): static {
+    $rules = new static();
     $rule_set->applyTo($rules);
     return $rules;
   }
@@ -76,21 +78,25 @@ class Rules implements RulesInterface {
   /**
    * Creates a Rules instance with common PHP project patterns.
    *
-   * @return self
+   * @return static
    *   A new Rules instance configured for PHP projects.
    */
-  public static function phpProject(): self {
-    return self::fromRuleSet(new PhpProjectRuleSet());
+  public static function phpProject(): static {
+    $rules = new static();
+    (new PhpProjectRuleSet())->applyTo($rules);
+    return $rules;
   }
 
   /**
    * Creates a Rules instance with common Node.js project patterns.
    *
-   * @return self
+   * @return static
    *   A new Rules instance configured for Node.js projects.
    */
-  public static function nodeProject(): self {
-    return self::fromRuleSet(new NodeProjectRuleSet());
+  public static function nodeProject(): static {
+    $rules = new static();
+    (new NodeProjectRuleSet())->applyTo($rules);
+    return $rules;
   }
 
   /**
@@ -99,13 +105,13 @@ class Rules implements RulesInterface {
    * @param string $file
    *   The path to the rules file.
    *
-   * @return self
+   * @return static
    *   A new Rules instance.
    *
    * @throws \AlexSkrypnyk\Snapshot\Exception\SnapshotException
    *   If the file does not exist or cannot be read.
    */
-  public static function fromFile(string $file): self {
+  public static function fromFile(string $file): static {
     if (!File::exists($file)) {
       throw new SnapshotException(sprintf('File %s does not exist.', $file));
     }
@@ -118,7 +124,7 @@ class Rules implements RulesInterface {
       throw new RulesException(sprintf('Failed to read the %s file.', $file), $exception->getCode(), $exception);
     }
     // @codeCoverageIgnoreEnd
-    return (new self())->parse($content);
+    return (new static())->parse($content);
   }
 
   /**

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -82,9 +82,7 @@ class Rules implements RulesInterface {
    *   A new Rules instance configured for PHP projects.
    */
   public static function phpProject(): static {
-    $rules = new static();
-    (new PhpProjectRuleSet())->applyTo($rules);
-    return $rules;
+    return static::fromRuleSet(new PhpProjectRuleSet());
   }
 
   /**
@@ -94,9 +92,7 @@ class Rules implements RulesInterface {
    *   A new Rules instance configured for Node.js projects.
    */
   public static function nodeProject(): static {
-    $rules = new static();
-    (new NodeProjectRuleSet())->applyTo($rules);
-    return $rules;
+    return static::fromRuleSet(new NodeProjectRuleSet());
   }
 
   /**

--- a/src/Rules/RulesInterface.php
+++ b/src/Rules/RulesInterface.php
@@ -127,6 +127,17 @@ interface RulesInterface {
   public function ignoreContent(string ...$patterns): static;
 
   /**
+   * Fluent method to add multiple global patterns.
+   *
+   * @param string ...$patterns
+   *   Patterns that apply everywhere.
+   *
+   * @return $this
+   *   Return self for chaining.
+   */
+  public function global(string ...$patterns): static;
+
+  /**
    * Fluent method to include multiple patterns.
    *
    * @param string ...$patterns

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -17,8 +17,8 @@ use AlexSkrypnyk\Snapshot\Sync\Syncer;
  * Static facade for directory snapshot operations.
  *
  * Provides quick access to snapshot functionality for one-off operations.
- * For configured operations with rules and content processors, use
- * SnapshotBuilder instead.
+ * For configured operations with rules, a file filter or a content processor,
+ * use SnapshotBuilder instead.
  *
  * @code
  * // Quick one-off operations
@@ -53,14 +53,15 @@ class Snapshot {
    *   Directory to scan.
    * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
    *   Optional comparison rules.
-   * @param callable|null $content_processor
-   *   Optional callback to process file content.
+   * @param callable|null $file_filter
+   *   Optional callback receiving each indexed file; returning FALSE excludes
+   *   the file from the index.
    *
    * @return \AlexSkrypnyk\Snapshot\Index\Index
    *   The directory index.
    */
-  public static function scan(string $directory, ?Rules $rules = NULL, ?callable $content_processor = NULL): Index {
-    return new Index($directory, $rules, $content_processor);
+  public static function scan(string $directory, ?Rules $rules = NULL, ?callable $file_filter = NULL): Index {
+    return new Index($directory, $rules, $file_filter);
   }
 
   /**
@@ -72,17 +73,18 @@ class Snapshot {
    *   Actual directory path.
    * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
    *   Optional comparison rules.
-   * @param callable|null $content_processor
-   *   Optional callback to process file content.
+   * @param callable|null $file_filter
+   *   Optional callback receiving each indexed file; returning FALSE excludes
+   *   the file from both indexes.
    *
    * @return \AlexSkrypnyk\Snapshot\Compare\Comparer
    *   Comparison result object.
    */
-  public static function compare(string $baseline, string $actual, ?Rules $rules = NULL, ?callable $content_processor = NULL): Comparer {
-    $baseline_index = new Index($baseline, $rules, $content_processor);
+  public static function compare(string $baseline, string $actual, ?Rules $rules = NULL, ?callable $file_filter = NULL): Comparer {
+    $baseline_index = new Index($baseline, $rules, $file_filter);
 
     File::mkdir($actual);
-    $actual_index = new Index($actual, $rules ?: $baseline_index->getRules(), $content_processor);
+    $actual_index = new Index($actual, $rules ?: $baseline_index->getRules(), $file_filter);
 
     return (new Comparer($baseline_index, $actual_index))->compare();
   }
@@ -98,13 +100,14 @@ class Snapshot {
    *   Directory to write diff files to.
    * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
    *   Optional comparison rules.
-   * @param callable|null $content_processor
-   *   Optional callback to process file content.
+   * @param callable|null $file_filter
+   *   Optional callback receiving each indexed file; returning FALSE excludes
+   *   the file from both indexes.
    */
-  public static function diff(string $baseline, string $actual, string $output, ?Rules $rules = NULL, ?callable $content_processor = NULL): void {
+  public static function diff(string $baseline, string $actual, string $output, ?Rules $rules = NULL, ?callable $file_filter = NULL): void {
     File::mkdir($output);
 
-    $comparer = self::compare($baseline, $actual, $rules, $content_processor);
+    $comparer = self::compare($baseline, $actual, $rules, $file_filter);
 
     $absent_left = $comparer->getAbsentLeftDiffs();
     $absent_right = $comparer->getAbsentRightDiffs();
@@ -144,23 +147,23 @@ class Snapshot {
    *
    * @param string $baseline
    *   Baseline directory path.
-   * @param string $patches
-   *   Directory containing patch/diff files.
+   * @param string $diffs
+   *   Directory containing diff files produced by self::diff().
    * @param string $destination
    *   Destination directory for patched output.
    * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
-   *   Optional rules applied to the baseline sync and the patches scan.
+   *   Optional rules applied to the baseline sync and the diffs scan.
    * @param callable|null $content_processor
    *   Optional callback to process content after patching.
    */
-  public static function patch(string $baseline, string $patches, string $destination, ?Rules $rules = NULL, ?callable $content_processor = NULL): void {
+  public static function patch(string $baseline, string $diffs, string $destination, ?Rules $rules = NULL, ?callable $content_processor = NULL): void {
     File::mkdir($destination);
 
     self::sync($baseline, $destination, 0755, FALSE, $rules);
 
     $patcher = new Patcher($baseline, $destination);
 
-    $patch_index = self::scan($patches, $rules);
+    $patch_index = self::scan($diffs, $rules);
     foreach ($patch_index->getFiles() as $file) {
       // getFiles() allows a transform callback to return non-file values;
       // skip anything that is not a file since none is passed here.
@@ -218,11 +221,12 @@ class Snapshot {
    *   Whether to copy empty directories.
    * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
    *   Optional comparison rules.
-   * @param callable|null $content_processor
-   *   Optional callback to process file content.
+   * @param callable|null $file_filter
+   *   Optional callback receiving each indexed file; returning FALSE excludes
+   *   the file from the sync.
    */
-  public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, ?Rules $rules = NULL, ?callable $content_processor = NULL): void {
-    $index = self::scan($source, $rules, $content_processor);
+  public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, ?Rules $rules = NULL, ?callable $file_filter = NULL): void {
+    $index = self::scan($source, $rules, $file_filter);
     (new Syncer($index))->sync($destination, $permissions, $copy_empty_dirs);
   }
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -10,7 +10,7 @@ use AlexSkrypnyk\Snapshot\Compare\Diff;
 use AlexSkrypnyk\Snapshot\Index\Index;
 use AlexSkrypnyk\Snapshot\Index\IndexedFileInterface;
 use AlexSkrypnyk\Snapshot\Patch\Patcher;
-use AlexSkrypnyk\Snapshot\Rules\Rules;
+use AlexSkrypnyk\Snapshot\Rules\RulesInterface;
 use AlexSkrypnyk\Snapshot\Sync\Syncer;
 
 /**
@@ -51,7 +51,7 @@ class Snapshot {
    *
    * @param string $directory
    *   Directory to scan.
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
    *   Optional callback receiving each indexed file; returning FALSE excludes
@@ -60,7 +60,7 @@ class Snapshot {
    * @return \AlexSkrypnyk\Snapshot\Index\Index
    *   The directory index.
    */
-  public static function scan(string $directory, ?Rules $rules = NULL, ?callable $file_filter = NULL): Index {
+  public static function scan(string $directory, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL): Index {
     return new Index($directory, $rules, $file_filter);
   }
 
@@ -71,7 +71,7 @@ class Snapshot {
    *   Baseline directory path (expected).
    * @param string $actual
    *   Actual directory path.
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
    *   Optional callback receiving each indexed file; returning FALSE excludes
@@ -80,7 +80,7 @@ class Snapshot {
    * @return \AlexSkrypnyk\Snapshot\Compare\Comparer
    *   Comparison result object.
    */
-  public static function compare(string $baseline, string $actual, ?Rules $rules = NULL, ?callable $file_filter = NULL): Comparer {
+  public static function compare(string $baseline, string $actual, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL): Comparer {
     $baseline_index = new Index($baseline, $rules, $file_filter);
 
     File::mkdir($actual);
@@ -98,13 +98,13 @@ class Snapshot {
    *   Actual directory path.
    * @param string $output
    *   Directory to write diff files to.
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
    *   Optional callback receiving each indexed file; returning FALSE excludes
    *   the file from both indexes.
    */
-  public static function diff(string $baseline, string $actual, string $output, ?Rules $rules = NULL, ?callable $file_filter = NULL): void {
+  public static function diff(string $baseline, string $actual, string $output, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL): void {
     File::mkdir($output);
 
     $comparer = self::compare($baseline, $actual, $rules, $file_filter);
@@ -151,12 +151,12 @@ class Snapshot {
    *   Directory containing diff files produced by self::diff().
    * @param string $destination
    *   Destination directory for patched output.
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional rules applied to the baseline sync and the diffs scan.
    * @param callable|null $content_processor
    *   Optional callback to process content after patching.
    */
-  public static function patch(string $baseline, string $diffs, string $destination, ?Rules $rules = NULL, ?callable $content_processor = NULL): void {
+  public static function patch(string $baseline, string $diffs, string $destination, ?RulesInterface $rules = NULL, ?callable $content_processor = NULL): void {
     File::mkdir($destination);
 
     self::sync($baseline, $destination, 0755, FALSE, $rules);
@@ -219,13 +219,13 @@ class Snapshot {
    *   Directory permissions.
    * @param bool $copy_empty_dirs
    *   Whether to copy empty directories.
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
    *   Optional callback receiving each indexed file; returning FALSE excludes
    *   the file from the sync.
    */
-  public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, ?Rules $rules = NULL, ?callable $file_filter = NULL): void {
+  public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL): void {
     $index = self::scan($source, $rules, $file_filter);
     (new Syncer($index))->sync($destination, $permissions, $copy_empty_dirs);
   }

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -54,8 +54,8 @@ class Snapshot {
    * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
-   *   Optional callback receiving each indexed file; returning FALSE excludes
-   *   the file from the index.
+   *   Optional callback receiving each candidate file as an IndexedFile;
+   *   returning FALSE excludes the file from the index.
    *
    * @return \AlexSkrypnyk\Snapshot\Index\Index
    *   The directory index.
@@ -74,8 +74,8 @@ class Snapshot {
    * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
-   *   Optional callback receiving each indexed file; returning FALSE excludes
-   *   the file from both indexes.
+   *   Optional callback receiving each candidate file as an IndexedFile;
+   *   returning FALSE excludes the file from both indexes.
    *
    * @return \AlexSkrypnyk\Snapshot\Compare\Comparer
    *   Comparison result object.
@@ -101,8 +101,8 @@ class Snapshot {
    * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
-   *   Optional callback receiving each indexed file; returning FALSE excludes
-   *   the file from both indexes.
+   *   Optional callback receiving each candidate file as an IndexedFile;
+   *   returning FALSE excludes the file from both indexes.
    */
   public static function diff(string $baseline, string $actual, string $output, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL): void {
     File::mkdir($output);
@@ -222,8 +222,8 @@ class Snapshot {
    * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
-   *   Optional callback receiving each indexed file; returning FALSE excludes
-   *   the file from the sync.
+   *   Optional callback receiving each candidate file as an IndexedFile;
+   *   returning FALSE excludes the file from the sync.
    */
   public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL): void {
     $index = self::scan($source, $rules, $file_filter);

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -163,8 +163,8 @@ class Snapshot {
 
     $patcher = new Patcher($baseline, $destination);
 
-    $patch_index = self::scan($diffs, $rules);
-    foreach ($patch_index->getFiles() as $file) {
+    $diffs_index = self::scan($diffs, $rules);
+    foreach ($diffs_index->getFiles() as $file) {
       // getFiles() allows a transform callback to return non-file values;
       // skip anything that is not a file since none is passed here.
       if (!$file instanceof IndexedFileInterface) {

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -137,6 +137,23 @@ class SnapshotBuilder {
   }
 
   /**
+   * Add global patterns to the rules.
+   *
+   * Creates rules if not set.
+   *
+   * @param string ...$patterns
+   *   Patterns that apply everywhere.
+   *
+   * @return $this
+   *   Return self for chaining.
+   */
+  public function addGlobal(string ...$patterns): static {
+    $this->rules ??= new Rules();
+    $this->rules->global(...$patterns);
+    return $this;
+  }
+
+  /**
    * Add include patterns to the rules.
    *
    * Creates rules if not set.

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -91,8 +91,8 @@ class SnapshotBuilder {
    * Set the file filter callback used by the indexing operations.
    *
    * @param callable $file_filter
-   *   Callback receiving the IndexedFile of each indexed file; returning FALSE
-   *   excludes the file from the index.
+   *   Callback receiving each candidate file as an IndexedFile; returning
+   *   FALSE excludes the file from the index.
    *
    * @return $this
    *   Return self for chaining.

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -11,14 +11,14 @@ use AlexSkrypnyk\Snapshot\Rules\Rules;
 /**
  * Configurable snapshot builder for repeated operations.
  *
- * Use this class to configure rules or content processors and perform
- * multiple operations with the same settings.
+ * Use this class to configure rules, a file filter or a content processor and
+ * perform multiple operations with the same settings.
  *
  * @code
  * $builder = SnapshotBuilder::create()
  *     ->withRules(Rules::phpProject())
  *     ->addSkip('custom/')
- *     ->withContentProcessor(fn($content) => trim($content));
+ *     ->withFileFilter(fn(IndexedFile $file) => !$file->isLink());
  *
  * $builder->sync($src, $dest);
  * $comparer = $builder->compare($dir1, $dir2);
@@ -32,11 +32,18 @@ class SnapshotBuilder {
   protected ?Rules $rules = NULL;
 
   /**
-   * Configured content processor callback.
+   * Configured content processor callback for the patch operation.
    *
    * @var callable|null
    */
   protected $contentProcessor;
+
+  /**
+   * Configured file filter callback for the indexing operations.
+   *
+   * @var callable|null
+   */
+  protected $fileFilter;
 
   /**
    * Creates a new configurable SnapshotBuilder instance.
@@ -63,16 +70,32 @@ class SnapshotBuilder {
   }
 
   /**
-   * Set the content processor callback.
+   * Set the content processor callback used by the patch operation.
    *
    * @param callable $processor
-   *   Callback to process file content before operations.
+   *   Callback receiving the content of each patched file as a string and
+   *   returning the content to write.
    *
    * @return $this
    *   Return self for chaining.
    */
   public function withContentProcessor(callable $processor): static {
     $this->contentProcessor = $processor;
+    return $this;
+  }
+
+  /**
+   * Set the file filter callback used by the indexing operations.
+   *
+   * @param callable $file_filter
+   *   Callback receiving the IndexedFile of each indexed file; returning FALSE
+   *   excludes the file from the index.
+   *
+   * @return $this
+   *   Return self for chaining.
+   */
+  public function withFileFilter(callable $file_filter): static {
+    $this->fileFilter = $file_filter;
     return $this;
   }
 
@@ -165,6 +188,16 @@ class SnapshotBuilder {
   }
 
   /**
+   * Get the configured file filter.
+   *
+   * @return callable|null
+   *   The configured file filter or NULL.
+   */
+  public function getFileFilter(): ?callable {
+    return $this->fileFilter;
+  }
+
+  /**
    * Scan a directory and create an index.
    *
    * @param string $directory
@@ -174,7 +207,7 @@ class SnapshotBuilder {
    *   The directory index.
    */
   public function scan(string $directory): Index {
-    return Snapshot::scan($directory, $this->rules, $this->contentProcessor);
+    return Snapshot::scan($directory, $this->rules, $this->fileFilter);
   }
 
   /**
@@ -189,7 +222,7 @@ class SnapshotBuilder {
    *   Comparison result object.
    */
   public function compare(string $baseline, string $actual): Comparer {
-    return Snapshot::compare($baseline, $actual, $this->rules, $this->contentProcessor);
+    return Snapshot::compare($baseline, $actual, $this->rules, $this->fileFilter);
   }
 
   /**
@@ -206,7 +239,7 @@ class SnapshotBuilder {
    *   Return self for chaining.
    */
   public function diff(string $baseline, string $actual, string $output): static {
-    Snapshot::diff($baseline, $actual, $output, $this->rules, $this->contentProcessor);
+    Snapshot::diff($baseline, $actual, $output, $this->rules, $this->fileFilter);
     return $this;
   }
 
@@ -215,16 +248,16 @@ class SnapshotBuilder {
    *
    * @param string $baseline
    *   Baseline directory path.
-   * @param string $patches
-   *   Directory containing patch/diff files.
+   * @param string $diffs
+   *   Directory containing diff files produced by self::diff().
    * @param string $destination
    *   Destination directory for patched output.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function patch(string $baseline, string $patches, string $destination): static {
-    Snapshot::patch($baseline, $patches, $destination, $this->rules, $this->contentProcessor);
+  public function patch(string $baseline, string $diffs, string $destination): static {
+    Snapshot::patch($baseline, $diffs, $destination, $this->rules, $this->contentProcessor);
     return $this;
   }
 
@@ -244,7 +277,7 @@ class SnapshotBuilder {
    *   Return self for chaining.
    */
   public function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE): static {
-    Snapshot::sync($source, $destination, $permissions, $copy_empty_dirs, $this->rules, $this->contentProcessor);
+    Snapshot::sync($source, $destination, $permissions, $copy_empty_dirs, $this->rules, $this->fileFilter);
     return $this;
   }
 

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -23,6 +23,8 @@ use AlexSkrypnyk\Snapshot\Rules\Rules;
  * $builder->sync($src, $dest);
  * $comparer = $builder->compare($dir1, $dir2);
  * @endcode
+ *
+ * @phpstan-consistent-constructor
  */
 class SnapshotBuilder {
 
@@ -48,11 +50,11 @@ class SnapshotBuilder {
   /**
    * Creates a new configurable SnapshotBuilder instance.
    *
-   * @return self
+   * @return static
    *   A new SnapshotBuilder instance.
    */
-  public static function create(): self {
-    return new self();
+  public static function create(): static {
+    return new static();
   }
 
   /**

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -7,6 +7,7 @@ namespace AlexSkrypnyk\Snapshot;
 use AlexSkrypnyk\Snapshot\Compare\Comparer;
 use AlexSkrypnyk\Snapshot\Index\Index;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
+use AlexSkrypnyk\Snapshot\Rules\RulesInterface;
 
 /**
  * Configurable snapshot builder for repeated operations.
@@ -31,7 +32,7 @@ class SnapshotBuilder {
   /**
    * Configured rules for operations.
    */
-  protected ?Rules $rules = NULL;
+  protected ?RulesInterface $rules = NULL;
 
   /**
    * Configured content processor callback for the patch operation.
@@ -60,13 +61,13 @@ class SnapshotBuilder {
   /**
    * Set the rules for snapshot operations.
    *
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface $rules
    *   The rules to use.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function withRules(Rules $rules): static {
+  public function withRules(RulesInterface $rules): static {
     $this->rules = $rules;
     return $this;
   }
@@ -172,10 +173,10 @@ class SnapshotBuilder {
   /**
    * Get the configured rules.
    *
-   * @return \AlexSkrypnyk\Snapshot\Rules\Rules|null
+   * @return \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null
    *   The configured rules or NULL.
    */
-  public function getRules(): ?Rules {
+  public function getRules(): ?RulesInterface {
     return $this->rules;
   }
 

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -16,6 +16,8 @@ use AlexSkrypnyk\Snapshot\Rules\RulesInterface;
  * perform multiple operations with the same settings.
  *
  * @code
+ * use AlexSkrypnyk\Snapshot\Index\IndexedFile;
+ *
  * $builder = SnapshotBuilder::create()
  *     ->withRules(Rules::phpProject())
  *     ->addSkip('custom/')

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -75,15 +75,15 @@ class SnapshotBuilder {
   /**
    * Set the content processor callback used by the patch operation.
    *
-   * @param callable $processor
+   * @param callable $content_processor
    *   Callback receiving the content of each patched file as a string and
    *   returning the content to write.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function withContentProcessor(callable $processor): static {
-    $this->contentProcessor = $processor;
+  public function withContentProcessor(callable $content_processor): static {
+    $this->contentProcessor = $content_processor;
     return $this;
   }
 

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -39,21 +39,22 @@ trait SnapshotTrait {
   /**
    * Assert that two directories have identical structure and content.
    *
-   * @param string $dir1
-   *   First directory path to compare.
-   * @param string $dir2
-   *   Second directory path to compare.
-   * @param string|null $message
-   *   Optional custom failure message.
-   * @param callable|null $match_content
-   *   Optional callback to process file content before comparison.
-   * @param bool $show_diff
-   *   Whether to include diff output in failure messages.
+   * @param string $expected
+   *   Expected directory path.
+   * @param string $actual
+   *   Actual directory path.
    * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
    *   Optional comparison rules.
+   * @param callable|null $file_filter
+   *   Optional callback receiving each indexed file; returning FALSE excludes
+   *   the file from both indexes.
+   * @param bool $show_diff
+   *   Whether to include diff output in failure messages.
+   * @param string|null $message
+   *   Optional custom failure message.
    */
-  public function assertDirectoriesIdentical(string $dir1, string $dir2, ?string $message = NULL, ?callable $match_content = NULL, bool $show_diff = TRUE, ?Rules $rules = NULL): void {
-    $text = Snapshot::compare($dir1, $dir2, $rules, $match_content)->render(['show_diff' => $show_diff]);
+  public function assertDirectoriesIdentical(string $expected, string $actual, ?Rules $rules = NULL, ?callable $file_filter = NULL, bool $show_diff = TRUE, ?string $message = NULL): void {
+    $text = Snapshot::compare($expected, $actual, $rules, $file_filter)->render(['show_diff' => $show_diff]);
     if (!empty($text)) {
       $this->fail($message ? $message . PHP_EOL . $text : $text);
     }
@@ -101,7 +102,7 @@ trait SnapshotTrait {
       File::copy($baseline . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT, $expected . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT);
     }
 
-    $this->assertDirectoriesIdentical($expected, $actual, $message);
+    $this->assertDirectoriesIdentical($expected, $actual, message: $message);
   }
 
   /**

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -6,7 +6,7 @@ namespace AlexSkrypnyk\Snapshot\Testing;
 
 use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Exception\PatchException;
-use AlexSkrypnyk\Snapshot\Rules\Rules;
+use AlexSkrypnyk\Snapshot\Rules\RulesInterface;
 use AlexSkrypnyk\Snapshot\Snapshot;
 use PHPUnit\Framework\TestStatus\Error;
 use PHPUnit\Framework\TestStatus\Failure;
@@ -43,7 +43,7 @@ trait SnapshotTrait {
    *   Expected directory path.
    * @param string $actual
    *   Actual directory path.
-   * @param \AlexSkrypnyk\Snapshot\Rules\Rules|null $rules
+   * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
    *   Optional callback receiving each indexed file; returning FALSE excludes
@@ -53,7 +53,7 @@ trait SnapshotTrait {
    * @param string|null $message
    *   Optional custom failure message.
    */
-  public function assertDirectoriesIdentical(string $expected, string $actual, ?Rules $rules = NULL, ?callable $file_filter = NULL, bool $show_diff = TRUE, ?string $message = NULL): void {
+  public function assertDirectoriesIdentical(string $expected, string $actual, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL, bool $show_diff = TRUE, ?string $message = NULL): void {
     $text = Snapshot::compare($expected, $actual, $rules, $file_filter)->render(['show_diff' => $show_diff]);
     if (!empty($text)) {
       $this->fail($message ? $message . PHP_EOL . $text : $text);

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -70,7 +70,7 @@ trait SnapshotTrait {
    * @param string $baseline
    *   Baseline directory path.
    * @param string $diffs
-   *   Directory containing diff/patch files to apply to the baseline.
+   *   Directory containing diff files produced by Snapshot::diff().
    * @param string $actual
    *   Actual directory path to compare.
    * @param string|null $expected

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -46,8 +46,8 @@ trait SnapshotTrait {
    * @param \AlexSkrypnyk\Snapshot\Rules\RulesInterface|null $rules
    *   Optional comparison rules.
    * @param callable|null $file_filter
-   *   Optional callback receiving each indexed file; returning FALSE excludes
-   *   the file from both indexes.
+   *   Optional callback receiving each candidate file as an IndexedFile;
+   *   returning FALSE excludes the file from both indexes.
    * @param bool $show_diff
    *   Whether to include diff output in failure messages.
    * @param string|null $message

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -66,12 +66,12 @@ trait SnapshotTrait {
    * This method applies patch files to a baseline directory and then compares
    * the resulting directory with an actual directory to verify they match.
    *
-   * @param string $actual
-   *   Actual directory path to compare.
    * @param string $baseline
    *   Baseline directory path.
    * @param string $diffs
    *   Directory containing diff/patch files to apply to the baseline.
+   * @param string $actual
+   *   Actual directory path to compare.
    * @param string|null $expected
    *   Optional path where to create the expected directory. If NULL, a
    *   directory unique to this invocation is created under the system temp
@@ -79,7 +79,7 @@ trait SnapshotTrait {
    * @param string|null $message
    *   Optional custom failure message.
    */
-  public function assertSnapshotMatchesBaseline(string $actual, string $baseline, string $diffs, ?string $expected = NULL, ?string $message = NULL): void {
+  public function assertSnapshotMatchesBaseline(string $baseline, string $diffs, string $actual, ?string $expected = NULL, ?string $message = NULL): void {
     if (!is_dir($baseline)) {
       $this->fail($message ?: sprintf('The baseline directory does not exist: %s', $baseline));
     }

--- a/tests/phpunit/Fixtures/functional_update/baseline_change/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/baseline_change/tests/SnapshotTest.php
@@ -52,7 +52,7 @@ final class SnapshotTest extends TestCase {
     }
     else {
       $scenario_dir = $this->getSnapshotsDir() . '/' . $dataset;
-      $this->assertSnapshotMatchesBaseline($this->getActualDir(), $baseline_dir, $scenario_dir);
+      $this->assertSnapshotMatchesBaseline($baseline_dir, $scenario_dir, $this->getActualDir());
     }
   }
 

--- a/tests/phpunit/Fixtures/functional_update/both_change/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/both_change/tests/SnapshotTest.php
@@ -52,7 +52,7 @@ final class SnapshotTest extends TestCase {
     }
     else {
       $scenario_dir = $this->getSnapshotsDir() . '/' . $dataset;
-      $this->assertSnapshotMatchesBaseline($this->getActualDir(), $baseline_dir, $scenario_dir);
+      $this->assertSnapshotMatchesBaseline($baseline_dir, $scenario_dir, $this->getActualDir());
     }
   }
 

--- a/tests/phpunit/Fixtures/functional_update/no_change/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/no_change/tests/SnapshotTest.php
@@ -52,7 +52,7 @@ final class SnapshotTest extends TestCase {
     }
     else {
       $scenario_dir = $this->getSnapshotsDir() . '/' . $dataset;
-      $this->assertSnapshotMatchesBaseline($this->getActualDir(), $baseline_dir, $scenario_dir);
+      $this->assertSnapshotMatchesBaseline($baseline_dir, $scenario_dir, $this->getActualDir());
     }
   }
 

--- a/tests/phpunit/Fixtures/functional_update/scenario_change/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/scenario_change/tests/SnapshotTest.php
@@ -52,7 +52,7 @@ final class SnapshotTest extends TestCase {
     }
     else {
       $scenario_dir = $this->getSnapshotsDir() . '/' . $dataset;
-      $this->assertSnapshotMatchesBaseline($this->getActualDir(), $baseline_dir, $scenario_dir);
+      $this->assertSnapshotMatchesBaseline($baseline_dir, $scenario_dir, $this->getActualDir());
     }
   }
 

--- a/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/SnapshotTest.php
+++ b/tests/phpunit/Fixtures/functional_update/scenario_only_change/tests/SnapshotTest.php
@@ -52,7 +52,7 @@ final class SnapshotTest extends TestCase {
     }
     else {
       $scenario_dir = $this->getSnapshotsDir() . '/' . $dataset;
-      $this->assertSnapshotMatchesBaseline($this->getActualDir(), $baseline_dir, $scenario_dir);
+      $this->assertSnapshotMatchesBaseline($baseline_dir, $scenario_dir, $this->getActualDir());
     }
   }
 

--- a/tests/phpunit/Functional/SnapshotTraitUpdateTest.php
+++ b/tests/phpunit/Functional/SnapshotTraitUpdateTest.php
@@ -276,7 +276,7 @@ final class ScenarioUpdateTest extends TestCase {
   }
 
   public function testScenarioMatch(): void {
-    \$this->assertSnapshotMatchesBaseline(\$this->actual, \$this->baseline, \$this->snapshots);
+    \$this->assertSnapshotMatchesBaseline(\$this->baseline, \$this->snapshots, \$this->actual);
   }
 
 }

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -192,8 +192,7 @@ final class IndexTest extends UnitTestCase {
   public function testFileFilterCallback(): void {
     $dir = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal_advanced' . DIRECTORY_SEPARATOR . 'directory2');
 
-    $file_filter =
-        (fn(IndexedFile $file): bool => str_contains($file->getContent(), 'specific content'));
+    $file_filter = fn(IndexedFile $file): bool => str_contains($file->getContent(), 'specific content');
 
     $test_file = $dir . DIRECTORY_SEPARATOR . 'test_file_filter.txt';
     file_put_contents($test_file, 'This file contains specific content that should be included');

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -189,6 +189,28 @@ final class IndexTest extends UnitTestCase {
     rmdir($test_dir);
   }
 
+  public function testFileFilterExcludesIgnoreContentFile(): void {
+    $test_dir = $this->locationsTmp() . DIRECTORY_SEPARATOR . 'test_filter_ignore_content';
+    File::mkdir($test_dir);
+
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'keep.txt', 'keep');
+    file_put_contents($test_dir . DIRECTORY_SEPARATOR . 'volatile.lock', 'volatile');
+
+    $rules = (new Rules())->addIgnoreContent('volatile.lock');
+
+    // Without a filter the ignore-content file is indexed and marked.
+    $marked = (new Index($test_dir, $rules))->getFiles();
+    $this->assertArrayHasKey('volatile.lock', $marked);
+    $this->assertInstanceOf(IndexedFileInterface::class, $marked['volatile.lock']);
+    $this->assertTrue($marked['volatile.lock']->isIgnoreContent());
+
+    // A filter rejecting it excludes it, so the filter does see it.
+    $filter_rules = (new Rules())->addIgnoreContent('volatile.lock');
+    $filtered = new Index($test_dir, $filter_rules, fn(IndexedFile $file): bool => $file->getBasename() !== 'volatile.lock');
+
+    $this->assertSame(['keep.txt'], array_keys($filtered->getFiles()));
+  }
+
   public function testFileFilterCallback(): void {
     $dir = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal_advanced' . DIRECTORY_SEPARATOR . 'directory2');
 

--- a/tests/phpunit/Unit/IndexTest.php
+++ b/tests/phpunit/Unit/IndexTest.php
@@ -19,12 +19,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
 final class IndexTest extends UnitTestCase {
 
   #[DataProvider('dataProviderIndexScan')]
-  public function testIndexScan(?callable $rules, ?callable $before_match_content, array $expected): void {
+  public function testIndexScan(?callable $rules, ?callable $file_filter, array $expected): void {
     $dir = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal_advanced' . DIRECTORY_SEPARATOR . 'directory2');
 
     $rules = is_callable($rules) ? $rules() : $rules;
 
-    $index = new Index($dir, $rules, $before_match_content);
+    $index = new Index($dir, $rules, $file_filter);
     $this->callProtectedMethod($index, 'scan');
 
     $this->assertSame($expected, array_keys($index->getFiles()));
@@ -189,21 +189,21 @@ final class IndexTest extends UnitTestCase {
     rmdir($test_dir);
   }
 
-  public function testBeforeMatchContentCallback(): void {
+  public function testFileFilterCallback(): void {
     $dir = File::dir($this->locationsFixtureDir('compare') . DIRECTORY_SEPARATOR . 'files_equal_advanced' . DIRECTORY_SEPARATOR . 'directory2');
 
-    $before_match_content =
+    $file_filter =
         (fn(IndexedFile $file): bool => str_contains($file->getContent(), 'specific content'));
 
-    $test_file = $dir . DIRECTORY_SEPARATOR . 'test_before_match.txt';
+    $test_file = $dir . DIRECTORY_SEPARATOR . 'test_file_filter.txt';
     file_put_contents($test_file, 'This file contains specific content that should be included');
 
     try {
-      $index = new Index($dir, NULL, $before_match_content);
+      $index = new Index($dir, NULL, $file_filter);
 
       $files = $index->getFiles();
 
-      $this->assertArrayHasKey('test_before_match.txt', $files);
+      $this->assertArrayHasKey('test_file_filter.txt', $files);
 
       $control_index = new Index($dir);
       $control_files = $control_index->getFiles();

--- a/tests/phpunit/Unit/IndexedFileTest.php
+++ b/tests/phpunit/Unit/IndexedFileTest.php
@@ -279,6 +279,17 @@ final class IndexedFileTest extends UnitTestCase {
     $indexed_file->getPathnameFromBasepath();
   }
 
+  public function testMutatorsReturnSelf(): void {
+    $file_path = self::$sut . DIRECTORY_SEPARATOR . 'test.txt';
+    file_put_contents($file_path, 'test content');
+
+    $indexed_file = new IndexedFile($file_path, self::$sut);
+
+    $this->assertSame($indexed_file, $indexed_file->setBasepath(self::$sut));
+    $this->assertSame($indexed_file, $indexed_file->setContent('new content'));
+    $this->assertSame($indexed_file, $indexed_file->setIgnoreContent());
+  }
+
   public function testContentIgnoredMarkerConstant(): void {
     $this->assertSame('content_ignored', IndexedFile::CONTENT_IGNORED_MARKER);
   }

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\Snapshot\Tests\Unit;
 
+use AlexSkrypnyk\Snapshot\Rules\AbstractRuleSet;
 use AlexSkrypnyk\Snapshot\Rules\NodeProjectRuleSet;
 use AlexSkrypnyk\Snapshot\Rules\PhpProjectRuleSet;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
@@ -12,6 +13,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(Rules::class)]
+#[CoversClass(AbstractRuleSet::class)]
 #[CoversClass(PhpProjectRuleSet::class)]
 #[CoversClass(NodeProjectRuleSet::class)]
 final class RulesTest extends UnitTestCase {
@@ -188,7 +190,7 @@ final class RulesTest extends UnitTestCase {
     // so a mock simulates the file read exception.
     $rules_class = new class() extends Rules {
 
-      public static function fromFile(string $file): Rules {
+      public static function fromFile(string $file): static {
         throw new \Exception(sprintf('Failed to read the %s file.', $file));
       }
 
@@ -311,18 +313,24 @@ EOT;
   public function testPhpProjectRuleSetPatterns(): void {
     $rule_set = new PhpProjectRuleSet();
 
-    $this->assertContains('vendor/', $rule_set->getSkipPatterns());
-    $this->assertContains('.phpunit.cache/', $rule_set->getSkipPatterns());
-    $this->assertContains('composer.lock', $rule_set->getIgnoreContentPatterns());
+    $this->assertContains('vendor/', $rule_set->getSkip());
+    $this->assertContains('.phpunit.cache/', $rule_set->getSkip());
+    $this->assertContains('composer.lock', $rule_set->getIgnoreContent());
+    $this->assertSame([], $rule_set->getGlobal());
+    $this->assertSame([], $rule_set->getInclude());
+    $this->assertSame([], $rule_set->getIncludeContent());
   }
 
   public function testNodeProjectRuleSetPatterns(): void {
     $rule_set = new NodeProjectRuleSet();
 
-    $this->assertContains('node_modules/', $rule_set->getSkipPatterns());
-    $this->assertContains('.npm/', $rule_set->getSkipPatterns());
-    $this->assertContains('package-lock.json', $rule_set->getIgnoreContentPatterns());
-    $this->assertContains('yarn.lock', $rule_set->getIgnoreContentPatterns());
+    $this->assertContains('node_modules/', $rule_set->getSkip());
+    $this->assertContains('.npm/', $rule_set->getSkip());
+    $this->assertContains('package-lock.json', $rule_set->getIgnoreContent());
+    $this->assertContains('yarn.lock', $rule_set->getIgnoreContent());
+    $this->assertSame([], $rule_set->getGlobal());
+    $this->assertSame([], $rule_set->getInclude());
+    $this->assertSame([], $rule_set->getIncludeContent());
   }
 
   public function testRuleSetApplyTo(): void {
@@ -337,13 +345,61 @@ EOT;
     $this->assertContains('vendor/', $result->getSkip());
   }
 
-  public function testRuleSetToRules(): void {
-    $rule_set = new PhpProjectRuleSet();
-    $rules = $rule_set->toRules();
+  public function testRuleSetApplyToWithoutRulesCreatesRules(): void {
+    $rules = (new PhpProjectRuleSet())->applyTo();
 
     $this->assertInstanceOf(Rules::class, $rules);
     $this->assertContains('vendor/', $rules->getSkip());
     $this->assertContains('composer.lock', $rules->getIgnoreContent());
   }
+
+  public function testRuleSetAppliesAllRuleKinds(): void {
+    $rules = (new AllKindsRuleSet())->applyTo();
+
+    $this->assertSame(['skipped/'], $rules->getSkip());
+    $this->assertSame(['ignored.lock'], $rules->getIgnoreContent());
+    $this->assertSame(['*.tmp'], $rules->getGlobal());
+    $this->assertSame(['skipped/keep.txt'], $rules->getInclude());
+    $this->assertSame(['ignored.lock'], $rules->getIncludeContent());
+  }
+
+  public function testFactoriesReturnSubclass(): void {
+    $file = $this->locationsTmp() . DIRECTORY_SEPARATOR . 'subclass.ignorecontent';
+    file_put_contents($file, "vendor/\n");
+
+    try {
+      $this->assertInstanceOf(CustomRules::class, CustomRules::create());
+      $this->assertInstanceOf(CustomRules::class, CustomRules::phpProject());
+      $this->assertInstanceOf(CustomRules::class, CustomRules::nodeProject());
+      $this->assertInstanceOf(CustomRules::class, CustomRules::fromRuleSet(new PhpProjectRuleSet()));
+      $this->assertInstanceOf(CustomRules::class, CustomRules::fromFile($file));
+    }
+    finally {
+      unlink($file);
+    }
+  }
+
+}
+
+/**
+ * Rules subclass used to assert that the factories honour late static binding.
+ */
+class CustomRules extends Rules {
+}
+
+/**
+ * Rule set covering every rule kind that applyTo() forwards.
+ */
+class AllKindsRuleSet extends AbstractRuleSet {
+
+  protected const SKIP_PATTERNS = ['skipped/'];
+
+  protected const IGNORE_CONTENT_PATTERNS = ['ignored.lock'];
+
+  protected const GLOBAL_PATTERNS = ['*.tmp'];
+
+  protected const INCLUDE_PATTERNS = ['skipped/keep.txt'];
+
+  protected const INCLUDE_CONTENT_PATTERNS = ['ignored.lock'];
 
 }

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -253,6 +253,13 @@ EOT;
     $this->assertSame(['composer.lock', 'package-lock.json'], $rules->getIgnoreContent());
   }
 
+  public function testFluentGlobalMethod(): void {
+    $rules = Rules::create()
+      ->global('*.log', '.DS_Store');
+
+    $this->assertSame(['*.log', '.DS_Store'], $rules->getGlobal());
+  }
+
   public function testFluentIncludeMethod(): void {
     $rules = Rules::create()
       ->include('important.log', 'keep-this.txt');
@@ -271,11 +278,13 @@ EOT;
     $rules = Rules::create()
       ->skip('vendor/', 'node_modules/')
       ->ignoreContent('composer.lock')
+      ->global('*.log')
       ->include('important.txt')
       ->includeContent('important.log');
 
     $this->assertSame(['vendor/', 'node_modules/'], $rules->getSkip());
     $this->assertSame(['composer.lock'], $rules->getIgnoreContent());
+    $this->assertSame(['*.log'], $rules->getGlobal());
     $this->assertSame(['important.txt'], $rules->getInclude());
     $this->assertSame(['important.log'], $rules->getIncludeContent());
   }

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -271,12 +271,12 @@ EOT;
     $rules = Rules::create()
       ->skip('vendor/', 'node_modules/')
       ->ignoreContent('composer.lock')
-      ->include('!important.txt')
+      ->include('important.txt')
       ->includeContent('important.log');
 
     $this->assertSame(['vendor/', 'node_modules/'], $rules->getSkip());
     $this->assertSame(['composer.lock'], $rules->getIgnoreContent());
-    $this->assertSame(['!important.txt'], $rules->getInclude());
+    $this->assertSame(['important.txt'], $rules->getInclude());
     $this->assertSame(['important.log'], $rules->getIncludeContent());
   }
 

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -365,27 +365,39 @@ EOT;
   public function testRuleSetAppliesAllRuleKinds(): void {
     $rules = (new AllKindsRuleSet())->applyTo();
 
-    $this->assertSame(['skipped/'], $rules->getSkip());
     $this->assertSame(['ignored.lock'], $rules->getIgnoreContent());
+    $this->assertSame(['skipped/'], $rules->getSkip());
     $this->assertSame(['*.tmp'], $rules->getGlobal());
     $this->assertSame(['skipped/keep.txt'], $rules->getInclude());
-    $this->assertSame(['ignored.lock'], $rules->getIncludeContent());
+    $this->assertSame(['compared.lock'], $rules->getIncludeContent());
   }
 
-  public function testFactoriesReturnSubclass(): void {
+  #[DataProvider('dataProviderFactoriesReturnSubclass')]
+  public function testFactoriesReturnSubclass(string $factory): void {
     $file = $this->locationsTmp() . DIRECTORY_SEPARATOR . 'subclass.ignorecontent';
     file_put_contents($file, "vendor/\n");
 
+    $arguments = match ($factory) {
+      'fromRuleSet' => [new PhpProjectRuleSet()],
+      'fromFile' => [$file],
+      default => [],
+    };
+
     try {
-      $this->assertInstanceOf(CustomRules::class, CustomRules::create());
-      $this->assertInstanceOf(CustomRules::class, CustomRules::phpProject());
-      $this->assertInstanceOf(CustomRules::class, CustomRules::nodeProject());
-      $this->assertInstanceOf(CustomRules::class, CustomRules::fromRuleSet(new PhpProjectRuleSet()));
-      $this->assertInstanceOf(CustomRules::class, CustomRules::fromFile($file));
+      $rules = CustomRules::$factory(...$arguments);
+      $this->assertInstanceOf(CustomRules::class, $rules);
     }
     finally {
       unlink($file);
     }
+  }
+
+  public static function dataProviderFactoriesReturnSubclass(): \Iterator {
+    yield 'create' => ['create'];
+    yield 'phpProject' => ['phpProject'];
+    yield 'nodeProject' => ['nodeProject'];
+    yield 'fromRuleSet' => ['fromRuleSet'];
+    yield 'fromFile' => ['fromFile'];
   }
 
 }
@@ -393,22 +405,24 @@ EOT;
 /**
  * Rules subclass used to assert that the factories honour late static binding.
  */
-class CustomRules extends Rules {
+final class CustomRules extends Rules {
 }
 
 /**
  * Rule set covering every rule kind that applyTo() forwards.
+ *
+ * Each kind carries a distinct pattern so a misrouted constant is visible.
  */
-class AllKindsRuleSet extends AbstractRuleSet {
-
-  protected const SKIP_PATTERNS = ['skipped/'];
+final class AllKindsRuleSet extends AbstractRuleSet {
 
   protected const IGNORE_CONTENT_PATTERNS = ['ignored.lock'];
+
+  protected const SKIP_PATTERNS = ['skipped/'];
 
   protected const GLOBAL_PATTERNS = ['*.tmp'];
 
   protected const INCLUDE_PATTERNS = ['skipped/keep.txt'];
 
-  protected const INCLUDE_CONTENT_PATTERNS = ['ignored.lock'];
+  protected const INCLUDE_CONTENT_PATTERNS = ['compared.lock'];
 
 }

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -7,6 +7,7 @@ namespace AlexSkrypnyk\Snapshot\Tests\Unit;
 use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Compare\Comparer;
 use AlexSkrypnyk\Snapshot\Index\Index;
+use AlexSkrypnyk\Snapshot\Index\IndexedFile;
 use AlexSkrypnyk\Snapshot\Rules\Rules;
 use AlexSkrypnyk\Snapshot\Snapshot;
 use AlexSkrypnyk\Snapshot\SnapshotBuilder;
@@ -21,6 +22,7 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $this->assertInstanceOf(SnapshotBuilder::class, $builder);
     $this->assertNotInstanceOf(Rules::class, $builder->getRules());
     $this->assertNull($builder->getContentProcessor());
+    $this->assertNull($builder->getFileFilter());
   }
 
   public function testWithRules(): void {
@@ -35,6 +37,14 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $builder = SnapshotBuilder::create()->withContentProcessor($processor);
 
     $this->assertSame($processor, $builder->getContentProcessor());
+  }
+
+  public function testWithFileFilter(): void {
+    $file_filter = fn(IndexedFile $file): bool => TRUE;
+    $builder = SnapshotBuilder::create()->withFileFilter($file_filter);
+
+    $this->assertSame($file_filter, $builder->getFileFilter());
+    $this->assertNull($builder->getContentProcessor());
   }
 
   public function testAddSkip(): void {
@@ -209,6 +219,63 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $this->assertSame($builder, $result);
     $this->assertFileExists($destination . DIRECTORY_SEPARATOR . 'keep.txt');
     $this->assertFileDoesNotExist($destination . DIRECTORY_SEPARATOR . 'skip.txt');
+  }
+
+  public function testSyncWithFileFilterExcludesFiles(): void {
+    $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
+    $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
+    mkdir($src, 0777, TRUE);
+
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'keep.txt', 'keep content');
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'drop.txt', 'drop content');
+
+    $builder = SnapshotBuilder::create()->withFileFilter(fn(IndexedFile $file): bool => $file->getBasename() !== 'drop.txt');
+    $builder->sync($src, $dst);
+
+    $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'keep.txt');
+    $this->assertFileDoesNotExist($dst . DIRECTORY_SEPARATOR . 'drop.txt');
+  }
+
+  public function testFileFilterAndContentProcessorReceiveOwnValues(): void {
+    $baseline = self::$sut . DIRECTORY_SEPARATOR . 'baseline';
+    $diffs = self::$sut . DIRECTORY_SEPARATOR . 'diffs';
+    $destination = self::$sut . DIRECTORY_SEPARATOR . 'destination';
+    $synced = self::$sut . DIRECTORY_SEPARATOR . 'synced';
+    mkdir($baseline, 0777, TRUE);
+    mkdir($diffs, 0777, TRUE);
+
+    file_put_contents($baseline . DIRECTORY_SEPARATOR . 'keep.txt', 'keep content');
+    file_put_contents($baseline . DIRECTORY_SEPARATOR . 'drop.txt', 'drop content');
+
+    $filtered = [];
+    $processed = [];
+
+    $builder = SnapshotBuilder::create()
+      ->withFileFilter(function (IndexedFile $file) use (&$filtered): bool {
+        $filtered[] = $file->getPathnameFromBasepath();
+        return $file->getBasename() !== 'drop.txt';
+      })
+      ->withContentProcessor(function (string $content) use (&$processed): string {
+        $processed[] = $content;
+        return strtoupper($content);
+      });
+
+    $builder->patch($baseline, $diffs, $destination);
+
+    $this->assertSame([], $filtered, 'File filter is not used by the patch operation');
+    sort($processed);
+    $this->assertSame(['drop content', 'keep content'], $processed);
+    $this->assertStringEqualsFile($destination . DIRECTORY_SEPARATOR . 'keep.txt', 'KEEP CONTENT');
+
+    $processed = [];
+
+    $builder->sync($baseline, $synced);
+
+    $this->assertSame([], $processed, 'Content processor is not used by the sync operation');
+    sort($filtered);
+    $this->assertSame(['drop.txt', 'keep.txt'], $filtered);
+    $this->assertFileExists($synced . DIRECTORY_SEPARATOR . 'keep.txt');
+    $this->assertFileDoesNotExist($synced . DIRECTORY_SEPARATOR . 'drop.txt');
   }
 
   public function testSyncWithRulesHonoursSkip(): void {

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -205,16 +205,16 @@ final class SnapshotBuilderTest extends UnitTestCase {
 
   public function testPatchWithRulesHonoursSkip(): void {
     $baseline = self::$sut . DIRECTORY_SEPARATOR . 'baseline';
-    $patches = self::$sut . DIRECTORY_SEPARATOR . 'patches';
+    $diffs = self::$sut . DIRECTORY_SEPARATOR . 'diffs';
     $destination = self::$sut . DIRECTORY_SEPARATOR . 'destination';
     mkdir($baseline, 0777, TRUE);
-    mkdir($patches, 0777, TRUE);
+    mkdir($diffs, 0777, TRUE);
 
     file_put_contents($baseline . DIRECTORY_SEPARATOR . 'keep.txt', 'keep content');
     file_put_contents($baseline . DIRECTORY_SEPARATOR . 'skip.txt', 'secret content');
 
     $builder = SnapshotBuilder::create()->withRules(Rules::create()->skip('skip.txt'));
-    $result = $builder->patch($baseline, $patches, $destination);
+    $result = $builder->patch($baseline, $diffs, $destination);
 
     $this->assertSame($builder, $result);
     $this->assertFileExists($destination . DIRECTORY_SEPARATOR . 'keep.txt');

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -273,17 +273,16 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $builder->patch($baseline, $diffs, $destination);
 
     $this->assertSame([], $filtered, 'File filter is not used by the patch operation');
-    sort($processed);
-    $this->assertSame(['drop content', 'keep content'], $processed);
+    $this->assertEqualsCanonicalizing(['drop content', 'keep content'], $processed);
     $this->assertStringEqualsFile($destination . DIRECTORY_SEPARATOR . 'keep.txt', 'KEEP CONTENT');
 
+    $filtered = [];
     $processed = [];
 
     $builder->sync($baseline, $synced);
 
     $this->assertSame([], $processed, 'Content processor is not used by the sync operation');
-    sort($filtered);
-    $this->assertSame(['drop.txt', 'keep.txt'], $filtered);
+    $this->assertEqualsCanonicalizing(['drop.txt', 'keep.txt'], $filtered);
     $this->assertFileExists($synced . DIRECTORY_SEPARATOR . 'keep.txt');
     $this->assertFileDoesNotExist($synced . DIRECTORY_SEPARATOR . 'drop.txt');
   }

--- a/tests/phpunit/Unit/SnapshotBuilderTest.php
+++ b/tests/phpunit/Unit/SnapshotBuilderTest.php
@@ -63,6 +63,14 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $this->assertSame(['composer.lock', 'package-lock.json'], $rules->getIgnoreContent());
   }
 
+  public function testAddGlobal(): void {
+    $builder = SnapshotBuilder::create()->addGlobal('*.log', '.DS_Store');
+
+    $rules = $builder->getRules();
+    $this->assertInstanceOf(Rules::class, $rules);
+    $this->assertSame(['*.log', '.DS_Store'], $rules->getGlobal());
+  }
+
   public function testAddInclude(): void {
     $builder = SnapshotBuilder::create()->addInclude('important.log');
 
@@ -84,6 +92,7 @@ final class SnapshotBuilderTest extends UnitTestCase {
       ->withRules(Rules::phpProject())
       ->addSkip('custom/')
       ->addIgnoreContent('custom.lock')
+      ->addGlobal('*.tmp')
       ->withContentProcessor(fn(string $content): string => $content);
 
     $rules = $builder->getRules();
@@ -92,6 +101,7 @@ final class SnapshotBuilderTest extends UnitTestCase {
     $this->assertContains('custom/', $rules->getSkip());
     $this->assertContains('composer.lock', $rules->getIgnoreContent());
     $this->assertContains('custom.lock', $rules->getIgnoreContent());
+    $this->assertContains('*.tmp', $rules->getGlobal());
   }
 
   public function testScan(): void {

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -460,19 +460,19 @@ ABSENT,
 
   public function testPatchWithRules(): void {
     $baseline = self::$sut . DIRECTORY_SEPARATOR . 'baseline';
-    $patches = self::$sut . DIRECTORY_SEPARATOR . 'patches';
+    $diffs = self::$sut . DIRECTORY_SEPARATOR . 'diffs';
     $destination = self::$sut . DIRECTORY_SEPARATOR . 'destination';
     mkdir($baseline, 0777, TRUE);
-    mkdir($patches, 0777, TRUE);
+    mkdir($diffs, 0777, TRUE);
 
     file_put_contents($baseline . DIRECTORY_SEPARATOR . 'keep.txt', 'keep content');
     file_put_contents($baseline . DIRECTORY_SEPARATOR . 'skip.txt', 'secret baseline content');
-    file_put_contents($patches . DIRECTORY_SEPARATOR . 'newfile.txt', 'new content');
-    file_put_contents($patches . DIRECTORY_SEPARATOR . 'skip.txt', 'secret patch content');
+    file_put_contents($diffs . DIRECTORY_SEPARATOR . 'newfile.txt', 'new content');
+    file_put_contents($diffs . DIRECTORY_SEPARATOR . 'skip.txt', 'secret diff content');
 
     $rules = Rules::create()->skip('skip.txt');
 
-    Snapshot::patch($baseline, $patches, $destination, $rules);
+    Snapshot::patch($baseline, $diffs, $destination, $rules);
 
     $this->assertFileExists($destination . DIRECTORY_SEPARATOR . 'keep.txt');
     $this->assertFileExists($destination . DIRECTORY_SEPARATOR . 'newfile.txt');

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -418,6 +418,23 @@ ABSENT,
     $this->assertArrayHasKey('f2.txt', $absent_right);
   }
 
+  public function testComparerAddFileMutatorsReturnSelf(): void {
+    $dir1 = self::$sut . DIRECTORY_SEPARATOR . 'dir1';
+    $dir2 = self::$sut . DIRECTORY_SEPARATOR . 'dir2';
+    mkdir($dir1, 0777, TRUE);
+    mkdir($dir2, 0777, TRUE);
+
+    file_put_contents($dir1 . DIRECTORY_SEPARATOR . 'f1.txt', 'content1');
+    file_put_contents($dir2 . DIRECTORY_SEPARATOR . 'f1.txt', 'content1');
+
+    $comparer = Snapshot::compare($dir1, $dir2);
+    $left_file = new IndexedFile($dir1 . DIRECTORY_SEPARATOR . 'f1.txt', $dir1);
+    $right_file = new IndexedFile($dir2 . DIRECTORY_SEPARATOR . 'f1.txt', $dir2);
+
+    $this->assertSame($comparer, $comparer->addLeftFile($left_file));
+    $this->assertSame($comparer, $comparer->addRightFile($right_file));
+  }
+
   public function testSyncRespectsContentIgnored(): void {
     $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
     $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';

--- a/tests/phpunit/Unit/SnapshotTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotTraitTest.php
@@ -132,7 +132,7 @@ final class SnapshotTraitTest extends TestCase {
     $subdir_path = $this->actualDir . DIRECTORY_SEPARATOR . 'subdir' . DIRECTORY_SEPARATOR;
     file_put_contents($subdir_path . 'file2.txt', 'Subdir content');
 
-    $this->assertSnapshotMatchesBaseline($this->actualDir, $this->baselineDir, $this->diffDir);
+    $this->assertSnapshotMatchesBaseline($this->baselineDir, $this->diffDir, $this->actualDir);
     $this->addToAssertionCount(1);
   }
 
@@ -159,7 +159,7 @@ final class SnapshotTraitTest extends TestCase {
     file_put_contents($subdir_path . 'file2.txt', 'Subdir content');
 
     try {
-      $this->assertSnapshotMatchesBaseline($this->actualDir, $this->baselineDir, $this->diffDir, $this->expectedDir);
+      $this->assertSnapshotMatchesBaseline($this->baselineDir, $this->diffDir, $this->actualDir, $this->expectedDir);
       $this->fail('Assertion should have failed for different content');
     }
     catch (AssertionFailedError $assertion_failed_error) {
@@ -172,7 +172,7 @@ final class SnapshotTraitTest extends TestCase {
     $nonexistent_dir = $this->tmpDir . DIRECTORY_SEPARATOR . 'nonexistent';
 
     try {
-      $this->assertSnapshotMatchesBaseline($this->actualDir, $nonexistent_dir, $this->diffDir);
+      $this->assertSnapshotMatchesBaseline($nonexistent_dir, $this->diffDir, $this->actualDir);
       $this->fail('Assertion should have failed for nonexistent baseline directory');
     }
     catch (AssertionFailedError $assertion_failed_error) {
@@ -194,7 +194,7 @@ final class SnapshotTraitTest extends TestCase {
     mkdir($this->actualDir, 0777, TRUE);
 
     try {
-      $this->assertSnapshotMatchesBaseline($this->actualDir, $this->baselineDir, $this->diffDir);
+      $this->assertSnapshotMatchesBaseline($this->baselineDir, $this->diffDir, $this->actualDir);
       $this->fail('Assertion should have failed for invalid patch');
     }
     catch (AssertionFailedError $assertion_failed_error) {
@@ -214,7 +214,7 @@ final class SnapshotTraitTest extends TestCase {
     mkdir($this->actualDir, 0777, TRUE);
 
     try {
-      $this->assertSnapshotMatchesBaseline($this->actualDir, $this->baselineDir, $this->diffDir);
+      $this->assertSnapshotMatchesBaseline($this->baselineDir, $this->diffDir, $this->actualDir);
       $this->fail('Assertion should have failed for hunk mismatch');
     }
     catch (AssertionFailedError $assertion_failed_error) {
@@ -234,7 +234,7 @@ final class SnapshotTraitTest extends TestCase {
     mkdir($this->actualDir, 0777, TRUE);
 
     try {
-      $this->assertSnapshotMatchesBaseline($this->actualDir, $this->baselineDir, $this->diffDir);
+      $this->assertSnapshotMatchesBaseline($this->baselineDir, $this->diffDir, $this->actualDir);
       $this->fail('Assertion should have failed for unexpected EOF');
     }
     catch (AssertionFailedError $assertion_failed_error) {
@@ -259,7 +259,7 @@ final class SnapshotTraitTest extends TestCase {
     file_put_contents($this->expectedDir . DIRECTORY_SEPARATOR . 'file1.txt', 'Original content');
     file_put_contents($this->expectedDir . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT, "*.ignored\n*.log");
 
-    $this->assertSnapshotMatchesBaseline($this->actualDir, $this->baselineDir, $this->diffDir, $this->expectedDir);
+    $this->assertSnapshotMatchesBaseline($this->baselineDir, $this->diffDir, $this->actualDir, $this->expectedDir);
     $this->addToAssertionCount(1);
 
     $expected_ignore_content_path = $this->expectedDir . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT;
@@ -279,12 +279,12 @@ final class SnapshotTraitTest extends TestCase {
     mkdir($this->actualDir, 0777, TRUE);
     file_put_contents($this->actualDir . DIRECTORY_SEPARATOR . 'file1.txt', 'Original content');
 
-    $this->assertSnapshotMatchesBaseline($this->actualDir, $this->baselineDir, $this->diffDir, NULL, 'Custom success message');
+    $this->assertSnapshotMatchesBaseline($this->baselineDir, $this->diffDir, $this->actualDir, NULL, 'Custom success message');
     $this->addToAssertionCount(1);
 
     $nonexistent_dir = $this->tmpDir . DIRECTORY_SEPARATOR . 'nonexistent';
     try {
-      $this->assertSnapshotMatchesBaseline($this->actualDir, $nonexistent_dir, $this->diffDir, NULL, 'Custom failure message');
+      $this->assertSnapshotMatchesBaseline($nonexistent_dir, $this->diffDir, $this->actualDir, NULL, 'Custom failure message');
       $this->fail('Assertion should have failed');
     }
     catch (AssertionFailedError $assertion_failed_error) {

--- a/tests/phpunit/Unit/SnapshotTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotTraitTest.php
@@ -92,7 +92,7 @@ final class SnapshotTraitTest extends TestCase {
     }
 
     try {
-      $this->assertDirectoriesIdentical($dir1, $dir2, 'Custom message for missing files');
+      $this->assertDirectoriesIdentical($dir1, $dir2, message: 'Custom message for missing files');
       $this->fail('Assertion should have failed for missing files');
     }
     catch (AssertionFailedError $assertion_failed_error) {
@@ -114,7 +114,7 @@ final class SnapshotTraitTest extends TestCase {
     file_put_contents($dir2 . DIRECTORY_SEPARATOR . 'file1.txt', 'Different content');
 
     $rules = Rules::create()->skip('file1.txt');
-    $this->assertDirectoriesIdentical($dir1, $dir2, NULL, NULL, TRUE, $rules);
+    $this->assertDirectoriesIdentical($dir1, $dir2, $rules);
   }
 
   public function testAssertSnapshotMatchesBaselinePositive(): void {


### PR DESCRIPTION
Closes #57, closes #58, closes #66, closes #73. Addresses the interface items of #60 (a final PR completes it).

## Summary

This PR settles the Snapshot library's public API ahead of its next major release, converging naming and shapes that had drifted across the callback, comparison and rule-set surfaces. The index callback splits into two honestly-named contracts - `$file_filter` for the indexing operations and `$content_processor` reserved for `patch()` - and both `assertSnapshotMatchesBaseline()` and `assertDirectoriesIdentical()` move to an expected-first, message-last argument order. The `RuleSet` family gains all five rule kinds on its interface and abstract base, with `toRules()` removed in favor of `Rules::fromRuleSet()` and `applyTo()`. Mutator methods on `ComparerInterface` and `IndexedFileInterface` become fluent, returning `static` instead of `void`, and factory methods return `static` instead of `self` so subclasses stay chainable. `PatchException`'s promoted constructor properties move to the camelCase convention used everywhere else in the codebase, and the facade, builder and trait couple to `RulesInterface` rather than the concrete `Rules` class. Every break in this PR was reviewed and approved by the maintainer as part of the settlement; none of it is accidental.

## Breaking changes

The README's new Upgrading section carries the full 19-row old-to-new migration table. Highlights, most dangerous first:

- `assertSnapshotMatchesBaseline()` reordered to `($baseline, $diffs, $actual, ...)` - all three are strings, so old positional calls run against the wrong directories with no error; review call sites when upgrading.
- `assertDirectoriesIdentical()` re-tailed to `($expected, $actual, $rules, $file_filter, $show_diff, $message)` - old misuse fails loudly (a string in the rules position throws).
- The index callback is a file filter, not a content processor: `$file_filter` on `scan()/compare()/diff()/sync()` and the builder's new `withFileFilter()`; `withContentProcessor()` now feeds `patch()` only.
- `ComparerInterface::addLeftFile/addRightFile` and `IndexedFileInterface::setBasepath/setContent/setIgnoreContent` return `static` instead of `void` (breaking for direct implementers).
- `RulesInterface`/`RuleSetInterface` gained methods - breaking for direct implementers; classes extending `Rules`/`AbstractRuleSet` inherit them.

The next release containing this PR must be tagged as a major version; the release drafter defaults to minor.

## Changes

**#66 - `PatchException` camelCase**
- Renamed the promoted constructor properties `$file_path`, `$line_number`, `$line_content` to `$filePath`, `$lineNumber`, `$lineContent`; the public getters are unchanged.

**#57 - Diff and patch vocabulary**
- Reordered `assertSnapshotMatchesBaseline()` to the expected-first convention: `($baseline, $diffs, $actual, $expected, $message)`.
- Renamed the index callback from an overloaded content processor to an honestly-named `$file_filter` on `Index::__construct()`, `Snapshot::scan/compare/diff/sync()` and `SnapshotTrait`; `withContentProcessor()` now feeds `patch()` only, and `SnapshotBuilder` gained a separate `withFileFilter()`.
- Renamed `$patches` to `$diffs` across `Snapshot::patch()`, `SnapshotBuilder::patch()` and `assertSnapshotMatchesBaseline()`, matching the directory that `Snapshot::diff()` produces.
- Renamed the transformation callback parameter `$cb` to `$transformer` on `Index::getFiles()` and the three `Comparer` diff getters.
- Re-tailed `assertDirectoriesIdentical()` to `($expected, $actual, $rules, $file_filter, $show_diff, $message)`, moving `$message` last.
- Added `testFileFilterAndContentProcessorReceiveOwnValues()`, pinning that the two builder callbacks receive their own distinct values.
- Ran the file filter for every file that survives the skip and global rules, including files marked by an ignore-content rule - previously such files bypassed the callback entirely, an artifact of the old before-match-content semantics; a filter returning `FALSE` can now exclude them, pinned by `testFileFilterExcludesIgnoreContentFile()`.
- Pinned `applyTo()`'s contract to return the same rules instance it applied to, which the factory and the existing `assertSame()` test rely on.

**#58 - `RuleSet` interface settlement**
- Renamed `RuleSetInterface::getSkipPatterns()`/`getIgnoreContentPatterns()` to suffixless `getSkip()`/`getIgnoreContent()`.
- Removed `RuleSetInterface::toRules()`; `Rules::fromRuleSet()` remains the entry point, with `applyTo()` as the underlying conversion primitive.
- Added the fifth rule kind, global patterns, end to end: the `GLOBAL_PATTERNS` constant, `getGlobal()`, fluent `Rules::global()` and `SnapshotBuilder::addGlobal()`; `INCLUDE_PATTERNS` and `INCLUDE_CONTENT_PATTERNS` are likewise first-class on the interface and abstract base.
- Changed `ComparerInterface::addLeftFile()`/`addRightFile()` and `IndexedFileInterface::setBasepath()`/`setContent()`/`setIgnoreContent()` from `void` to fluent `static` returns.
- Changed the `Rules` and `SnapshotBuilder` factory methods (`create()`, `fromRuleSet()`, `phpProject()`, `nodeProject()`, `fromFile()`) from `self` to `static`, using `new static()` and `@phpstan-consistent-constructor`.
- Added `testFactoriesReturnSubclass()`, a data-provider test pinning correct subclass dispatch.

**#60 - Interface items (partial; a final PR completes it)**
- Coupled `Index`, `Snapshot`, `SnapshotBuilder` and `SnapshotTrait` to `?RulesInterface` instead of the concrete `?Rules` class.

**Documentation**
- Added a two-callback reference table to the README distinguishing `withFileFilter()` from `withContentProcessor()`.
- Added an Upgrading section to the README with a 19-row old-to-new migration table.
- Recorded the promoted-property camelCase convention in AGENTS.md.

**Also in this branch**
- Removed a misleading `!` prefix from a fluent `include()` pattern in tests (#63).

## Deferred by design

- `Rules` implementing `RuleSetInterface` (the shapes now match closely) and `assertSnapshotMatchesBaseline()` gaining rules/filter passthrough - both additive, left for their own design discussion.

## Merge order

All predecessor PRs in this series are merged, so this PR can merge on its own; the final internal-dedup PR stacks on this branch and merges after it.

## Before / After

```
BEFORE: scattered vocabulary
┌────────────────────────────────────────────────────────────
│
│  $content_processor    one name, two different contracts
│  $cb                   transform callback
│  $patches              diff directory
│  assertSnapshotMatchesBaseline($actual, $baseline, $diffs)
│  getSkipPatterns() / getIgnoreContentPatterns()
│  addLeftFile(): void / setContent(): void
│  create(): self / new self()
└────────────────────────────────────────────────────────────

AFTER: settled system
┌────────────────────────────────────────────────────────────
│
│  $file_filter           scan() / compare() / diff() / sync()
│  $content_processor     patch() only
│  $transformer           transform callback
│  $diffs                 diff directory
│  assertSnapshotMatchesBaseline($baseline, $diffs, $actual)
│  getSkip() / getIgnoreContent()
│  addLeftFile(): static / setContent(): static
│  create(): static / new static()
└────────────────────────────────────────────────────────────
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Standardized public argument order, parameter names, and diff terminology.
- Separated file filters from content processors with `withFileFilter()`.
- Expanded `RuleSetInterface` to support all five rule kinds.
- Replaced `toRules()` with `Rules::fromRuleSet()` and `applyTo()`.
- Added fluent, subclass-aware factories and mutators.
- Updated APIs to use `RulesInterface`.
- Renamed `PatchException` constructor properties to camelCase.
- Added migration documentation and settlement tests.

This is a breaking change for the next major release.

Possibly related to `#57`, `#58`, `#66`, and `#73`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
