### PR TITLE
Updated 'alexskrypnyk/file' to 1.2.0 and 'alexskrypnyk/phpunit-helpers' to 1.0.0.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ tests/phpunit/
 
 ### Writing Tests
 
-- Use PHPUnit 11 attributes: `#[CoversClass()]`, `#[DataProvider()]`
+- Use PHPUnit 12 attributes: `#[CoversClass()]`, `#[DataProvider()]`
 - Data provider method names start with `dataProvider`
 - Use `UnitTestCase` as base class (includes `SnapshotTrait` and `LocationsTrait`)
 - Functional tests use `FunctionalTestCase` which adds `ProcessTrait`

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     },
     "require": {
         "php": ">=8.3",
-        "alexskrypnyk/file": "^0.19.0",
+        "alexskrypnyk/file": "^1.2.0",
         "sebastian/diff": "^6.0 || ^7.0"
     },
     "require-dev": {
-        "alexskrypnyk/phpunit-helpers": "^0.16.0",
+        "alexskrypnyk/phpunit-helpers": "^1.0.0",
         "composer": ">=2.10",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
         "drevops/phpcs-standard": "^0.7",
@@ -30,7 +30,7 @@
         "ergebnis/composer-normalize": "^2.52.0",
         "phpbench/phpbench": "^1.7.0",
         "phpstan/phpstan": "^2.2.13",
-        "phpunit/phpunit": "^11.5.56",
+        "phpunit/phpunit": "^12.5.24",
         "rector/rector": "^2.6.6",
         "symfony/process": "^7.4.18"
     },

--- a/tests/phpunit/Functional/SnapshotTraitUpdateTest.php
+++ b/tests/phpunit/Functional/SnapshotTraitUpdateTest.php
@@ -7,9 +7,9 @@ namespace AlexSkrypnyk\Snapshot\Tests\Functional;
 use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Snapshot;
 use AlexSkrypnyk\Snapshot\Testing\SnapshotTrait;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 
