### PR TITLE
Fixed 'sync()' rewriting ignored files, separator-bound pattern matching and drifted docs.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,11 @@
 # AGENTS.md
 
-This file provides guidance to AI agents when working with
-code in this repository.
+This file provides guidance to AI agents when working with code in this repository.
 
 
 ## Project Overview
 
-**Snapshot** is a PHP library for directory snapshot testing. It provides
-functionality for creating, comparing, and applying directory snapshots using
-a baseline + diff architecture. This is particularly useful for testing code
-generators, scaffolding tools, or any system that produces file output.
+**Snapshot** is a PHP library for directory snapshot testing. It provides functionality for creating, comparing, and applying directory snapshots using a baseline + diff architecture. This is particularly useful for testing code generators, scaffolding tools, or any system that produces file output.
 
 ### Core Concepts
 
@@ -252,8 +248,7 @@ class MyTest extends TestCase {
 
 ### Auto-Update Feature
 
-Set `UPDATE_SNAPSHOTS=1` environment variable to automatically update snapshots
-when tests fail due to directory comparison mismatches:
+Set `UPDATE_SNAPSHOTS=1` environment variable to automatically update snapshots when tests fail due to directory comparison mismatches:
 
 ```bash
 UPDATE_SNAPSHOTS=1 ./vendor/bin/phpunit
@@ -261,27 +256,17 @@ UPDATE_SNAPSHOTS=1 ./vendor/bin/phpunit
 
 ### Bulk Snapshot Updates (`bin/update-snapshots`)
 
-CLI that runs PHPUnit per dataset with `UPDATE_SNAPSHOTS=1` (in parallel, with
-timeouts and retries) to regenerate many snapshots at once:
+CLI that runs PHPUnit per dataset with `UPDATE_SNAPSHOTS=1` (in parallel, with timeouts and retries) to regenerate many snapshots at once:
 
 ```bash
 vendor/bin/update-snapshots testMySnapshot tests/snapshots
 ```
 
-**Exit-code contract**: successfully updating snapshots is the expected outcome
-and exits `0`. The script exits non-zero **only** when a dataset genuinely
-cannot be updated - a non-snapshot failure or a timeout.
+**Exit-code contract**: successfully updating snapshots is the expected outcome and exits `0`. The script exits non-zero **only** when a dataset genuinely cannot be updated - a non-snapshot failure or a timeout.
 
-A per-dataset PHPUnit run still exits non-zero when it updates a snapshot (the
-assertion fails before `tearDown()` rewrites it). The script reclassifies such
-runs as "updated" by detecting `SnapshotTrait`'s `[SNAPSHOT] Baseline updated` /
-`[SNAPSHOT] Diffs updated` completion markers in the captured output - so those
-marker strings are a contract shared with `src/Testing/SnapshotTrait.php`; keep
-them in sync.
+A per-dataset PHPUnit run still exits non-zero when it updates a snapshot (the assertion fails before `tearDown()` rewrites it). The script reclassifies such runs as "updated" by detecting `SnapshotTrait`'s `[SNAPSHOT] Baseline updated` / `[SNAPSHOT] Diffs updated` completion markers in the captured output - so those marker strings are a contract shared with `src/Testing/SnapshotTrait.php`; keep them in sync.
 
-Functional tests run the script as a subprocess against fixtures in
-`tests/phpunit/Fixtures/functional_update/`. Coverage measures `src/` only, so
-`bin/` is not coverage-gated.
+Functional tests run the script as a subprocess against fixtures in `tests/phpunit/Fixtures/functional_update/`. Coverage measures `src/` only, so `bin/` is not coverage-gated.
 
 
 ## Performance Benchmarks
@@ -329,8 +314,7 @@ GitHub Actions workflows test across:
 - PHP versions: 8.3, 8.4, 8.5
 - Separate jobs: lint, test, coverage upload (Codecov)
 
-Lint, coverage threshold and Codecov upload run on the PHP 8.4 `normal`
-dependency leg only.
+Lint, coverage threshold and Codecov upload run on the PHP 8.4 `normal` dependency leg only.
 
 Key workflows:
 - `.github/workflows/test-php.yml` - PHP testing
@@ -339,11 +323,7 @@ Key workflows:
 
 ## Updating from the template
 
-This project was generated from a template and can pull the template's latest
-infrastructure (CI workflows, linting and test configuration, and docs)
-at any time. When you are asked to "update scaffold", fetch the updater skill
-from the template repository into the local `.claude/skills/` directory, then
-invoke it:
+This project was generated from a template and can pull the template's latest infrastructure (CI workflows, linting and test configuration, and docs) at any time. When you are asked to "update scaffold", fetch the updater skill from the template repository into the local `.claude/skills/` directory, then invoke it:
 
 1. Create the target directory if it does not exist:
 
@@ -359,5 +339,4 @@ invoke it:
 
 3. Invoke the `update-consumer-scaffold` skill and follow its steps.
 
-The skill directory is fetched on demand and is git-ignored - it is not
-committed to the project.
+The skill directory is fetched on demand and is git-ignored - it is not committed to the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing
 
-Thank you for considering a contribution to this project. This guide covers
-setting up a local environment and running the linting, tests and benchmarks.
+Thank you for considering a contribution to this project. This guide covers setting up a local environment and running the linting, tests and benchmarks.
 
 ## Local setup
 
@@ -11,9 +10,7 @@ composer install
 
 ## Linting
 
-`composer lint` runs PHP_CodeSniffer, PHPStan and Rector in check mode.
-`composer lint-fix` applies the fixes that Rector and PHP Code Beautifier can
-make automatically.
+`composer lint` runs PHP_CodeSniffer, PHPStan and Rector in check mode. `composer lint-fix` applies the fixes that Rector and PHP Code Beautifier can make automatically.
 
 ```bash
 composer lint
@@ -36,8 +33,7 @@ vendor/bin/phpunit --filter testMethodName
 
 ## Performance benchmarks
 
-PHPBench measures the core operations against a stored baseline. CI compares
-each run to that baseline and fails when a benchmark moves by more than 5%.
+PHPBench measures the core operations against a stored baseline. CI compares each run to that baseline and fails when a benchmark moves by more than 5%.
 
 ```bash
 # Run benchmarks against the stored baseline.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ A `!^` rule overrides content ignoring instead: `!^composer.lock` keeps comparin
 
 The `.ignorecontent` file itself and the `.git/` directory are always skipped and cannot be re-included by any `!` rule.
 
+Patterns are always written with a forward slash, on every platform. The file is portable text, so a Windows host reads `build/cache/` as the same path pattern a Linux host does.
+
 #### Why Ignore Content?
 
 Some files should exist but have unpredictable or environment-specific content:
@@ -245,7 +247,7 @@ Some files should exist but have unpredictable or environment-specific content:
 - **Generated timestamps** - Files containing build dates or version hashes
 - **Environment configs** - Files that vary between CI and local environments
 
-Using `^filename` ensures the file exists without failing on content differences.
+Using `^filename` ensures the file exists without failing on content differences. Comparison is the only operation the rule changes: `sync()` and `patch()` still copy the file verbatim, so an ignored file reaches its destination intact.
 
 #### Pattern Reference
 
@@ -457,6 +459,7 @@ This release settles the public API and contains breaking changes.
 
 - **Read this first - one break is silent.** `assertSnapshotMatchesBaseline()` reordered its three leading string parameters from `($actual, $baseline, $diffs)` to `($baseline, $diffs, $actual)`. Every parameter is a string path, so an un-updated call still type-checks and runs against the wrong directories instead of failing at the call site. Update every call site before upgrading.
 - **The companion break is loud.** `assertDirectoriesIdentical()` moved `$message` to last and promoted `$rules` to third, so an un-updated call that passed a message third now throws a `TypeError` rather than misbehaving quietly.
+- **`sync()` no longer rewrites content-ignored files.** `Snapshot::sync()` and `SnapshotBuilder::sync()` used to write the fixed marker `content_ignored` in place of the content of every file matched by a `^` rule, so syncing a tree that carried a `.ignorecontent` produced a destination with placeholder text instead of the real files. They now copy every file verbatim. Pass `placeholder_ignored_content: TRUE` to get the old behaviour, which is what `SnapshotTrait` uses to keep volatile files stable in a committed baseline.
 
 Every renamed or reshaped public symbol:
 
@@ -481,8 +484,10 @@ Every renamed or reshaped public symbol:
 | `Rules::create/fromRuleSet/phpProject/nodeProject/fromFile(): self` | the same factories returning `static` |
 | `?Rules` parameters and returns across the facade, builder, trait and `Index` | `?RulesInterface` |
 | `PatchException::$file_path/$line_number/$line_content` | `$filePath/$lineNumber/$lineContent`; the getters are unchanged |
+| `RulesInterface::addSkip/addIgnoreContent/addGlobal/addInclude/addIncludeContent(string $pattern)` | the same methods taking `string ...$patterns` |
+| `SyncerInterface::sync($dst, $permissions, $copy_empty_dirs)` | `sync($dst, $permissions, $copy_empty_dirs, $placeholder_ignored_content)` |
 
-Additive for callers, breaking for direct implementers: `Rules::global()` (also on `RulesInterface`) and `RuleSetInterface::getGlobal()`/`getInclude()`/`getIncludeContent()` with their `GLOBAL_PATTERNS`, `INCLUDE_PATTERNS` and `INCLUDE_CONTENT_PATTERNS` constants. Classes extending `Rules` or `AbstractRuleSet` inherit them and need no change; classes implementing `RulesInterface` or `RuleSetInterface` directly must add the new methods. Purely additive: `SnapshotBuilder::addGlobal()` and `SnapshotBuilder::withFileFilter()`/`getFileFilter()`.
+Additive for callers, breaking for direct implementers: `Rules::global()` (also on `RulesInterface`) and `RuleSetInterface::getGlobal()`/`getInclude()`/`getIncludeContent()` with their `GLOBAL_PATTERNS`, `INCLUDE_PATTERNS` and `INCLUDE_CONTENT_PATTERNS` constants, the variadic `RulesInterface::add*()` signatures, and the fourth `SyncerInterface::sync()` parameter. Classes extending `Rules`, `AbstractRuleSet` or `Syncer` inherit them and need no change; classes implementing `RulesInterface`, `RuleSetInterface` or `SyncerInterface` directly must match the new signatures. Purely additive: `SnapshotBuilder::addGlobal()`, `SnapshotBuilder::withFileFilter()`/`getFileFilter()` and the `Rules::PATTERN_SEPARATOR` constant.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - **Unified diff format** - Human-readable patch files that can be reviewed in PRs
 - **Auto-update snapshots** - Automatically update snapshots when tests fail
 - **Batch update CLI** - Regenerate many snapshots at once, in parallel, with timeouts and retries
-- **Version normalization** - Replace volatile versions, hashes and timestamps before snapshots are written
+- **Version normalization** - Replace volatile versions and hashes before snapshots are written
 - **Flexible ignore rules** - Skip files, directories, or ignore content differences
 - **PHPUnit integration** - Simple trait with intuitive assertions
 
@@ -34,25 +34,18 @@
 
 This library is designed for testing systems that generate file output:
 
-- **Template repositories** - Test scaffolds, skeletons, and boilerplate generators
-  to ensure customization options produce the expected file structure
-- **Code generators** - Verify that generated code matches expected output across
-  different configuration scenarios
-- **Build tools** - Assert that compilation or transformation processes produce
-  correct artifacts
+- **Template repositories** - Test scaffolds, skeletons, and boilerplate generators to ensure customization options produce the expected file structure
+- **Code generators** - Verify that generated code matches expected output across different configuration scenarios
+- **Build tools** - Assert that compilation or transformation processes produce correct artifacts
 - **Migration scripts** - Validate that file transformations work correctly
 
-For example, if you maintain a project template with customizable options (like
-choosing a database driver or enabling optional features), you can use this
-library to test each combination of options produces the correct files.
+For example, if you maintain a project template with customizable options (like choosing a database driver or enabling optional features), you can use this library to test each combination of options produces the correct files.
 
 ## 🧩 Concepts
 
 ### Baseline
 
-A **baseline** is a reference directory containing the expected file structure
-and content. It represents the "golden master" that your test output is compared
-against.
+A **baseline** is a reference directory containing the expected file structure and content. It represents the "golden master" that your test output is compared against.
 
 ```
 fixtures/
@@ -65,9 +58,7 @@ fixtures/
 
 ### Snapshot (Scenario)
 
-A **snapshot** (or scenario) represents differences from the baseline for a
-specific test case. Instead of duplicating the entire expected output, you only
-store the files that differ.
+A **snapshot** (or scenario) represents differences from the baseline for a specific test case. Instead of duplicating the entire expected output, you only store the files that differ.
 
 ```
 fixtures/
@@ -83,8 +74,7 @@ fixtures/
 
 ### Diff Files
 
-Snapshot directories contain **diff files** in unified diff format. These
-describe how a file should differ from its baseline version:
+Snapshot directories contain **diff files** in unified diff format. These describe how a file should differ from its baseline version:
 
 ```diff
 @@ -1,8 +1,8 @@
@@ -101,8 +91,7 @@ describe how a file should differ from its baseline version:
 
 Snapshot directories can also contain:
 - **New files** - Full file content for files not in baseline (copied as-is)
-- **Deletion markers** - Files prefixed with `-` (e.g., `-README.md`) indicate
-  the file should not exist in this scenario
+- **Deletion markers** - Files prefixed with `-` (e.g., `-README.md`) indicate the file should not exist in this scenario
 
 ## 📦 Installation
 
@@ -133,8 +122,7 @@ class MyTest extends TestCase {
 
 ### Baseline + Diff Testing
 
-For multiple test scenarios sharing common files, use a baseline directory with
-scenario-specific diffs:
+For multiple test scenarios sharing common files, use a baseline directory with scenario-specific diffs:
 
 ```php
 public function testScenarioA(): void {
@@ -173,8 +161,7 @@ UPDATE_SNAPSHOTS=1 ./vendor/bin/phpunit
 
 ### Batch Snapshot Updates
 
-For tests with many datasets, use the `update-snapshots` CLI tool to update
-snapshots with timeout handling, automatic retries, and parallel execution:
+For tests with many datasets, use the `update-snapshots` CLI tool to update snapshots with timeout handling, automatic retries, and parallel execution:
 
 ```bash
 # Update all datasets for a test
@@ -205,6 +192,7 @@ Options:
 - `--retries=<count>` - Max retries for timed out tests (default: 12)
 - `--jobs=<count>` - Number of parallel jobs for scenarios (default: 4)
 - `--debug` - Show PHPUnit output for failed tests
+- `--help` - Show the usage summary and exit
 
 #### Exit Codes
 
@@ -212,18 +200,13 @@ Updating a snapshot is the expected outcome, so the tool exits `0` when it updat
 
 #### Parallel Execution
 
-When updating all datasets, the baseline is always run first (since other
-scenarios may depend on it). Once the baseline completes, all remaining
-scenarios run in parallel using the number of jobs specified by `--jobs`.
+When updating all datasets, the baseline is always run first (since other scenarios may depend on it). Once the baseline completes, all remaining scenarios run in parallel using the number of jobs specified by `--jobs`.
 
-In a TTY terminal, a live progress display shows the status of all tasks with
-keyboard scrolling (arrow keys and Page Up/Down). In non-TTY environments
-(e.g., CI), results are printed after all tasks complete.
+In a TTY terminal, a live progress display shows the status of all tasks with keyboard scrolling (arrow keys and Page Up/Down). In non-TTY environments (e.g., CI), results are printed after all tasks complete.
 
 ### Ignore Rules
 
-Create a `.ignorecontent` file in your baseline directory to control which files
-are compared and how.
+Create a `.ignorecontent` file in your baseline directory to control which files are compared and how.
 
 ```
 # Skip by file name, anywhere in the tree
@@ -257,8 +240,7 @@ The `.ignorecontent` file itself and the `.git/` directory are always skipped an
 
 Some files should exist but have unpredictable or environment-specific content:
 
-- **`composer.lock`** - You want to verify it was generated, but the exact
-  content depends on dependency resolution timing and isn't meaningful to test
+- **`composer.lock`** - You want to verify it was generated, but the exact content depends on dependency resolution timing and isn't meaningful to test
 - **`package-lock.json`** - Same as above for npm dependencies
 - **Generated timestamps** - Files containing build dates or version hashes
 - **Environment configs** - Files that vary between CI and local environments
@@ -303,8 +285,7 @@ Snapshot::sync($source, $destination);
 
 ### Fluent Builder API
 
-For configured operations with rules, a file filter or a content processor, use
-`SnapshotBuilder`:
+For configured operations with rules, a file filter or a content processor, use `SnapshotBuilder`:
 
 ```php
 use AlexSkrypnyk\Snapshot\Index\IndexedFile;
@@ -319,7 +300,9 @@ $builder = SnapshotBuilder::create()
     ->addInclude('custom/keep.txt')
     ->addIncludeContent('custom/keep.log')
     // Drop every generated file from the index
-    ->withFileFilter(fn(IndexedFile $file) => !str_contains($file->getPathnameFromBasepath(), 'generated/'))
+    ->withFileFilter(fn(IndexedFile $file) => !str_contains(
+        $file->getPathnameFromBasepath(), 'generated/'
+    ))
     // Normalise the content of every file written by patch()
     ->withContentProcessor(fn(string $content) => trim($content));
 
@@ -368,8 +351,7 @@ $rules = Rules::fromFile($baseline . '/.ignorecontent');
 $comparer = Snapshot::compare($baseline, $actual, $rules);
 ```
 
-The presets are built from rule sets. Extend `AbstractRuleSet` to define your
-own reusable set and turn it into rules with `Rules::fromRuleSet()`:
+The presets are built from rule sets. Extend `AbstractRuleSet` to define your own reusable set and turn it into rules with `Rules::fromRuleSet()`:
 
 ```php
 use AlexSkrypnyk\Snapshot\Rules\AbstractRuleSet;
@@ -392,19 +374,15 @@ class MyProjectRuleSet extends AbstractRuleSet {
 $rules = Rules::fromRuleSet(new MyProjectRuleSet());
 ```
 
-Each constant maps to the matching `Rules` pattern list, and a set can define
-only the constants it needs - the rest default to empty.
+Each constant maps to the matching `Rules` pattern list, and a set can define only the constants it needs - the rest default to empty.
 
 ### Version Normalization
 
-When updating snapshots, volatile content like version numbers, hashes, and
-timestamps can cause unnecessary churn. The `Replacer` class automatically
-normalizes this content during snapshot updates.
+When updating snapshots, volatile content like version numbers and commit hashes can cause unnecessary churn. The `Replacer` class automatically normalizes this content during snapshot updates.
 
 #### Default Behavior
 
-The `snapshotUpdateBefore()` hook automatically applies version normalization
-using `File::getReplacer()->addVersionReplacements()`:
+The `snapshotUpdateBefore()` hook automatically applies version normalization using `File::getReplacer()->addVersionReplacements()`:
 
 ```php
 // This happens automatically in snapshotUpdateOnFailure()
@@ -413,10 +391,11 @@ File::getReplacer()->addVersionReplacements()->replaceInDir($actual);
 
 The default patterns replace:
 - Semver versions (`1.2.3`, `v1.2.3-beta.1`) → `__VERSION__`
-- Git hashes (`@abc123...`) → `@__HASH__`
+- Git hashes prefixed with `@` or `#` (`@abc123...`) → `@__HASH__`
 - SRI integrity hashes (`sha512-...`) → `__INTEGRITY__`
-- Docker image tags (`nginx:1.21.0`) → `nginx:__VERSION__`
-- GitHub Actions versions (`actions/checkout@v4`) → `actions/checkout@__VERSION__`
+- Docker image tags, including digests and `canary` (`nginx:1.21.0`) → `nginx:__VERSION__`
+- GitHub Actions versions and digests (`actions/checkout@v4`) → `actions/checkout@__VERSION__`
+- Node versions in workflows (`node-version: 20.1.0`) → `node-version: __VERSION__`
 - Package versions in JSON (`"^1.2.3"`) → `"__VERSION__"`
 
 #### Customizing Version Replacement
@@ -507,13 +486,11 @@ Additive for callers, breaking for direct implementers: `Rules::global()` (also 
 
 ## 🤝 Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local development setup, the
-linting and testing commands, and how to run the performance benchmarks.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local development setup, the linting and testing commands, and how to run the performance benchmarks.
 
 ## 🔄 Updating
 
-To pull the latest infrastructure from the template into this project, ask
-Claude Code to "update scaffold" - see [`AGENTS.md`](AGENTS.md) for details.
+To pull the latest infrastructure from the template into this project, ask Claude Code to "update scaffold" - see [`AGENTS.md`](AGENTS.md) for details.
 
 ---
 _This repository was created using the [Scaffold](https://getscaffold.dev/) project template_

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,7 @@
 
 ## Supported versions
 
-Security fixes are released for the latest `1.x` release. Older releases do not
-receive backported fixes.
+Security fixes are released for the latest `1.x` release. Older releases do not receive backported fixes.
 
 | Version | Supported          |
 |---------|--------------------|
@@ -12,14 +11,8 @@ receive backported fixes.
 
 ## Reporting a vulnerability
 
-Please do not report security vulnerabilities through public GitHub issues,
-pull requests, or discussions.
+Please do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
 
-Report them privately through
-[GitHub Security Advisories](https://github.com/alexskrypnyk/snapshot/security/advisories/new).
-Include the affected version, a description of the issue, and the steps needed
-to reproduce it.
+Report them privately through [GitHub Security Advisories](https://github.com/alexskrypnyk/snapshot/security/advisories/new). Include the affected version, a description of the issue, and the steps needed to reproduce it.
 
-You can expect an initial response within 7 days. If the report is accepted, a
-fix is released and an advisory published crediting you, unless you ask to
-remain anonymous.
+You can expect an initial response within 7 days. If the report is accepted, a fix is released and an advisory published crediting you, unless you ask to remain anonymous.

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -54,7 +54,7 @@ class Index implements IndexInterface {
         ? Rules::fromFile($directory . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT)
         : new Rules()
       );
-    $this->rules->addSkip(Snapshot::IGNORECONTENT)->addSkip('.git/');
+    $this->rules->addSkip(Snapshot::IGNORECONTENT, '.git' . Rules::PATTERN_SEPARATOR);
   }
 
   /**
@@ -133,7 +133,8 @@ class Index implements IndexInterface {
 
       // Neither the rules file nor the VCS tree is user-overridable, so both
       // are hard-skipped before include patterns are checked.
-      if ($relative_path === Snapshot::IGNORECONTENT || str_starts_with($relative_path, '.git/')) {
+      $normalised_path = str_replace(DIRECTORY_SEPARATOR, Rules::PATTERN_SEPARATOR, $relative_path);
+      if ($normalised_path === Snapshot::IGNORECONTENT || str_starts_with($normalised_path, '.git' . Rules::PATTERN_SEPARATOR)) {
         continue;
       }
 
@@ -217,16 +218,20 @@ class Index implements IndexInterface {
    *   TRUE if the path matches the pattern, FALSE otherwise.
    */
   protected static function pathMatchesPattern(string $path, string $pattern): bool {
+    // Patterns always use a forward slash, so compare against a path spelled
+    // the same way rather than with the host's separator.
+    $path = str_replace(DIRECTORY_SEPARATOR, Rules::PATTERN_SEPARATOR, $path);
+
     // Match directory pattern (e.g., "dir/").
-    if (str_ends_with($pattern, DIRECTORY_SEPARATOR)) {
+    if (str_ends_with($pattern, Rules::PATTERN_SEPARATOR)) {
       return str_starts_with($path, $pattern);
     }
 
     // Match direct children (e.g., "dir/*").
     if (str_contains($pattern, '/*')) {
-      $parent_dir = rtrim($pattern, '/*') . DIRECTORY_SEPARATOR;
+      $parent_dir = rtrim($pattern, '/*') . Rules::PATTERN_SEPARATOR;
 
-      return str_starts_with($path, $parent_dir) && substr_count($path, DIRECTORY_SEPARATOR) === substr_count($parent_dir, DIRECTORY_SEPARATOR);
+      return str_starts_with($path, $parent_dir) && substr_count($path, Rules::PATTERN_SEPARATOR) === substr_count($parent_dir, Rules::PATTERN_SEPARATOR);
     }
 
     // @phpcs:ignore Drupal.Functions.DiscouragedFunctions.Discouraged

--- a/src/Rules/AbstractRuleSet.php
+++ b/src/Rules/AbstractRuleSet.php
@@ -88,25 +88,11 @@ abstract class AbstractRuleSet implements RuleSetInterface {
   public function applyTo(?RulesInterface $rules = NULL): RulesInterface {
     $rules ??= new Rules();
 
-    foreach ($this->getIgnoreContent() as $pattern) {
-      $rules->addIgnoreContent($pattern);
-    }
-
-    foreach ($this->getSkip() as $pattern) {
-      $rules->addSkip($pattern);
-    }
-
-    foreach ($this->getGlobal() as $pattern) {
-      $rules->addGlobal($pattern);
-    }
-
-    foreach ($this->getInclude() as $pattern) {
-      $rules->addInclude($pattern);
-    }
-
-    foreach ($this->getIncludeContent() as $pattern) {
-      $rules->addIncludeContent($pattern);
-    }
+    $rules->addIgnoreContent(...$this->getIgnoreContent());
+    $rules->addSkip(...$this->getSkip());
+    $rules->addGlobal(...$this->getGlobal());
+    $rules->addInclude(...$this->getInclude());
+    $rules->addIncludeContent(...$this->getIncludeContent());
 
     return $rules;
   }

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -16,6 +16,14 @@ use AlexSkrypnyk\Snapshot\Exception\SnapshotException;
 class Rules implements RulesInterface {
 
   /**
+   * Path separator used within rule patterns.
+   *
+   * The rules file is portable text, so its patterns are always written with
+   * a forward slash regardless of the host's DIRECTORY_SEPARATOR.
+   */
+  public const PATTERN_SEPARATOR = '/';
+
+  /**
    * Patterns for files where only content should be ignored.
    *
    * @var array<int, string>
@@ -161,40 +169,40 @@ class Rules implements RulesInterface {
   /**
    * {@inheritdoc}
    */
-  public function addIgnoreContent(string $pattern): static {
-    $this->ignoreContentPatterns[] = $pattern;
+  public function addIgnoreContent(string ...$patterns): static {
+    array_push($this->ignoreContentPatterns, ...$patterns);
     return $this;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addSkip(string $pattern): static {
-    $this->skipPatterns[] = $pattern;
+  public function addSkip(string ...$patterns): static {
+    array_push($this->skipPatterns, ...$patterns);
     return $this;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addGlobal(string $pattern): static {
-    $this->globalPatterns[] = $pattern;
+  public function addGlobal(string ...$patterns): static {
+    array_push($this->globalPatterns, ...$patterns);
     return $this;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addInclude(string $pattern): static {
-    $this->includePatterns[] = $pattern;
+  public function addInclude(string ...$patterns): static {
+    array_push($this->includePatterns, ...$patterns);
     return $this;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addIncludeContent(string $pattern): static {
-    $this->includeContentPatterns[] = $pattern;
+  public function addIncludeContent(string ...$patterns): static {
+    array_push($this->includeContentPatterns, ...$patterns);
     return $this;
   }
 
@@ -202,50 +210,35 @@ class Rules implements RulesInterface {
    * {@inheritdoc}
    */
   public function skip(string ...$patterns): static {
-    foreach ($patterns as $pattern) {
-      $this->addSkip($pattern);
-    }
-    return $this;
+    return $this->addSkip(...$patterns);
   }
 
   /**
    * {@inheritdoc}
    */
   public function ignoreContent(string ...$patterns): static {
-    foreach ($patterns as $pattern) {
-      $this->addIgnoreContent($pattern);
-    }
-    return $this;
+    return $this->addIgnoreContent(...$patterns);
   }
 
   /**
    * {@inheritdoc}
    */
   public function global(string ...$patterns): static {
-    foreach ($patterns as $pattern) {
-      $this->addGlobal($pattern);
-    }
-    return $this;
+    return $this->addGlobal(...$patterns);
   }
 
   /**
    * {@inheritdoc}
    */
   public function include(string ...$patterns): static {
-    foreach ($patterns as $pattern) {
-      $this->addInclude($pattern);
-    }
-    return $this;
+    return $this->addInclude(...$patterns);
   }
 
   /**
    * {@inheritdoc}
    */
   public function includeContent(string ...$patterns): static {
-    foreach ($patterns as $pattern) {
-      $this->addIncludeContent($pattern);
-    }
-    return $this;
+    return $this->addIncludeContent(...$patterns);
   }
 
   /**
@@ -297,7 +290,7 @@ class Rules implements RulesInterface {
       elseif ($line[0] === '^') {
         $this->ignoreContentPatterns[] = substr($line, 1);
       }
-      elseif (!str_contains($line, DIRECTORY_SEPARATOR)) {
+      elseif (!str_contains($line, self::PATTERN_SEPARATOR)) {
         $this->globalPatterns[] = $line;
       }
       else {

--- a/src/Rules/RulesInterface.php
+++ b/src/Rules/RulesInterface.php
@@ -50,59 +50,59 @@ interface RulesInterface {
   public function getIncludeContent(): array;
 
   /**
-   * Adds a pattern for files where only content should be ignored.
+   * Adds patterns for files where only content should be ignored.
    *
-   * @param string $pattern
-   *   The pattern to add.
+   * @param string ...$patterns
+   *   The patterns to add.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function addIgnoreContent(string $pattern): static;
+  public function addIgnoreContent(string ...$patterns): static;
 
   /**
-   * Adds a pattern for files to skip.
+   * Adds patterns for files to skip.
    *
-   * @param string $pattern
-   *   The pattern to add.
+   * @param string ...$patterns
+   *   The patterns to add.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function addSkip(string $pattern): static;
+  public function addSkip(string ...$patterns): static;
 
   /**
-   * Adds a global pattern that applies everywhere.
+   * Adds global patterns that apply everywhere.
    *
-   * @param string $pattern
-   *   The pattern to add.
+   * @param string ...$patterns
+   *   The patterns to add.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function addGlobal(string $pattern): static;
+  public function addGlobal(string ...$patterns): static;
 
   /**
-   * Adds a pattern for files to explicitly include.
+   * Adds patterns for files to explicitly include.
    *
-   * @param string $pattern
-   *   The pattern to add.
+   * @param string ...$patterns
+   *   The patterns to add.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function addInclude(string $pattern): static;
+  public function addInclude(string ...$patterns): static;
 
   /**
-   * Adds a pattern for files where content should be explicitly compared.
+   * Adds patterns for files where content should be explicitly compared.
    *
-   * @param string $pattern
-   *   The pattern to add.
+   * @param string ...$patterns
+   *   The patterns to add.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function addIncludeContent(string $pattern): static;
+  public function addIncludeContent(string ...$patterns): static;
 
   /**
    * Fluent method to skip multiple patterns.

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -231,10 +231,14 @@ class Snapshot {
    * @param callable|null $file_filter
    *   Optional callback receiving each candidate file as an IndexedFile;
    *   returning FALSE excludes the file from the sync.
+   * @param bool $placeholder_ignored_content
+   *   Whether to write a fixed placeholder in place of the content of files
+   *   matched by an ignore-content rule. Keeps volatile files stable in a
+   *   committed baseline. When FALSE, every file is copied verbatim.
    */
-  public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL): void {
+  public static function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, ?RulesInterface $rules = NULL, ?callable $file_filter = NULL, bool $placeholder_ignored_content = FALSE): void {
     $index = self::scan($source, $rules, $file_filter);
-    (new Syncer($index))->sync($destination, $permissions, $copy_empty_dirs);
+    (new Syncer($index))->sync($destination, $permissions, $copy_empty_dirs, $placeholder_ignored_content);
   }
 
   /**

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -185,7 +185,6 @@ class Snapshot {
       $relative_path = $file->getPathnameFromBasepath();
 
       if (str_starts_with($basename, self::DELETION_MARKER)) {
-        // Deletion marker - remove file from destination.
         $target = $destination . DIRECTORY_SEPARATOR . $file->getPathFromBasepath() . DIRECTORY_SEPARATOR . substr($basename, strlen(self::DELETION_MARKER));
         File::remove($target);
       }

--- a/src/SnapshotBuilder.php
+++ b/src/SnapshotBuilder.php
@@ -117,7 +117,7 @@ class SnapshotBuilder {
    */
   public function addSkip(string ...$patterns): static {
     $this->rules ??= new Rules();
-    $this->rules->skip(...$patterns);
+    $this->rules->addSkip(...$patterns);
     return $this;
   }
 
@@ -134,7 +134,7 @@ class SnapshotBuilder {
    */
   public function addIgnoreContent(string ...$patterns): static {
     $this->rules ??= new Rules();
-    $this->rules->ignoreContent(...$patterns);
+    $this->rules->addIgnoreContent(...$patterns);
     return $this;
   }
 
@@ -151,7 +151,7 @@ class SnapshotBuilder {
    */
   public function addGlobal(string ...$patterns): static {
     $this->rules ??= new Rules();
-    $this->rules->global(...$patterns);
+    $this->rules->addGlobal(...$patterns);
     return $this;
   }
 
@@ -168,7 +168,7 @@ class SnapshotBuilder {
    */
   public function addInclude(string ...$patterns): static {
     $this->rules ??= new Rules();
-    $this->rules->include(...$patterns);
+    $this->rules->addInclude(...$patterns);
     return $this;
   }
 
@@ -185,7 +185,7 @@ class SnapshotBuilder {
    */
   public function addIncludeContent(string ...$patterns): static {
     $this->rules ??= new Rules();
-    $this->rules->includeContent(...$patterns);
+    $this->rules->addIncludeContent(...$patterns);
     return $this;
   }
 
@@ -294,12 +294,16 @@ class SnapshotBuilder {
    *   Directory permissions.
    * @param bool $copy_empty_dirs
    *   Whether to copy empty directories.
+   * @param bool $placeholder_ignored_content
+   *   Whether to write a fixed placeholder in place of the content of files
+   *   matched by an ignore-content rule. Keeps volatile files stable in a
+   *   committed baseline. When FALSE, every file is copied verbatim.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE): static {
-    Snapshot::sync($source, $destination, $permissions, $copy_empty_dirs, $this->rules, $this->fileFilter);
+  public function sync(string $source, string $destination, int $permissions = 0755, bool $copy_empty_dirs = FALSE, bool $placeholder_ignored_content = FALSE): static {
+    Snapshot::sync($source, $destination, $permissions, $copy_empty_dirs, $this->rules, $this->fileFilter, $placeholder_ignored_content);
     return $this;
   }
 

--- a/src/Sync/Syncer.php
+++ b/src/Sync/Syncer.php
@@ -27,7 +27,7 @@ class Syncer implements SyncerInterface {
   /**
    * {@inheritdoc}
    */
-  public function sync(string $dst, int $permissions = 0755, bool $copy_empty_dirs = FALSE): static {
+  public function sync(string $dst, int $permissions = 0755, bool $copy_empty_dirs = FALSE, bool $placeholder_ignored_content = FALSE): static {
     File::mkdir($dst, $permissions);
 
     foreach ($this->srcIndex->getFiles() as $file) {
@@ -41,12 +41,13 @@ class Syncer implements SyncerInterface {
 
       $absolute_src_path = $file->getPathname();
       $absolute_dst_path = $dst . DIRECTORY_SEPARATOR . $file->getPathnameFromBasepath();
-      if ($file->isIgnoreContent()) {
+
+      if ($placeholder_ignored_content && $file->isIgnoreContent()) {
         File::dump($absolute_dst_path, $file->getContent());
+        continue;
       }
-      else {
-        File::copy($absolute_src_path, $absolute_dst_path, $permissions, $copy_empty_dirs);
-      }
+
+      File::copy($absolute_src_path, $absolute_dst_path, $permissions, $copy_empty_dirs);
     }
 
     return $this;

--- a/src/Sync/SyncerInterface.php
+++ b/src/Sync/SyncerInterface.php
@@ -18,10 +18,14 @@ interface SyncerInterface {
    *   Directory permissions to use when creating directories.
    * @param bool $copy_empty_dirs
    *   Whether to copy empty directories.
+   * @param bool $placeholder_ignored_content
+   *   Whether to write a fixed placeholder in place of the content of files
+   *   matched by an ignore-content rule. Keeps volatile files stable in a
+   *   committed baseline. When FALSE, every file is copied verbatim.
    *
    * @return $this
    *   Return self for chaining.
    */
-  public function sync(string $dst, int $permissions = 0755, bool $copy_empty_dirs = FALSE): static;
+  public function sync(string $dst, int $permissions = 0755, bool $copy_empty_dirs = FALSE, bool $placeholder_ignored_content = FALSE): static;
 
 }

--- a/src/Testing/SnapshotTrait.php
+++ b/src/Testing/SnapshotTrait.php
@@ -97,7 +97,8 @@ trait SnapshotTrait {
       $this->fail($message ?: sprintf('Failed to apply patch: %s', $patch_exception->getMessage()));
     }
 
-    // Do not override .ignorecontent file from the baseline directory.
+    // The patch skips the rules file, so restore the baseline's copy for the
+    // comparison below.
     $this->snapshotCopyIgnoreContent($baseline, $expected);
 
     $this->assertDirectoriesIdentical($expected, $actual, message: $message);
@@ -184,7 +185,7 @@ trait SnapshotTrait {
     $this->snapshotCopyIgnoreContent($baseline, $tmp);
 
     File::rmdir($baseline);
-    Snapshot::sync($actual, $baseline);
+    Snapshot::sync($actual, $baseline, placeholder_ignored_content: TRUE);
 
     $this->snapshotCopyIgnoreContent($tmp, $baseline);
 
@@ -249,8 +250,19 @@ trait SnapshotTrait {
    * By default, applies version normalization patterns to replace volatile
    * content (version numbers, hashes, etc.) with placeholders.
    *
-   * Override to customize preprocessing. Call parent::snapshotUpdateBefore()
-   * to keep default behavior, or replace entirely with custom logic.
+   * A class method of the same name replaces this implementation rather than
+   * wrapping it, so an override that needs the default must alias the trait
+   * method and call the alias:
+   *
+   * @code
+   * use SnapshotTrait {
+   *   snapshotUpdateBefore as snapshotUpdateBeforeDefault;
+   * }
+   *
+   * protected function snapshotUpdateBefore(string $actual): void {
+   *   $this->snapshotUpdateBeforeDefault($actual);
+   * }
+   * @endcode
    *
    * @param string $actual
    *   Path to the actual output directory.

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -154,6 +154,13 @@ final class RulesTest extends UnitTestCase {
     $this->assertSame(['some/path/'], $rules->getSkip());
   }
 
+  public function testParseRoutesPathPatternsByForwardSlash(): void {
+    $rules = Rules::create()->parse("build/cache/\n*.log\n");
+
+    $this->assertSame(['build/cache/'], $rules->getSkip(), 'A pattern holding a forward slash is a path pattern.');
+    $this->assertSame(['*.log'], $rules->getGlobal(), 'A pattern without a forward slash matches the name alone.');
+  }
+
   #[DataProvider('dataProviderAddMethods')]
   public function testAddMethods(string $method, string $getter, string $pattern): void {
     $rules = new Rules();
@@ -167,6 +174,25 @@ final class RulesTest extends UnitTestCase {
     yield 'addGlobal' => ['addGlobal', 'getGlobal', 'global-pattern'];
     yield 'addInclude' => ['addInclude', 'getInclude', 'include-pattern'];
     yield 'addIncludeContent' => ['addIncludeContent', 'getIncludeContent', 'include-content-pattern'];
+  }
+
+  #[DataProvider('dataProviderAddMethodsAcceptVariadicPatterns')]
+  public function testAddMethodsAcceptVariadicPatterns(string $method, string $getter): void {
+    $many = new Rules();
+    $many->$method('first', 'second');
+    $this->assertSame(['first', 'second'], $many->$getter());
+
+    $none = new Rules();
+    $none->$method();
+    $this->assertSame([], $none->$getter());
+  }
+
+  public static function dataProviderAddMethodsAcceptVariadicPatterns(): \Iterator {
+    yield 'addIgnoreContent' => ['addIgnoreContent', 'getIgnoreContent'];
+    yield 'addSkip' => ['addSkip', 'getSkip'];
+    yield 'addGlobal' => ['addGlobal', 'getGlobal'];
+    yield 'addInclude' => ['addInclude', 'getInclude'];
+    yield 'addIncludeContent' => ['addIncludeContent', 'getIncludeContent'];
   }
 
   public function testAddMethodChaining(): void {

--- a/tests/phpunit/Unit/RulesTest.php
+++ b/tests/phpunit/Unit/RulesTest.php
@@ -345,7 +345,6 @@ final class RulesTest extends UnitTestCase {
   public function testRuleSetApplyTo(): void {
     $rule_set = new PhpProjectRuleSet();
 
-    // Apply to existing rules.
     $existing_rules = Rules::create()->skip('custom/');
     $result = $rule_set->applyTo($existing_rules);
 

--- a/tests/phpunit/Unit/SnapshotTest.php
+++ b/tests/phpunit/Unit/SnapshotTest.php
@@ -466,7 +466,7 @@ final class SnapshotTest extends UnitTestCase {
     $this->assertSame($comparer, $comparer->addRightFile($right_file));
   }
 
-  public function testSyncRespectsContentIgnored(): void {
+  public function testSyncCopiesContentIgnoredFilesVerbatim(): void {
     $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
     $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
     mkdir($src, 0777, TRUE);
@@ -480,6 +480,21 @@ final class SnapshotTest extends UnitTestCase {
     $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'regular.txt');
     $this->assertSame('regular content', file_get_contents($dst . DIRECTORY_SEPARATOR . 'regular.txt'));
     $this->assertFileExists($dst . DIRECTORY_SEPARATOR . 'ignored.txt');
+    $this->assertSame('actual secret content', file_get_contents($dst . DIRECTORY_SEPARATOR . 'ignored.txt'));
+  }
+
+  public function testSyncPlaceholdersContentIgnoredFilesOnRequest(): void {
+    $src = self::$sut . DIRECTORY_SEPARATOR . 'src';
+    $dst = self::$sut . DIRECTORY_SEPARATOR . 'dst';
+    mkdir($src, 0777, TRUE);
+
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'regular.txt', 'regular content');
+    file_put_contents($src . DIRECTORY_SEPARATOR . 'ignored.txt', 'actual secret content');
+    file_put_contents($src . DIRECTORY_SEPARATOR . Snapshot::IGNORECONTENT, "^ignored.txt\n");
+
+    Snapshot::sync($src, $dst, placeholder_ignored_content: TRUE);
+
+    $this->assertSame('regular content', file_get_contents($dst . DIRECTORY_SEPARATOR . 'regular.txt'));
     $this->assertSame(IndexedFile::CONTENT_IGNORED_MARKER, file_get_contents($dst . DIRECTORY_SEPARATOR . 'ignored.txt'));
   }
 


### PR DESCRIPTION
## Summary

Polish pass over the repository, plus five findings it surfaced that are fixed here rather than tracked separately. The documentation work reconciles the README against the code and settles its source formatting. The source work fixes two defects, one wrong docblock claim, one misleading comment, and an API inconsistency.

Three of these change behaviour and are listed under **Breaking changes** below. The `Snapshot::sync()` fix is the one to read first: it changes what lands on disk for anyone syncing a tree that carries a `.ignorecontent`.

## Breaking changes

- **`sync()` no longer rewrites content-ignored files.** `Snapshot::sync()` and `SnapshotBuilder::sync()` replaced the content of every file matched by a `^` rule with the fixed marker `content_ignored`, so syncing a tree carrying a `.ignorecontent` wrote placeholder text where the real file should be. They now copy every file verbatim. The old behaviour moved behind a new `placeholder_ignored_content` argument, which `SnapshotTrait` passes when rewriting a baseline - there a stable value is exactly what keeps volatile files out of version control.
- **`RulesInterface::add*()` are variadic.** `addSkip()`, `addIgnoreContent()`, `addGlobal()`, `addInclude()` and `addIncludeContent()` now take `string ...$patterns`. Additive for callers; classes implementing `RulesInterface` directly must match the new signature.
- **`SyncerInterface::sync()` takes a fourth parameter.** Additive for callers; direct implementers of `SyncerInterface` must match it.

## Changes

**Defect: `sync()` corrupted content-ignored files.** `Syncer::sync()` dumped `$file->getContent()` for ignore-content files, which is the sentinel `content_ignored` rather than the file's bytes. Harmless inside `patch()`, where both sides of the comparison are ignored and compare equal regardless, but `Snapshot::sync($source, $destination)` is documented as a general-purpose copy. Reproduced with a real `composer.lock` syncing to the literal string `content_ignored`; now covered by tests on both sides of the new argument.

**Defect: pattern matching was tied to `DIRECTORY_SEPARATOR`.** `Rules::parse()` decided whether a pattern was a path pattern or a name pattern with `str_contains($line, DIRECTORY_SEPARATOR)`, and `Index::pathMatchesPattern()` matched with the same constant. `.ignorecontent` is portable text whose documented syntax uses `/`, so on a host where the separator is not `/` a rule such as `build/cache/` was classified as a name pattern, matched against basenames only, and silently stopped working. Both sides now use the separator the file format defines, exposed as `Rules::PATTERN_SEPARATOR`, and paths are normalised before matching. No-op on POSIX, which is why CI never caught it.

**Wrong claim: `snapshotUpdateBefore()` docblock.** It advised calling `parent::snapshotUpdateBefore()` to keep the default behaviour. `SnapshotTrait` is a trait: a class method of the same name replaces the trait's implementation rather than wrapping it, so `parent::` resolves to the parent class, which has no such method. For the `class MyTest extends TestCase { use SnapshotTrait; }` shape the README itself documents, that call fails. The docblock now shows the trait-alias form, verified to run the override, reach the default, and apply the version replacements.

**Misleading comment in `assertSnapshotMatchesBaseline()`.** `// Do not override .ignorecontent file from the baseline directory.` sat above a line that copies that file, reading as a prohibition against the very thing the code does. Reworded to state the mechanism: the patch skips the rules file, so the baseline's copy is restored for the comparison.

**API inconsistency: `addSkip()` had two arities.** `SnapshotBuilder::addSkip()` was variadic while `RulesInterface::addSkip()` took a single pattern, so the same name meant different things on two public classes. The interface primitives are now variadic, which aligns the two without breaking any caller. `AbstractRuleSet::applyTo()` loses five loops as a result.

**Documentation.** Removed the claim that snapshot updates replace timestamps: `addVersionReplacements()` covers versions, hashes, integrity digests and image tags, and has no timestamp pattern. Listed the `node-version`, Docker digest and `#`-prefixed hash patterns the default-pattern list omitted, and added the `--help` flag missing from the CLI options. Documented that patterns always use `/` on every platform, and that an ignore-content rule changes comparison only - `sync()` and `patch()` still copy the file intact.

**Documentation formatting.** Joined hand-wrapped prose across `README.md`, `AGENTS.md`, `CONTRIBUTING.md` and `SECURITY.md` so each paragraph and list item is one source line, and wrapped the one over-wide README code example to 80 columns.

**Comments.** Deleted two source comments that restated the code directly below them.

## Verification

- `composer lint` clean: PHPCS, PHPStan level 9, Rector.
- `composer test`: 288 tests, 836 assertions, all passing (up from 281 - twelve new assertions across five new test cases, less the two collapsed into one).
- Line coverage 99.80% (493/494), up from 99.6%.
- Secret scan clean: gitleaks across all 170 commits, no tracked `.env*`, no private keys, no credential assignments, zero GitHub secret-scanning alerts.

## Before / After

```
Snapshot::sync() with a .ignorecontent carrying "^composer.lock"

  BEFORE                                AFTER
  ┌──────────────────────┐              ┌──────────────────────┐
  │ source/              │              │ source/              │
  │  composer.lock       │              │  composer.lock       │
  │   {"real":"lock"}    │              │   {"real":"lock"}    │
  └──────────┬───────────┘              └──────────┬───────────┘
             │ sync()                              │ sync()
             ▼                                     ▼
  ┌──────────────────────┐              ┌──────────────────────┐
  │ dest/                │              │ dest/                │
  │  composer.lock       │              │  composer.lock       │
  │   content_ignored  ✗ │              │   {"real":"lock"}  ✓ │
  └──────────────────────┘              └──────────────────────┘
                                        placeholder_ignored_content: TRUE
                                        restores the old marker behaviour,
                                        which is what SnapshotTrait passes.


Pattern classification in Rules::parse()

  BEFORE                                AFTER
  "build/cache/"                        "build/cache/"
       │                                     │
       ▼                                     ▼
  contains DIRECTORY_SEPARATOR?         contains "/" ?
       │                                     │
   ┌───┴────┐                                └──► always skip (path)
   │        │                                     on every platform
  POSIX   Windows
   │        │
  skip    global  ✗  matched against
  (path)          basenames, never fires
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Copy content-ignored files verbatim by default during synchronization.
- Add `placeholder_ignored_content` for baseline placeholder generation.
- Normalize rule patterns to `/` across platforms.
- Make `RulesInterface::add*()` methods variadic.
- Add the fourth parameter to `SyncerInterface::sync()`.
- Reconcile documentation with the implementation.
- Add tests for variadic rules and ignored-content synchronization.

## Verification

- 288 tests passed.
- 836 assertions passed.
- 99.80% line coverage.
- Linting passed.
- Secret scan passed.

## Possibly related

- Possibly related to [`#49`](https://github.com/AlexSkrypnyk/snapshot/issues/49), which covers passing `Rules` through `Snapshot::patch()` and `Snapshot::sync()`.
- Possibly related to [`#58`](https://github.com/AlexSkrypnyk/snapshot/issues/58), which covers the `Rules` and `RuleSet` interface shape.
- Possibly related to [`#63`](https://github.com/AlexSkrypnyk/snapshot/issues/63) and [`#64`](https://github.com/AlexSkrypnyk/snapshot/issues/64), which cover rule parsing and directory-pattern documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->