-#[CoversClass(SnapshotTrait::class)]
+#[CoversTrait(SnapshotTrait::class)]
 final class SnapshotTraitUpdateTest extends FunctionalTestCase {
 
   public function testUpdateBaselineOnFailure(): void {

--- a/tests/phpunit/Unit/PatcherTest.php
+++ b/tests/phpunit/Unit/PatcherTest.php
@@ -380,6 +380,8 @@ final class PatcherTest extends UnitTestCase {
     $patcher = new Patcher($source_dir, $dest_dir);
     $dst_file = $dest_dir . DIRECTORY_SEPARATOR . 'test.txt';
 
+    $patch_exception = NULL;
+
     try {
       self::callProtectedMethod($patcher, 'applyHunk', [
         &$diff,
@@ -387,14 +389,16 @@ final class PatcherTest extends UnitTestCase {
         $dst_file,
         $info,
       ]);
-      $this->fail('Expected PatchException was not thrown');
     }
-    catch (PatchException $patch_exception) {
-      $this->assertStringContainsString('Unexpected removal line', $patch_exception->getMessage());
-      $this->assertSame($source_file, $patch_exception->getFilePath());
-      $this->assertNotNull($patch_exception->getLineNumber());
-      $this->assertNotNull($patch_exception->getLineContent());
+    catch (\Throwable $throwable) {
+      $patch_exception = $throwable;
     }
+
+    $this->assertInstanceOf(PatchException::class, $patch_exception);
+    $this->assertStringContainsString('Unexpected removal line', $patch_exception->getMessage());
+    $this->assertSame($source_file, $patch_exception->getFilePath());
+    $this->assertNotNull($patch_exception->getLineNumber());
+    $this->assertNotNull($patch_exception->getLineContent());
   }
 
   public function testUnexpectedAdditionLine(): void {
@@ -425,6 +429,8 @@ final class PatcherTest extends UnitTestCase {
     $patcher = new Patcher($source_dir, $dest_dir);
     $dst_file = $dest_dir . DIRECTORY_SEPARATOR . 'test.txt';
 
+    $patch_exception = NULL;
+
     try {
       self::callProtectedMethod($patcher, 'applyHunk', [
         &$diff,
@@ -432,14 +438,16 @@ final class PatcherTest extends UnitTestCase {
         $dst_file,
         $info,
       ]);
-      $this->fail('Expected PatchException was not thrown');
     }
-    catch (PatchException $patch_exception) {
-      $this->assertStringContainsString('Unexpected addition line', $patch_exception->getMessage());
-      $this->assertSame($source_file, $patch_exception->getFilePath());
-      $this->assertNotNull($patch_exception->getLineNumber());
-      $this->assertNotNull($patch_exception->getLineContent());
+    catch (\Throwable $throwable) {
+      $patch_exception = $throwable;
     }
+
+    $this->assertInstanceOf(PatchException::class, $patch_exception);
+    $this->assertStringContainsString('Unexpected addition line', $patch_exception->getMessage());
+    $this->assertSame($source_file, $patch_exception->getFilePath());
+    $this->assertNotNull($patch_exception->getLineNumber());
+    $this->assertNotNull($patch_exception->getLineContent());
   }
 
   public function testPatchExceptionProperties(): void {

--- a/tests/phpunit/Unit/SnapshotTraitTest.php
+++ b/tests/phpunit/Unit/SnapshotTraitTest.php
@@ -9,7 +9,7 @@ use AlexSkrypnyk\Snapshot\Rules\Rules;
 use AlexSkrypnyk\Snapshot\Snapshot;
 use AlexSkrypnyk\Snapshot\Testing\SnapshotTrait;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  * The class extends PHPUnit's TestCase rather than the package's UnitTestCase,
  * so the trait runs without the locations and fixtures that base class sets up.
  */
-#[CoversClass(SnapshotTrait::class)]
+#[CoversTrait(SnapshotTrait::class)]
 final class SnapshotTraitTest extends TestCase {
 
   use SnapshotTrait;


### PR DESCRIPTION
## Summary

Raised `alexskrypnyk/file` to `^1.2.0` and `alexskrypnyk/phpunit-helpers` to `^1.0.0`, which pulls in a `phpunit/phpunit` bump from `^11.5.56` to `^12.5.24` since `phpunit-helpers` 1.0.0 requires PHPUnit `^12.5.24 || ^13`. PHPUnit 13 needs PHP >= 8.4.1, so `^12.5` is the highest constraint that keeps the PHP 8.3 CI leg working. Two test files needed small adjustments to stay compatible with PHPUnit 12's stricter attribute and exception-typing behavior; runtime behavior of the tests themselves is unchanged.

## Changes

- Bumped `alexskrypnyk/file` from `^0.19.0` to `^1.2.0` and `alexskrypnyk/phpunit-helpers` from `^0.16.0` to `^1.0.0` in `composer.json`, along with the resulting `phpunit/phpunit` bump from `^11.5.56` to `^12.5.24`.
- Replaced `#[CoversClass(SnapshotTrait::class)]` with `#[CoversTrait(SnapshotTrait::class)]` in `tests/phpunit/Unit/SnapshotTraitTest.php` and `tests/phpunit/Functional/SnapshotTraitUpdateTest.php`, since PHPUnit 12 rejects `CoversClass` when the target is a trait.
- Restructured `testUnexpectedRemovalLine()` and `testUnexpectedAdditionLine()` in `tests/phpunit/Unit/PatcherTest.php` to catch the thrown exception into a variable and assert its type with `assertInstanceOf(PatchException::class, ...)` before asserting its message and properties, because `phpunit-helpers` 1.0.0 added an explicit `@throws \InvalidArgumentException` docblock to `callProtectedMethod()` that made PHPStan flag the existing `catch (PatchException $e)` blocks as `catch.neverThrown` dead code. All original assertions are preserved.
- Updated `AGENTS.md` to reference PHPUnit 12 attributes instead of PHPUnit 11.

## Before / After

```
┌──────────────────────────────────────────┐
│ composer.json - dependency versions      │
├──────────────────────────────────────────┤
│ BEFORE                                   │
│   alexskrypnyk/file             ^0.19.0  │
│   alexskrypnyk/phpunit-helpers  ^0.16.0  │
│   phpunit/phpunit               ^11.5.56 │
│                                          │
│ AFTER                                    │
│   alexskrypnyk/file             ^1.2.0   │
│   alexskrypnyk/phpunit-helpers  ^1.0.0   │
│   phpunit/phpunit               ^12.5.24 │
└──────────────────────────────────────────┘

┌─────────────────────────────────────────────────────┐
│ SnapshotTraitTest.php / SnapshotTraitUpdateTest.php │
├─────────────────────────────────────────────────────┤
│ BEFORE  #[CoversClass(SnapshotTrait::class)]        │
│ AFTER   #[CoversTrait(SnapshotTrait::class)]        │
└─────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────────┐
│ PatcherTest.php - exception assertions                                  │
├─────────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                                  │
│   try { ...; $this->fail('not thrown'); }                               │
│   catch (PatchException $patch_exception) {                             │
│     assert message / getFilePath() / getLineNumber() / getLineContent() │
│   }                                                                     │
│                                                                         │
│ AFTER                                                                   │
│   $patch_exception = NULL;                                              │
│   try { ... }                                                           │
│   catch (\Throwable $throwable) { $patch_exception = $throwable; }      │
│                                                                         │
│   assertInstanceOf(PatchException::class, $patch_exception);            │
│   assert message / getFilePath() / getLineNumber() / getLineContent()   │
└─────────────────────────────────────────────────────────────────────────┘
```
